### PR TITLE
Implement queryChannels adapter surface

### DIFF
--- a/backend/chat/tests/test_room_list.py
+++ b/backend/chat/tests/test_room_list.py
@@ -1,0 +1,23 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class RoomListAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_list_rooms_returns_rooms(self):
+        Room.objects.create(uuid="r1", client="c1")
+        Room.objects.create(uuid="r2", client="c2")
+
+        token = self.make_token()
+        url = reverse("room-list")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 2)
+        uuids = {room["uuid"] for room in res.data}
+        self.assertEqual(uuids, {"r1", "r2"})

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -69,7 +69,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **pollComposer**                             | 🔲 | 🔲 |
 | **polls**                                    | 🔲 | 🔲 |
 | **query**                                    | 🔲 | 🔲 |
-| **queryChannels**                            | 🔲 | 🔲 |
+| **queryChannels**                            | ✅ | ✅ |
 | **queryReactions**                           | 🔲 | 🔲 |
 | **queryUsers**                               | 🔲 | 🔲 |
 | **read**                                     | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/queryChannels.test.ts
+++ b/frontend/__tests__/adapter/queryChannels.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('queryChannels fetches rooms and updates state', async () => {
+  const rooms = [
+    { uuid: 'room1', name: 'Room One' },
+    { uuid: 'room2', name: undefined },
+  ];
+
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => rooms,
+  });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channels = await client.queryChannels();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/', {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+
+  expect(channels).toHaveLength(2);
+  expect(channels[0].cid).toBe('messaging:room1');
+  expect(client.stateStore.getSnapshot().channels.length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- add frontend adapter tests for `queryChannels`
- add backend tests for `room-list` endpoint
- mark `queryChannels` surface complete

## Testing
- `pnpm --filter frontend test`
- `python manage.py test` *(fails: TypeError from twisted)*
- `pnpm turbo build` *(fails: cannot fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684f54d5e6208326bbe32d7003ea27ac