### PR TITLE
feat(adapter-backend): add lastRead endpoint and tests

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -82,3 +82,15 @@ class RoomCountUnreadView(APIView):
         else:
             unread = room.messages.filter(created_at__gt=state.last_read).count()
         return Response({"unread": unread})
+
+
+class RoomLastReadView(APIView):
+    """Return the last read timestamp for the current user in a room."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        state = ReadState.objects.filter(user=request.user, room=room).first()
+        last_read = state.last_read if state else None
+        return Response({"last_read": last_read})

--- a/backend/chat/tests/test_last_read.py
+++ b/backend/chat/tests/test_last_read.py
@@ -1,0 +1,28 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class LastReadAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_last_read_returns_none_initially_then_timestamp(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-last-read", kwargs={"room_uuid": room.uuid})
+
+        # initially no read state
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertIsNone(res.data["last_read"])
+
+        # mark as read
+        mark_url = reverse("room-mark-read", kwargs={"room_uuid": room.uuid})
+        self.client.post(mark_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertIsInstance(res.data["last_read"], str)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -6,6 +6,7 @@ from .api_views import (
     RoomMessageListCreateView,
     RoomMarkReadView,
     RoomCountUnreadView,
+    RoomLastReadView,
 )
 
 router = DefaultRouter()
@@ -28,5 +29,10 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/count_unread/",
         RoomCountUnreadView.as_view(),
         name="room-count-unread",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/last_read/",
+        RoomLastReadView.as_view(),
+        name="room-last-read",
     ),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -47,7 +47,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **initState**                                | 🔲 | 🔲 |
 | **initialized**                              | 🔲 | 🔲 |
 | **intro**                                    | 🔲 | 🔲 |
-| **lastRead**                                 | ✅ | 🔲 |
+| **lastRead**                                 | ✅ | ✅ |
 | **linkPreviewsManager**                      | 🔲 | 🔲 |
 | **listeners**                                | 🔲 | 🔲 |
 | **markRead**                                 | ✅ | ✅ |


### PR DESCRIPTION
## Summary
- implement `RoomLastReadView` API endpoint to fetch last read timestamp
- expose `/api/rooms/<room_uuid>/last_read/` URL
- add backend unit test for `last_read`
- update coverage table

## Testing
- `pnpm -r build` *(fails: Failed to fetch fonts and resolve modules)*
- `pnpm -r test`
- `python manage.py test` *(fails: Pillow not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f99aea7f4832690f15ab226cf6425