### PR TITLE
feat(adapter): implement markUnread surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -69,6 +69,17 @@ class RoomMarkReadView(APIView):
         return Response({"status": "ok"})
 
 
+class RoomMarkUnreadView(APIView):
+    """Clear the read state for the current user in a room."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        ReadState.objects.filter(user=request.user, room=room).delete()
+        return Response({"status": "ok"})
+
+
 class RoomCountUnreadView(APIView):
     """Return number of unread messages for the current user in a room."""
     authentication_classes = [SupabaseJWTAuthentication]

--- a/backend/chat/tests/test_mark_unread.py
+++ b/backend/chat/tests/test_mark_unread.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, ReadState
+
+class MarkUnreadAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_mark_unread_clears_readstate(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        mark_url = reverse("room-mark-read", kwargs={"room_uuid": room.uuid})
+        unmark_url = reverse("room-mark-unread", kwargs={"room_uuid": room.uuid})
+
+        self.client.post(mark_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(ReadState.objects.filter(room=room).count(), 1)
+
+        res = self.client.post(unmark_url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(ReadState.objects.filter(room=room).count(), 0)
+
+    def test_mark_unread_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-mark-unread", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_mark_unread_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-mark-unread", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -5,6 +5,7 @@ from .api_views import (
     RoomDetailView,
     RoomMessageListCreateView,
     RoomMarkReadView,
+    RoomMarkUnreadView,
     RoomCountUnreadView,
     RoomLastReadView,
     MessageDetailView,
@@ -25,6 +26,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/mark_read/",
         RoomMarkReadView.as_view(),
         name="room-mark-read",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/mark_unread/",
+        RoomMarkUnreadView.as_view(),
+        name="room-mark-unread",
     ),
     path(
         "api/rooms/<str:room_uuid>/count_unread/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -51,7 +51,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **linkPreviewsManager**                      | 🔲 | 🔲 |
 | **listeners**                                | 🔲 | 🔲 |
 | **markRead**                                 | ✅ | ✅ |
-| **markUnread**                               | 🔲 | 🔲 |
+| **markUnread**                               | ✅ | ✅ |
 | **members**                                  | 🔲 | 🔲 |
 | **messageComposer**                          | 🔲 | 🔲 |
 | **messages**                                 | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/markUnread.test.ts
+++ b/frontend/__tests__/adapter/markUnread.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('markUnread posts to backend and clears read state', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  (channel.state as any).read['u1'] = {
+    last_read: '2025-01-01T00:00:00Z',
+    unread_messages: 0,
+  };
+
+  await channel.markUnread();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/mark_unread/', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channel.state.read['u1']).toBeUndefined();
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -336,6 +336,21 @@ export class Channel {
         }
     }
 
+    async markUnread() {
+        const me = this.client.user.id;
+        if (me) {
+            fetch(`/api/rooms/${this.roomUuid}/mark_unread/`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${this.client['jwt']}`,
+                },
+            }).catch(() => { /* network errors ignored */ });
+
+            const { [me]: _removed, ...rest } = this._state.read;
+            this.bump({ read: rest });
+        }
+    }
+
 
     /** Network-level send that also updates local state & fires EVENTS.MESSAGE_NEW */
     async sendMessage({ text }: { text: string }) {


### PR DESCRIPTION
## Summary
- add `markUnread` method to adapter `Channel`
- expose `mark_unread` API endpoint in Django backend
- test backend mark-unread and adapter implementation
- mark `markUnread` completed in docs

## Testing
- `pnpm --filter frontend test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684fa53d342483268bacde0397c26953