### PR TITLE
feat(adapter): implement unarchive surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -146,3 +146,15 @@ class RoomArchiveView(APIView):
         room.save()
         return Response({"status": "ok"})
 
+
+class RoomUnarchiveView(APIView):
+    """Reopen a previously archived room."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        room.status = Room.ACTIVE
+        room.save()
+        return Response({"status": "ok"})
+

--- a/backend/chat/tests/test_unarchive_room.py
+++ b/backend/chat/tests/test_unarchive_room.py
@@ -1,0 +1,33 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class UnarchiveRoomAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_unarchive_room_sets_status_active(self):
+        room = Room.objects.create(uuid="r1", client="c1", status=Room.CLOSED)
+        token = self.make_token()
+        url = reverse("room-unarchive", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        room.refresh_from_db()
+        self.assertEqual(room.status, Room.ACTIVE)
+        self.assertEqual(res.data["status"], "ok")
+
+    def test_unarchive_room_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1", status=Room.CLOSED)
+        url = reverse("room-unarchive", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_unarchive_room_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1", status=Room.CLOSED)
+        token = self.make_token()
+        url = reverse("room-unarchive", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -11,6 +11,7 @@ from .api_views import (
     RoomConfigView,
     MessageDetailView,
     RoomArchiveView,
+    RoomUnarchiveView,
 )
 
 router = DefaultRouter()
@@ -53,6 +54,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/archive/",
         RoomArchiveView.as_view(),
         name="room-archive",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/unarchive/",
+        RoomUnarchiveView.as_view(),
+        name="room-unarchive",
     ),
     path(
         "api/messages/<int:message_id>/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -93,7 +93,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **truncate**                                 | 🔲 | 🔲 |
 | **truncated**                                | 🔲 | 🔲 |
 | **type**                                     | 🔲 | 🔲 |
-| **unarchive**                                | 🔲 | 🔲 |
+| **unarchive**                                | ✅ | ✅ |
 | **unmuteUser**                               | 🔲 | 🔲 |
 | **unpin**                                    | 🔲 | 🔲 |
 | **unpinMessage**                             | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/markRead.test.ts
+++ b/frontend/__tests__/adapter/markRead.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
-import { API } from '@/lib/stream-adapter';
+// import via relative path to avoid path alias issues in Vitest
+import { API } from '../../src/lib/stream-adapter';
 
 const originalFetch = global.fetch;
 
@@ -24,7 +25,7 @@ test('markRead posts to backend and updates state', async () => {
   await channel.markRead();
 
   expect(global.fetch).toHaveBeenCalledWith(
-    `${API.ROOMS}room1/mark_unread/`,
+    `${API.ROOMS}room1/mark_read/`,
     { method: 'POST', headers: { Authorization: 'Bearer jwt1' } },
   );
   const read = channel.state.read['u1'];

--- a/frontend/__tests__/adapter/unarchive.test.ts
+++ b/frontend/__tests__/adapter/unarchive.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('unarchive posts to backend endpoint', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.unarchive();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/unarchive/', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -408,6 +408,15 @@ export class Channel {
         if (!res.ok) throw new Error('archive failed');
     }
 
+    /** Unarchive this channel */
+    async unarchive() {
+        const res = await fetch(`/api/rooms/${this.roomUuid}/unarchive/`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('unarchive failed');
+    }
+
     /* event helpers */
     on = this.emitter.on as any;
     off = this.emitter.off as any;


### PR DESCRIPTION
## Summary
- add `unarchive()` in `Channel`
- implement backend API endpoint for unarchiving rooms
- cover new feature with unit tests
- fix markRead test import and expectation
- update TODO checklist

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_68500d83295883268c56a1135febd928