### PR TITLE
Implement userID surface in adapter

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -100,7 +100,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **updateMessage**                            | 🔲 | 🔲 |
 | **updated**                                  | 🔲 | 🔲 |
 | **user**                                     | 🔲 | 🔲 |
-| **userID**                                   | 🔲 | 🔲 |
+| **userID**                                   | ✅ | 🔲 |
 | **userToken**                                | 🔲 | 🔲 |
 | **visible**                                  | 🔲 | 🔲 |
 | **watch**                                    | ✅ | ✅ |

--- a/frontend/__tests__/adapter/userID.test.ts
+++ b/frontend/__tests__/adapter/userID.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('userID reflects constructor value', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  expect(client.userID).toBe('u1');
+});
+
+test('userID updates on connectUser and clears on disconnectUser', async () => {
+  const client = new ChatClient(null, null);
+  await client.connectUser({ id: 'u2' }, 'jwt2');
+  expect(client.userID).toBe('u2');
+
+  client.disconnectUser();
+  expect(client.userID).toBeNull();
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -23,7 +23,6 @@ export class ChatClient {
     clientID: string;
     /** Unique ID for the current connection (null until connected) */
     connectionId: string | null = null;
-    main
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];
@@ -86,6 +85,11 @@ export class ChatClient {
 
     setUserAgent(ua: string) {
         this.userAgent = ua;
+    }
+
+    /** Return the currently connected user's ID, if any */
+    get userID() {
+        return this.userId;
     }
 
     /** Initialize the client for a given user */


### PR DESCRIPTION
## Summary
- expose `userID` getter on the adapter client
- cover with unit tests
- mark `userID` surface done in docs

## Testing
- `pnpm -r build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685007b2ec588326a1435e6df5d9e4bf