### PR TITLE
feat(adapter): messages and user API

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,10 +1,11 @@
 #accounts/urls.py
 from django.urls import path
-from .views import SyncUserView, SessionView, QueryUsersView, UserAgentView
+from .views import SyncUserView, SessionView, QueryUsersView, UserAgentView, CurrentUserView
 
 urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
     path('api/session/', SessionView.as_view(), name='session'),
     path('api/users/', QueryUsersView.as_view(), name='query-users'),
-    path('api/user-agent/', UserAgentView.as_view(), name='user-agent'),
+    path('api/user-agent-auth/', UserAgentView.as_view(), name='user-agent'),
+    path('api/user/', CurrentUserView.as_view(), name='user'),
 ]

--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -57,6 +57,16 @@ class QueryUsersView(generics.ListAPIView):
         return get_user_model().objects.all()
 
 
+class CurrentUserView(APIView):
+    """Return details for the current authenticated user."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+        return Response({"id": user.id, "username": user.username})
+
+
 #---
 # # accounts/views.py
 # from rest_framework.views import APIView

--- a/backend/chat/tests/test_user.py
+++ b/backend/chat/tests/test_user.py
@@ -1,0 +1,25 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from accounts_supabase.models import CustomUser
+
+class CurrentUserAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+
+    def test_get_current_user(self):
+        token = self.make_token()
+        url = reverse("user")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["username"], "u1")
+
+    def test_current_user_requires_auth(self):
+        url = reverse("user")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -3,8 +3,8 @@ from django.urls import path, include
 
 
 urlpatterns = [
+    path('', include('accounts_supabase.urls')),
     path('', include('core.urls')),
     path('', include('chat.urls')),
-    path('', include('accounts_supabase.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -54,7 +54,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **markUnread**                               | ✅ | ✅ |
 | **members**                                  | 🔲 | 🔲 |
 | **messageComposer**                          | 🔲 | 🔲 |
-| **messages**                                 | 🔲 | 🔲 |
+| **messages**                                 | ✅ | ✅ |
 | **muteStatus**                               | 🔲 | 🔲 |
 | **muteUser**                                 | 🔲 | 🔲 |
 | **mutedChannels**                            | 🔲 | 🔲 |
@@ -99,7 +99,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **unpinMessage**                             | 🔲 | 🔲 |
 | **updateMessage**                            | 🔲 | 🔲 |
 | **updated**                                  | 🔲 | 🔲 |
-| **user**                                     | 🔲 | 🔲 |
+| **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | 🔲 |
 | **userToken**                                | 🔲 | 🔲 |
 | **visible**                                  | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/messages.test.ts
+++ b/frontend/__tests__/adapter/messages.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+const originalWS = (global as any).WebSocket;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  (global as any).WebSocket = vi.fn(() => ({ onmessage: null }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  (global as any).WebSocket = originalWS;
+  vi.restoreAllMocks();
+});
+
+test('messages getter reflects fetched history', async () => {
+  const msgs = [
+    { id: 'm1', text: 'hi', user_id: 'u2', created_at: '2025-01-01T00:00:00Z' },
+  ];
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => msgs });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.watch();
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.ROOMS}room1/messages/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channel.messages).toEqual(msgs);
+});

--- a/frontend/__tests__/adapter/user.test.ts
+++ b/frontend/__tests__/adapter/user.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getUser fetches current user and updates property', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => ({ id: 1, username: 'u1' }) });
+  const client = new ChatClient('u1', 'jwt1');
+  const info = await client.getUser();
+  expect(global.fetch).toHaveBeenCalledWith(API.USER, { headers: { Authorization: 'Bearer jwt1' } });
+  expect(info.username).toBe('u1');
+  expect(client.user.id).toBe('1');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -242,6 +242,8 @@ export class Channel {
 
     /* ─── getters Stream-UI expects ─── */
     get state() { return this._state; }
+    /** Convenience getter exposing current message list */
+    get messages() { return this._state.messages; }
     async getConfig() {
         const res = await fetch(`${API.ROOMS}${this.roomUuid}/config/`, {
             headers: { Authorization: `Bearer ${this.client['jwt']}` },

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -167,6 +167,17 @@ export class ChatClient {
         return res.ok ? await res.json() as User[] : [];
     }
 
+    /** Fetch the currently authenticated user */
+    async getUser() {
+        const res = await fetch(API.USER, {
+            headers: this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {},
+        });
+        if (!res.ok) throw new Error('user fetch failed');
+        const info = await res.json() as User;
+        (this as any).user = { id: String(info.id) };
+        return info;
+    }
+
     /** fetch global app settings */
     async getAppSettings(): Promise<AppSettings> {
         const res = await fetch(API.APP_SETTINGS, {

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -6,7 +6,8 @@ export const API = {
   APP_SETTINGS: '/api/app-settings/',
   MARK_UNREAD: '/api/rooms/',
   USERS: '/api/users/',
-  USER_AGENT: '/api/user-agent/',
+  USER: '/api/user/',
+  USER_AGENT: '/api/user-agent-auth/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- expose `channel.messages` getter
- add ChatClient.getUser to fetch current user
- wire new `/api/user/` endpoint and adjust `/api/user-agent-auth/`
- update router order to prioritize accounts
- document coverage for `messages` and `user`
- add unit tests

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685019543b848326bc1f0dadb57ba1a7