### PR TITLE
feat(adapter): implement watch surface

### DIFF
--- a/backend/chat/tests/test_get_messages.py
+++ b/backend/chat/tests/test_get_messages.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message
+
+class GetMessagesAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_get_messages_returns_messages(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        msg = Message.objects.create(body="hi", sent_by="u2")
+        room.messages.add(msg)
+        token = self.make_token()
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["body"], "hi")
+
+    def test_get_messages_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_get_messages_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -103,7 +103,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **userID**                                   | 🔲 | 🔲 |
 | **userToken**                                | 🔲 | 🔲 |
 | **visible**                                  | 🔲 | 🔲 |
-| **watch**                                    | 🔲 | 🔲 |
+| **watch**                                    | ✅ | ✅ |
 | **wsPromise**                                | 🔲 | 🔲 |
 
 ### How to tick items

--- a/frontend/__tests__/adapter/watch.test.ts
+++ b/frontend/__tests__/adapter/watch.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+const originalWS = (global as any).WebSocket;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  (global as any).WebSocket = vi.fn(() => ({ onmessage: null }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  (global as any).WebSocket = originalWS;
+  vi.restoreAllMocks();
+});
+
+test('watch fetches messages and opens websocket', async () => {
+  const messages = [
+    { id: 'm1', text: 'hi', user_id: 'u2', created_at: '2025-01-01T00:00:00Z' },
+  ];
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => messages });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.watch();
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.ROOMS}room1/messages/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channel.initialized).toBe(true);
+  expect(channel.state.latestMessages).toEqual(messages);
+  expect((global as any).WebSocket).toHaveBeenCalledWith(
+    'ws://localhost:8000/ws/room1/?token=jwt1'
+  );
+});


### PR DESCRIPTION
## Summary
- add frontend unit test for watch
- test GET /api/rooms/<uuid>/messages/ endpoint
- mark watch surface complete in docs

## Testing
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f98e5abcc8326a84bf58ed9243ebe