### PR TITLE
test(adapter): cover clientID surface

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -11,7 +11,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **channel**                                  | 🔲 | 🔲 |
 | **cid**                                      | 🔲 | 🔲 |
 | **clear**                                    | 🔲 | 🔲 |
-| **clientID**                                 | 🔲 | 🔲 |
+| **clientID**                                 | ✅ | 🔲 |
 | **compose**                                  | 🔲 | 🔲 |
 | **compositionIsEmpty**                       | 🔲 | 🔲 |
 | **config**                                   | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/clientID.test.ts
+++ b/frontend/__tests__/adapter/clientID.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('clientID is fixed identifier', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  expect(client.clientID).toBe('local-dev');
+});


### PR DESCRIPTION
## Summary
- add adapter test for `clientID`
- mark `clientID` as implemented in adapter docs

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684fa56c39348326a48cfa5b22eb69e6