### PR TITLE
Implement cleanup improvements

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,8 +1,8 @@
 #accounts/urls.py
 from django.urls import path
-from .views import SyncUserView, DisconnectUserView
+from .views import SyncUserView, SessionView
 
 urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
-    path('api/disconnect-user/', DisconnectUserView.as_view(), name='disconnect-user'),
+    path('api/session/', SessionView.as_view(), name='session'),
 ]

--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from accounts.authentication import SupabaseJWTAuthentication
 from accounts_supabase.models import UserProfile
+from django.utils import timezone
 
 class SyncUserView(APIView):
     # explicitly setting here again as sanity check
@@ -16,13 +17,14 @@ class SyncUserView(APIView):
         return Response({"status": "ok"})
 
 
-class DisconnectUserView(APIView):
+class SessionView(APIView):
     authentication_classes = [SupabaseJWTAuthentication]
     permission_classes = [IsAuthenticated]
 
-    def post(self, request):
-        # For now simply acknowledge the disconnect.
-        return Response({"status": "ok"})
+    def delete(self, request):
+        # Log timestamp for debugging stale tokens
+        print(f"disconnect at {timezone.now()} for {request.user}")
+        return Response(status=204)
 
 
 #---

--- a/backend/chat/tests/test_disconnect_user.py
+++ b/backend/chat/tests/test_disconnect_user.py
@@ -7,9 +7,20 @@ class DisconnectUserAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
         return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
 
-    def test_disconnect_user_returns_ok(self):
+    def test_disconnect_user_returns_no_content(self):
         token = self.make_token()
-        url = reverse('disconnect-user')
-        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["status"], "ok")
+        url = reverse('session')
+        res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 204)
+        self.assertEqual(res.data, None)
+
+    def test_disconnect_requires_auth(self):
+        url = reverse('session')
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_disconnect_wrong_method(self):
+        token = self.make_token()
+        url = reverse('session')
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/tests/test_room_list.py
+++ b/backend/chat/tests/test_room_list.py
@@ -21,3 +21,14 @@ class RoomListAPITests(APITestCase):
         self.assertEqual(len(res.data), 2)
         uuids = {room["uuid"] for room in res.data}
         self.assertEqual(uuids, {"r1", "r2"})
+
+    def test_room_list_requires_auth(self):
+        url = reverse("room-list")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_room_list_wrong_method(self):
+        token = self.make_token()
+        url = reverse("room-list")
+        res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/tests/test_send_message.py
+++ b/backend/chat/tests/test_send_message.py
@@ -19,3 +19,16 @@ class SendMessageAPITests(APITestCase):
         msg = room.messages.first()
         self.assertEqual(msg.body, "hello")
         self.assertEqual(msg.sent_by, "u1")
+
+    def test_send_message_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, {"text": "x"}, format="json")
+        self.assertEqual(res.status_code, 403)
+
+    def test_send_message_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/tests/test_sync_user.py
+++ b/backend/chat/tests/test_sync_user.py
@@ -16,3 +16,14 @@ class SyncUserAPITests(APITestCase):
         self.assertTrue(CustomUser.objects.filter(username="u1").exists())
         user = CustomUser.objects.get(username="u1")
         self.assertTrue(UserProfile.objects.filter(user=user).exists())
+
+    def test_sync_user_requires_auth(self):
+        url = reverse("sync-user")
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_sync_user_wrong_method(self):
+        token = self.make_token()
+        url = reverse("sync-user")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/core/tests/test_get_app_settings.py
+++ b/backend/core/tests/test_get_app_settings.py
@@ -7,3 +7,8 @@ class GetAppSettingsTests(APITestCase):
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data, {"file_uploads": True})
+
+    def test_wrong_method(self):
+        url = reverse('core:app-settings')
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 405)

--- a/frontend/__tests__/adapter/disconnectUser.test.ts
+++ b/frontend/__tests__/adapter/disconnectUser.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
 
 const originalFetch = global.fetch;
 
