### PR TITLE
feat(adapter): add active channels endpoint and method

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -170,3 +170,13 @@ class RoomUnarchiveView(APIView):
         room.save()
         return Response({"status": "ok"})
 
+
+class ActiveRoomListView(generics.ListAPIView):
+    """Return all rooms currently marked as ACTIVE."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = RoomSerializer
+
+    def get_queryset(self):
+        return Room.objects.filter(status=Room.ACTIVE)
+

--- a/backend/chat/tests/test_active_rooms.py
+++ b/backend/chat/tests/test_active_rooms.py
@@ -1,0 +1,31 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class ActiveRoomsAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_list_active_rooms(self):
+        Room.objects.create(uuid="r1", client="c1", status=Room.ACTIVE)
+        Room.objects.create(uuid="r2", client="c2", status=Room.CLOSED)
+        token = self.make_token()
+        url = reverse("active-rooms")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["uuid"], "r1")
+
+    def test_active_rooms_requires_auth(self):
+        url = reverse("active-rooms")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_active_rooms_wrong_method(self):
+        token = self.make_token()
+        url = reverse("active-rooms")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -13,6 +13,7 @@ from .api_views import (
     MessageRepliesView,
     RoomArchiveView,
     RoomUnarchiveView,
+    ActiveRoomListView,
 )
 
 router = DefaultRouter()
@@ -20,6 +21,7 @@ router = DefaultRouter()
 
 urlpatterns = [
     path("api/rooms/", RoomListCreateView.as_view(), name="room-list"),
+    path("api/rooms/active/", ActiveRoomListView.as_view(), name="active-rooms"),
     path("api/rooms/<str:uuid>/", RoomDetailView.as_view(), name="room-detail"),
     path(
         "api/rooms/<str:room_uuid>/messages/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -4,7 +4,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | surface                                      | adapter | backend |
 |----------------------------------------------|:-------:|:-------:|
 | **_user**                                    | 🔲 | 🔲 |
-| **activeChannels**                           | ✅ | 🔲 |
+| **activeChannels**                           | ✅ | ✅ |
 | **archive**                                  | ✅ | ✅ |
 | **attachmentManager**                        | 🔲 | 🔲 |
 | **axiosInstance**                            | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/getActiveChannels.test.ts
+++ b/frontend/__tests__/adapter/getActiveChannels.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getActiveChannels fetches active rooms', async () => {
+  const rooms = [{ uuid: 'r1', name: 'Room 1' }];
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => rooms });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channels = await client.getActiveChannels();
+
+  expect(global.fetch).toHaveBeenCalledWith(API.ACTIVE_ROOMS, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channels).toHaveLength(1);
+  expect(channels[0].cid).toBe('messaging:r1');
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -179,6 +179,15 @@ export class ChatClient {
         return settings;
     }
 
+    /** list of currently active channels */
+    async getActiveChannels() {
+        const res = await fetch(API.ACTIVE_ROOMS, {
+            headers: this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {},
+        });
+        const rooms = res.ok ? (await res.json() as Room[]) : [];
+        return rooms.map(r => new Channel(r.uuid, r.name ?? r.uuid, this));
+    }
+
     /** create / retrieve single channel for <Channel channel={…}> */
     channel(_: 'messaging', roomUuid: string) {
         return new Channel(roomUuid, roomUuid, this);

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -2,6 +2,7 @@ export const API = {
   SYNC_USER: '/api/sync-user/',
   SESSION: '/api/session/',
   ROOMS: '/api/rooms/',
+  ACTIVE_ROOMS: '/api/rooms/active/',
   MESSAGES: '/api/messages/',
   APP_SETTINGS: '/api/app-settings/',
   MARK_UNREAD: '/api/rooms/',


### PR DESCRIPTION
## Summary
- implement ActiveRoomListView on the backend
- expose `/api/rooms/active/` route
- add ChatClient.getActiveChannels and constant
- test new adapter method and backend view
- mark docs for activeChannels

## Testing
- `pnpm turbo build`
- `pnpm -r test`
- `DJANGO_SETTINGS_MODULE=jatte.settings pytest -q` *(fails: Pillow missing)*

------
https://chatgpt.com/codex/tasks/task_e_685019ec9fb083268c24792c382a9307