### PR TITLE
Implement sendMessage adapter/backend

### DIFF
--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -3,7 +3,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from accounts.authentication import SupabaseJWTAuthentication
-from accounts.models import UserProfile
+from accounts_supabase.models import UserProfile
 
 class SyncUserView(APIView):
     # explicitly setting here again as sanity check

--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -35,7 +35,15 @@ class RoomMessageListCreateView(APIView):
 
     def post(self, request, room_uuid):
         room = get_object_or_404(Room, uuid=room_uuid)
-        serializer = MessageSerializer(data=request.data)
+        data = request.data.copy()
+
+        # allow simple "text" payloads from the adapter
+        if "text" in data and "body" not in data:
+            data["body"] = data.pop("text")
+        if "sent_by" not in data:
+            data["sent_by"] = request.user.username
+
+        serializer = MessageSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         message = serializer.save(created_by=request.user)
         room.messages.add(message)

--- a/backend/chat/tests/test_send_message.py
+++ b/backend/chat/tests/test_send_message.py
@@ -1,0 +1,21 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message
+
+class SendMessageAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_send_message_creates_message(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(room.messages.count(), 1)
+        msg = room.messages.first()
+        self.assertEqual(msg.body, "hello")
+        self.assertEqual(msg.sent_by, "u1")

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
-from .api_views import RoomListCreateView, RoomDetailView, RoomMessageListCreateView, RoomListAPIView
+from .api_views import RoomListCreateView, RoomDetailView, RoomMessageListCreateView
 
 router = DefaultRouter()
 # Router is not used here but left for extensibility

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -78,7 +78,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **reminders**                                | 🔲 | 🔲 |
 | **restore**                                  | 🔲 | 🔲 |
 | **sendAction**                               | 🔲 | 🔲 |
-| **sendMessage**                              | 🔲 | 🔲 |
+| **sendMessage**                              | ✅ | ✅ |
 | **sendReaction**                             | 🔲 | 🔲 |
 | **setQuotedMessage**                         | 🔲 | 🔲 |
 | **setUserAgent**                             | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/sendMessage.test.ts
+++ b/frontend/__tests__/adapter/sendMessage.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('sendMessage posts message to API', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true });
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.sendMessage({ text: 'hello' });
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/messages/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer jwt1',
+    },
+    body: JSON.stringify({ text: 'hello' }),
+  });
+});


### PR DESCRIPTION
## Summary
- allow RoomMessageListCreateView to accept simple text payloads
- fix import path in `SyncUserView`
- remove unused import from chat urls
- add unit tests for sending messages
- cover adapter sendMessage with a unit test
- document work in todo list

## Testing
- `pnpm run -r test`
- `python backend/manage.py test chat.tests.test_room_list chat.tests.test_sync_user chat.tests.test_send_message`

------
https://chatgpt.com/codex/tasks/task_e_684f73c24c6c8326b79a78f193bcc850