### PR TITLE
feat(adapter): implement getAppSettings

### DIFF
--- a/backend/chat/tests.py
+++ b/backend/chat/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/core/tests/test_get_app_settings.py
+++ b/backend/core/tests/test_get_app_settings.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+class GetAppSettingsTests(APITestCase):
+    def test_returns_settings(self):
+        url = reverse('core:app-settings')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, {"file_uploads": True})

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -8,4 +8,5 @@ app_name = 'core'
 urlpatterns = [
     path('', views.index, name='index'),
     path('about/', views.about, name='about'),
+    path('api/app-settings/', views.get_app_settings, name='app-settings'),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -10,3 +10,8 @@ def index(request):
 @api_view(["GET"])
 def about(request):
     return Response({"about": "Jatte headless backend"})
+
+
+@api_view(["GET"])
+def get_app_settings(request):
+    return Response({"file_uploads": True})

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -36,7 +36,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **editingAuditState**                        | 🔲 | 🔲 |
 | **event**                                    | 🔲 | 🔲 |
 | **flagMessage**                              | 🔲 | 🔲 |
-| **getAppSettings**                           | 🔲 | 🔲 |
+| **getAppSettings**                           | ✅ | ✅ |
 | **getClient**                                | 🔲 | 🔲 |
 | **getConfig**                                | 🔲 | 🔲 |
 | **getReplies**                               | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/getAppSettings.test.ts
+++ b/frontend/__tests__/adapter/getAppSettings.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getAppSettings fetches settings from backend', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => ({ file_uploads: true }),
+  });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const settings = await client.getAppSettings();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/app-settings/', {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(settings).toEqual({ file_uploads: true });
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -128,6 +128,15 @@ export class ChatClient {
         return chans;
     }
 
+    /** fetch global app settings */
+    async getAppSettings() {
+        const res = await fetch('/api/app-settings/', {
+            headers: this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {},
+        });
+        if (!res.ok) throw new Error('getAppSettings failed');
+        return res.json();
+    }
+
     /** create / retrieve single channel for <Channel channel={…}> */
     channel(_: 'messaging', roomUuid: string) {
         return new Channel(roomUuid, roomUuid, this);


### PR DESCRIPTION
## Summary
- implement `getAppSettings` in ChatClient
- provide backend endpoint `/api/app-settings/`
- test adapter and backend logic
- check off `getAppSettings` in docs

## Testing
- `pnpm turbo run test`
- `python manage.py test`
- `pnpm turbo run build` *(fails: Can't resolve fonts and stream-ui)*

------
https://chatgpt.com/codex/tasks/task_e_684f882a000083269ad803d7414336fe