### PR TITLE
feat(adapter): implement channel surface

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -8,7 +8,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **archive**                                  | 🔲 | 🔲 |
 | **attachmentManager**                        | 🔲 | 🔲 |
 | **axiosInstance**                            | 🔲 | 🔲 |
-| **channel**                                  | 🔲 | 🔲 |
+| **channel**                                  | ✅ | 🔲 |
 | **cid**                                      | 🔲 | 🔲 |
 | **clear**                                    | 🔲 | 🔲 |
 | **clientID**                                 | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/channel.test.ts
+++ b/frontend/__tests__/adapter/channel.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+// channel() should return a Channel instance with correct cid/id
+
+test('channel returns Channel with matching cid and id', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  expect(channel.cid).toBe('messaging:room1');
+  expect(channel.id).toBe('room1');
+  expect(channel.data).toEqual({ name: 'room1' });
+  // ensure channel holds reference to client
+  // @ts-ignore internal
+  expect(channel['client']).toBe(client);
+});


### PR DESCRIPTION
## Summary
- add adapter test for `channel()` creation
- mark `channel` as done in adapter checklist

## Testing
- `pnpm --filter frontend test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684fa581ab788326b60aa6cfab3ff62e