### PR TITLE
Add test for getUserAgent

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -40,7 +40,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **getClient**                                | 🔲 | 🔲 |
 | **getConfig**                                | 🔲 | 🔲 |
 | **getReplies**                               | 🔲 | 🔲 |
-| **getUserAgent**                             | 🔲 | 🔲 |
+| **getUserAgent**                             | ✅ | 🔲 |
 | **hasSendableData**                          | 🔲 | 🔲 |
 | **hidden**                                   | 🔲 | 🔲 |
 | **id**                                       | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/getUserAgent.test.ts
+++ b/frontend/__tests__/adapter/getUserAgent.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('getUserAgent returns custom identifier', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  expect(client.getUserAgent()).toBe('custom-chat-client/0.0.1 stream-chat-react-adapter');
+});


### PR DESCRIPTION
## Summary
- cover `getUserAgent` in adapter tests
- mark `getUserAgent` adapter surface done in docs

## Testing
- `pnpm --filter frontend test`
- `python manage.py test chat.tests`

------
https://chatgpt.com/codex/tasks/task_e_684f80ca30a08326975b000bc5128d9f