### PR TITLE
feat(adapter): implement off surface with tests

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -61,7 +61,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **mutedUsers**                               | 🔲 | 🔲 |
 | **name**                                     | 🔲 | 🔲 |
 | **notifications**                            | 🔲 | 🔲 |
-| **off**                                      | 🔲 | 🔲 |
+| **off**                                      | ✅ | 🔲 |
 | **on**                                       | 🔲 | 🔲 |
 | **pin**                                      | 🔲 | 🔲 |
 | **pinMessage**                               | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/off.test.ts
+++ b/frontend/__tests__/adapter/off.test.ts
@@ -1,0 +1,16 @@
+import { expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { EVENTS } from '../../src/lib/stream-adapter/constants';
+
+// off.test.ts - ensures off removes listener
+
+test('off removes event listener', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const spy = vi.fn();
+  client.on(EVENTS.MESSAGE_NEW, spy);
+  client.off(EVENTS.MESSAGE_NEW, spy);
+
+  client.emit(EVENTS.MESSAGE_NEW, { message: { id: 'm1', text: 'x', user_id: 'u1', created_at: '2025-01-01T00:00:00Z' } });
+
+  expect(spy).not.toHaveBeenCalled();
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -23,7 +23,6 @@ export class ChatClient {
     clientID: string;
     /** Unique ID for the current connection (null until connected) */
     connectionId: string | null = null;
-    main
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];


### PR DESCRIPTION
## Summary
- implement `off` adapter surface via tests
- remove stray `main` token from ChatClient
- mark `off` as completed in docs

## Testing
- `pnpm -r build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6850079a28008326a2fb71190a5a84fd