### PR TITLE
Fix user model import

### DIFF
--- a/chat/models.py
+++ b/chat/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 
-from account.models import User
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
 
 
 class Message(models.Model):


### PR DESCRIPTION
## Summary
- fix import in chat models to use `get_user_model`

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c1939cab88326b94c24eed98c3346