### PR TITLE
feat(adapter): generate clientID and test

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -11,7 +11,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **channel**                                  | 🔲 | 🔲 |
 | **cid**                                      | 🔲 | 🔲 |
 | **clear**                                    | 🔲 | 🔲 |
-| **clientID**                                 | 🔲 | 🔲 |
+| **clientID**                                 | ✅ | 🔲 |
 | **compose**                                  | 🔲 | 🔲 |
 | **compositionIsEmpty**                       | 🔲 | 🔲 |
 | **config**                                   | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/clientID.test.ts
+++ b/frontend/__tests__/adapter/clientID.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('clientID generated on connectUser includes user id', async () => {
+  const client = new ChatClient();
+  await client.connectUser({ id: 'u1' }, 'jwt1');
+  expect(client.clientID).toMatch(/^u1--/);
+  expect(global.fetch).toHaveBeenCalledWith(API.SYNC_USER, expect.anything());
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -2,6 +2,8 @@ import mitt from 'mitt';
 import { MiniStore } from './MiniStore';
 import { Channel } from './Channel';
 import { API, EVENTS } from './constants';
+
+const randomId = () => Math.random().toString(36).slice(2);
 import type { Room, ChatEvents, AppSettings, User } from './types';
 
 /* ------------------------------------------------------------------ */
@@ -16,7 +18,7 @@ export class ChatClient {
     /** Populated by connectUser, nulled by disconnectUser */
 
 
-    clientID = 'local-dev';
+    clientID: string;
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];
@@ -44,6 +46,7 @@ export class ChatClient {
         private jwt: string | null = null,
     ) {
         this.user = { id: userId };
+        this.clientID = randomId();
 
         /* no-op stubs keep Stream-UI happy */
         this.threads = this.polls = {
@@ -89,6 +92,7 @@ export class ChatClient {
         this.userId = user.id;
         this.jwt = token;
         (this as any).user = { id: user.id };
+        this.clientID = `${user.id}--${randomId()}`;
         const res = await fetch(API.SYNC_USER, {
             method: 'POST',
             headers: {


### PR DESCRIPTION
## Summary
- create random clientID for ChatClient
- test clientID generation
- mark docs row for clientID

## Testing
- `pnpm -r run build`
- `pnpm -r test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684fa59172bc83269d94651a6e191f0a