### PR TITLE
feat(adapter): implement countUnread backend

### DIFF
--- a/backend/chat/migrations/0002_readstate.py
+++ b/backend/chat/migrations/0002_readstate.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('chat', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ReadState',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('last_read', models.DateTimeField()),
+                ('room', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='chat.room')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'unique_together': {('user', 'room')},
+            },
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -42,3 +42,14 @@ class Room(models.Model):
     
     def __str__(self):
         return f'{self.client} - {self.uuid}'
+
+
+class ReadState(models.Model):
+    """Track the last read timestamp per user per room."""
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    room = models.ForeignKey(Room, on_delete=models.CASCADE)
+    last_read = models.DateTimeField()
+
+    class Meta:
+        unique_together = ("user", "room")

--- a/backend/chat/tests/test_count_unread.py
+++ b/backend/chat/tests/test_count_unread.py
@@ -1,0 +1,37 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message
+
+class CountUnreadAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_count_unread_before_and_after_mark_read(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        room.messages.add(Message.objects.create(body="hi", sent_by="u2"))
+        room.messages.add(Message.objects.create(body="there", sent_by="u2"))
+
+        token = self.make_token()
+        count_url = reverse("room-count-unread", kwargs={"room_uuid": room.uuid})
+        mark_url = reverse("room-mark-read", kwargs={"room_uuid": room.uuid})
+
+        # before marking read, all messages are unread
+        res = self.client.get(count_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["unread"], 2)
+
+        # mark as read
+        self.client.post(mark_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        # no new messages -> unread should be 0
+        res = self.client.get(count_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.data["unread"], 0)
+
+        # add another message
+        room.messages.add(Message.objects.create(body="new", sent_by="u2"))
+
+        res = self.client.get(count_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.data["unread"], 1)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -5,6 +5,7 @@ from .api_views import (
     RoomDetailView,
     RoomMessageListCreateView,
     RoomMarkReadView,
+    RoomCountUnreadView,
 )
 
 router = DefaultRouter()
@@ -22,5 +23,10 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/mark_read/",
         RoomMarkReadView.as_view(),
         name="room-mark-read",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/count_unread/",
+        RoomCountUnreadView.as_view(),
+        name="room-count-unread",
     ),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -20,7 +20,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **connectionId**                             | 🔲 | 🔲 |
 | **contextType**                              | 🔲 | 🔲 |
 | **cooldown**                                 | 🔲 | 🔲 |
-| **countUnread**                              | ✅ | 🔲 |
+| **countUnread**                              | ✅ | ✅ |
 | **createDraft**                              | 🔲 | 🔲 |
 | **createPollOption**                         | 🔲 | 🔲 |
 | **customDataManager**                        | 🔲 | 🔲 |


### PR DESCRIPTION
## Summary
- add `ReadState` model and migration
- store timestamp in `mark_read` endpoint
- add `count_unread` endpoint
- test unread counts
- update adapter checklist

## Testing
- `pnpm -r test`
- `python manage.py test`
- `pnpm turbo run build --filter backend`

------
https://chatgpt.com/codex/tasks/task_e_684f9645cfc48326baec776afd083900