### PR TITLE
Implement archive surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -116,3 +116,15 @@ class MessageDetailView(APIView):
         msg = get_object_or_404(Message, id=message_id)
         msg.delete()
         return Response(status=204)
+
+
+class RoomArchiveView(APIView):
+    """Archive a room by setting its status to CLOSED."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        room.status = Room.CLOSED
+        room.save()
+        return Response({"status": "ok"})

--- a/backend/chat/tests/test_archive_room.py
+++ b/backend/chat/tests/test_archive_room.py
@@ -1,0 +1,33 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class ArchiveRoomAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_archive_room_sets_status_closed(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-archive", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        room.refresh_from_db()
+        self.assertEqual(room.status, Room.CLOSED)
+        self.assertEqual(res.data["status"], "ok")
+
+    def test_archive_room_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-archive", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_archive_room_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-archive", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -9,6 +9,7 @@ from .api_views import (
     RoomCountUnreadView,
     RoomLastReadView,
     MessageDetailView,
+    RoomArchiveView,
 )
 
 router = DefaultRouter()
@@ -41,6 +42,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/last_read/",
         RoomLastReadView.as_view(),
         name="room-last-read",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/archive/",
+        RoomArchiveView.as_view(),
+        name="room-archive",
     ),
     path(
         "api/messages/<int:message_id>/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -5,7 +5,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 |----------------------------------------------|:-------:|:-------:|
 | **_user**                                    | 🔲 | 🔲 |
 | **activeChannels**                           | ✅ | 🔲 |
-| **archive**                                  | 🔲 | 🔲 |
+| **archive**                                  | ✅ | ✅ |
 | **attachmentManager**                        | 🔲 | 🔲 |
 | **axiosInstance**                            | 🔲 | 🔲 |
 | **cid**                                      | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/archive.test.ts
+++ b/frontend/__tests__/adapter/archive.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('archive posts to backend endpoint', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.archive();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/archive/', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -393,6 +393,15 @@ export class Channel {
         });
     }
 
+    /** Archive this channel */
+    async archive() {
+        const res = await fetch(`/api/rooms/${this.roomUuid}/archive/`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('archive failed');
+    }
+
     /* event helpers */
     on = this.emitter.on as any;
     off = this.emitter.off as any;

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -23,7 +23,7 @@ export class ChatClient {
     clientID: string;
     /** Unique ID for the current connection (null until connected) */
     connectionId: string | null = null;
-    main
+
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];


### PR DESCRIPTION
## Summary
- add RoomArchiveView API endpoint and test
- wire archive view in chat URLs
- implement Channel.archive adapter method
- test adapter archive method
- mark `archive` row complete in TODO

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685007a7f638832698842b24bd2d32e8