@@ -16,8 +17,8 @@ test('disconnectUser clears state and notifies backend', () => {
   const client = new ChatClient('u1', 'jwt1');
   client.disconnectUser();
 
-  expect(global.fetch).toHaveBeenCalledWith('/api/disconnect-user/', {
-    method: 'POST',
+  expect(global.fetch).toHaveBeenCalledWith(API.SESSION, {
+    method: 'DELETE',
     headers: { Authorization: 'Bearer jwt1' },
   });
 

--- a/frontend/__tests__/adapter/getAppSettings.test.ts
+++ b/frontend/__tests__/adapter/getAppSettings.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API, EVENTS } from '../../src/lib/stream-adapter/constants';
 
 const originalFetch = global.fetch;
 
@@ -19,10 +20,14 @@ test('getAppSettings fetches settings from backend', async () => {
   });
 
   const client = new ChatClient('u1', 'jwt1');
+  const spy = vi.fn();
+  client.on(EVENTS.SETTINGS_UPDATED, spy);
   const settings = await client.getAppSettings();
 
-  expect(global.fetch).toHaveBeenCalledWith('/api/app-settings/', {
+  expect(global.fetch).toHaveBeenCalledWith(API.APP_SETTINGS, {
     headers: { Authorization: 'Bearer jwt1' },
   });
   expect(settings).toEqual({ file_uploads: true });
+  expect(client.settingsStore.getSnapshot()).toEqual({ file_uploads: true });
+  expect(spy).toHaveBeenCalledWith({ file_uploads: true });
 });

--- a/frontend/__tests__/adapter/queryChannels.test.ts
+++ b/frontend/__tests__/adapter/queryChannels.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
 
 const originalFetch = global.fetch;
 
@@ -26,7 +27,7 @@ test('queryChannels fetches rooms and updates state', async () => {
   const client = new ChatClient('u1', 'jwt1');
   const channels = await client.queryChannels();
 
-  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/', {
+  expect(global.fetch).toHaveBeenCalledWith(API.ROOMS, {
     headers: { Authorization: 'Bearer jwt1' },
   });
 

--- a/frontend/__tests__/adapter/sendMessage.test.ts
+++ b/frontend/__tests__/adapter/sendMessage.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API, EVENTS } from '../../src/lib/stream-adapter/constants';
 
 const originalFetch = global.fetch;
 
@@ -22,11 +23,11 @@ test('sendMessage posts message, updates state, and emits event', async () => {
   const channel = client.channel('messaging', 'room1');
 
   const eventSpy = vi.fn();
-  client.on('message.new', eventSpy);
+  client.on(EVENTS.MESSAGE_NEW, eventSpy);
 
   await channel.sendMessage({ text: 'hello' });
 
-  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/messages/', {
+  expect(global.fetch).toHaveBeenCalledWith(`${API.ROOMS}room1/messages/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -2,6 +2,7 @@ import mitt from 'mitt';
 import { MiniStore } from './MiniStore';
 import type { Message, ChatEvents } from './types';   // ⬅ add this
 import { ChatClient } from './ChatClient';
+import { API, EVENTS } from './constants';
 
 /* ──────────────────────────────────────────────────────────────── */
 /*  CustomChannel  –  minimal Stream-Chat look-alike               */
@@ -128,7 +129,7 @@ export class Channel {
                             messages: [...channelRef.state.messages, localMsg],
                             latestMessages: [...channelRef.state.latestMessages.slice(-49), localMsg],
                         });
-                        channelRef.emitter.emit('message.new', { type: 'message.new', message: localMsg });
+                        channelRef.emitter.emit(EVENTS.MESSAGE_NEW, { type: EVENTS.MESSAGE_NEW, message: localMsg });
 
                         /* 🔸 fire the real network request (no await needed for UX) */
                         channelRef.sendMessage({ text: draft })
@@ -259,7 +260,7 @@ export class Channel {
 
         /* initial history + read row */
         try {
-            const res = await fetch(`/api/rooms/${this.roomUuid}/messages/`, {
+            const res = await fetch(`${API.ROOMS}${this.roomUuid}/messages/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (res.ok) {
@@ -298,7 +299,7 @@ export class Channel {
                             messages: [...this._state.messages, msg],
                             latestMessages: [...this._state.latestMessages.slice(-49), msg], // keep last 50
                         });
-                        this.emitter.emit('message.new', { type: 'message.new', message: msg });
+                        this.emitter.emit(EVENTS.MESSAGE_NEW, { type: EVENTS.MESSAGE_NEW, message: msg });
                         break;
                     }
                     case 'typing.start':
@@ -326,9 +327,9 @@ export class Channel {
     }
 
 
-    /** Network-level send that also updates local state & fires message.new */
+    /** Network-level send that also updates local state & fires EVENTS.MESSAGE_NEW */
     async sendMessage({ text }: { text: string }) {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/messages/`, {
+        const res = await fetch(`${API.ROOMS}${this.roomUuid}/messages/`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -348,7 +349,7 @@ export class Channel {
         });
 
         /* global bus notify */
-        this.client.emit('message.new', { message: msg });
+        this.client.emit(EVENTS.MESSAGE_NEW, { message: msg });
 
         return msg;        
     }

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -1,0 +1,12 @@
+export const API = {
+  SYNC_USER: '/api/sync-user/',
+  SESSION: '/api/session/',
+  ROOMS: '/api/rooms/',
+  APP_SETTINGS: '/api/app-settings/',
+} as const;
+
+export const EVENTS = {
+  MESSAGE_NEW: 'message.new',
+  SETTINGS_UPDATED: 'settings.updated',
+} as const;
+

--- a/frontend/src/lib/stream-adapter/index.ts
+++ b/frontend/src/lib/stream-adapter/index.ts
@@ -1,3 +1,4 @@
 //frontend/src/lib/stream-adapter/index.ts
 export * from './types';          // re-export Room / Message / Events
-export { ChatClient } from './ChatClient';   //  ⬅ NEW
+export { ChatClient } from './ChatClient';
+export { API, EVENTS } from './constants';

--- a/frontend/src/lib/stream-adapter/types.ts
+++ b/frontend/src/lib/stream-adapter/types.ts
@@ -14,6 +14,11 @@ export interface Message {
   created_at: string;
 }
 
+/** Settings returned by `getAppSettings` */
+export interface AppSettings {
+  file_uploads: boolean;
+}
+
 /** Internal event-bus payloads used by CustomChannel */
 // export type Events =
 //   | { type: 'message.new';  message: Message }
@@ -24,4 +29,5 @@ export type ChatEvents = {
   'message.new': { type: 'message.new'; message: Message };
   'typing.start': { type: 'typing.start'; user_id: string };
   'typing.stop': { type: 'typing.stop'; user_id: string };
+  'settings.updated': AppSettings;
 };


### PR DESCRIPTION
## Summary
- add constants for API paths and event names
- type AppSettings and emit `settings.updated`
- update ChatClient to cache settings and use constants
- normalize session endpoint as DELETE `/api/session/`
- expand backend and adapter tests with negative cases
- fix duplicate URL name, remove duplicate export, and clarify event emit

## Testing
- `pnpm install`
- `python backend/manage.py test accounts_supabase chat core -v 0`
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_684f8f2558888326827db41ce324020e