### PR TITLE
Implement setUserAgent backend endpoint

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,9 +1,10 @@
 #accounts/urls.py
 from django.urls import path
-from .views import SyncUserView, SessionView, QueryUsersView
+from .views import SyncUserView, SessionView, QueryUsersView, UserAgentView
 
 urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
     path('api/session/', SessionView.as_view(), name='session'),
     path('api/users/', QueryUsersView.as_view(), name='query-users'),
+    path('api/user-agent/', UserAgentView.as_view(), name='user-agent'),
 ]

--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -29,6 +29,19 @@ class SessionView(APIView):
         return Response(status=204)
 
 
+class UserAgentView(APIView):
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        request.session['user_agent'] = request.data.get('user_agent', '')
+        return Response({"status": "ok"})
+
+    def get(self, request):
+        ua = request.session.get('user_agent')
+        return Response({"user_agent": ua})
+
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()

--- a/backend/chat/tests/test_set_user_agent.py
+++ b/backend/chat/tests/test_set_user_agent.py
@@ -1,0 +1,24 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class UserAgentAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_set_and_get_user_agent(self):
+        token = self.make_token()
+        url = reverse("user-agent")
+        res = self.client.post(url, {"user_agent": "ua1"}, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["status"], "ok")
+
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["user_agent"], "ua1")
+
+    def test_user_agent_requires_auth(self):
+        url = reverse("user-agent")
+        res = self.client.post(url, {"user_agent": "ua"})
+        self.assertEqual(res.status_code, 403)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -81,7 +81,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **sendMessage**                              | ✅ | ✅ |
 | **sendReaction**                             | 🔲 | 🔲 |
 | **setQuotedMessage**                         | 🔲 | 🔲 |
-| **setUserAgent**                             | ✅ | 🔲 |
+| **setUserAgent**                             | ✅ | ✅ |
 | **state**                                    | 🔲 | 🔲 |
 | **subarray**                                 | 🔲 | 🔲 |
 | **tag**                                      | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/setUserAgent.test.ts
+++ b/frontend/__tests__/adapter/setUserAgent.test.ts
@@ -1,8 +1,26 @@
-import { expect, test } from 'vitest';
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
 
-test('setUserAgent updates returned user agent', () => {
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('setUserAgent updates returned user agent and posts to backend', () => {
   const client = new ChatClient('u1', 'jwt1');
   client.setUserAgent('my-agent/1.0');
+
+  expect(global.fetch).toHaveBeenCalledWith(API.USER_AGENT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer jwt1' },
+    body: JSON.stringify({ user_agent: 'my-agent/1.0' }),
+  });
   expect(client.getUserAgent()).toBe('my-agent/1.0');
 });

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -85,6 +85,16 @@ export class ChatClient {
 
     setUserAgent(ua: string) {
         this.userAgent = ua;
+        if (this.jwt) {
+            fetch(API.USER_AGENT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${this.jwt}`,
+                },
+                body: JSON.stringify({ user_agent: ua }),
+            }).catch(() => { /* ignore network errors */ });
+        }
     }
 
     /** Return the currently connected user's ID, if any */

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -6,6 +6,7 @@ export const API = {
   APP_SETTINGS: '/api/app-settings/',
   MARK_UNREAD: '/api/rooms/',
   USERS: '/api/users/',
+  USER_AGENT: '/api/user-agent/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- add `/api/user-agent/` endpoint to persist client user agent
- call this endpoint from the adapter `setUserAgent`
- test new behavior in adapter and backend
- mark `setUserAgent` as implemented

## Testing
- `pnpm turbo run build test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6850140a34748326b14facb5d88f8c12