### PR TITLE
Implement setUserAgent adapter method

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -81,7 +81,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **sendMessage**                              | ✅ | ✅ |
 | **sendReaction**                             | 🔲 | 🔲 |
 | **setQuotedMessage**                         | 🔲 | 🔲 |
-| **setUserAgent**                             | 🔲 | 🔲 |
+| **setUserAgent**                             | ✅ | 🔲 |
 | **state**                                    | 🔲 | 🔲 |
 | **subarray**                                 | 🔲 | 🔲 |
 | **tag**                                      | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/setUserAgent.test.ts
+++ b/frontend/__tests__/adapter/setUserAgent.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('setUserAgent updates returned user agent', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  client.setUserAgent('my-agent/1.0');
+  expect(client.getUserAgent()).toBe('my-agent/1.0');
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -17,6 +17,7 @@ export class ChatClient {
 
 
     clientID = 'local-dev';
+    private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];
     listeners: Record<string, any[]> = {};
@@ -72,7 +73,11 @@ export class ChatClient {
     emit = this.bus.emit.bind(this);
 
     getUserAgent() {
-        return 'custom-chat-client/0.0.1 stream-chat-react-adapter';
+        return this.userAgent;
+    }
+
+    setUserAgent(ua: string) {
+        this.userAgent = ua;
     }
 
     /** Initialize the client for a given user */


### PR DESCRIPTION
## Summary
- implement `setUserAgent` in adapter ChatClient
- add unit test
- mark `setUserAgent` adapter surface as complete

## Testing
- `pnpm -r test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f9661db1c8326b788bdb155bd245b