### PR TITLE
feat(adapter): track activeChannels

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -4,7 +4,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | surface                                      | adapter | backend |
 |----------------------------------------------|:-------:|:-------:|
 | **_user**                                    | 🔲 | 🔲 |
-| **activeChannels**                           | 🔲 | 🔲 |
+| **activeChannels**                           | ✅ | 🔲 |
 | **archive**                                  | 🔲 | 🔲 |
 | **attachmentManager**                        | 🔲 | 🔲 |
 | **axiosInstance**                            | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/activeChannels.test.ts
+++ b/frontend/__tests__/adapter/activeChannels.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+const originalWS = (global as any).WebSocket;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  (global as any).WebSocket = vi.fn(() => ({ onmessage: null }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  (global as any).WebSocket = originalWS;
+  vi.restoreAllMocks();
+});
+
+test('activeChannels stores channel after watch', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => [] });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.watch();
+
+  expect(client.activeChannels[channel.cid]).toBe(channel);
+});
+
+test('disconnectUser clears activeChannels', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => [] });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  await channel.watch();
+
+  client.disconnectUser();
+
+  expect(Object.keys(client.activeChannels).length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add activeChannels tests
- mark activeChannels adapter surface complete

## Testing
- `pnpm --recursive test`
- `pnpm --recursive build`


------
https://chatgpt.com/codex/tasks/task_e_684fa576bc0c8326b1f4b293f69ddb98