### PR TITLE
Implement getConfig surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -116,3 +116,21 @@ class MessageDetailView(APIView):
         msg = get_object_or_404(Message, id=message_id)
         msg.delete()
         return Response(status=204)
+
+
+class RoomConfigView(APIView):
+    """Return configuration flags for the given room."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, room_uuid):
+        # For now return static configuration matching adapter defaults
+        get_object_or_404(Room, uuid=room_uuid)
+        return Response(
+            {
+                "typing_events": True,
+                "read_events": True,
+                "reactions": True,
+                "uploads": True,
+            }
+        )

--- a/backend/chat/tests/test_get_config.py
+++ b/backend/chat/tests/test_get_config.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class GetConfigAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_get_config_returns_defaults(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-config", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, {
+            "typing_events": True,
+            "read_events": True,
+            "reactions": True,
+            "uploads": True,
+        })
+
+    def test_get_config_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-config", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_get_config_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-config", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -8,6 +8,7 @@ from .api_views import (
     RoomMarkUnreadView,
     RoomCountUnreadView,
     RoomLastReadView,
+    RoomConfigView,
     MessageDetailView,
 )
 
@@ -41,6 +42,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/last_read/",
         RoomLastReadView.as_view(),
         name="room-last-read",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/config/",
+        RoomConfigView.as_view(),
+        name="room-config",
     ),
     path(
         "api/messages/<int:message_id>/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -38,7 +38,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **flagMessage**                              | 🔲 | 🔲 |
 | **getAppSettings**                           | ✅ | ✅ |
 | **getClient**                                | 🔲 | 🔲 |
-| **getConfig**                                | 🔲 | 🔲 |
+| **getConfig**                                | ✅ | ✅ |
 | **getReplies**                               | 🔲 | 🔲 |
 | **getUserAgent**                             | ✅ | 🔲 |
 | **hasSendableData**                          | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/getConfig.test.ts
+++ b/frontend/__tests__/adapter/getConfig.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getConfig fetches room config', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => ({ typing_events: true }),
+  });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  const cfg = await channel.getConfig();
+  expect(global.fetch).toHaveBeenCalledWith(
+    `${API.ROOMS}room1/config/`,
+    { headers: { Authorization: `Bearer jwt1` } }
+  );
+  expect(cfg).toEqual({ typing_events: true });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -242,7 +242,13 @@ export class Channel {
 
     /* ─── getters Stream-UI expects ─── */
     get state() { return this._state; }
-    getConfig() { return { typing_events: true, read_events: true, reactions: true, uploads: true }; }
+    async getConfig() {
+        const res = await fetch(`${API.ROOMS}${this.roomUuid}/config/`, {
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('getConfig failed');
+        return await res.json();
+    }
 
     countUnread() {
         const me = this._state.read[this.client.user.id!];

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -23,7 +23,6 @@ export class ChatClient {
     clientID: string;
     /** Unique ID for the current connection (null until connected) */
     connectionId: string | null = null;
-    main
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];


### PR DESCRIPTION
## Summary
- expose channel configuration via new API endpoint
- fetch room config from frontend channel
- test new backend endpoint and frontend method
- mark `getConfig` in adapter-todo

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685007af2f548326a0f8d0b4bb66e399