### PR TITLE
feat(adapter): implement channel backend endpoint test

### DIFF
--- a/backend/chat/tests/test_room_detail.py
+++ b/backend/chat/tests/test_room_detail.py
@@ -1,0 +1,32 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class RoomDetailAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_room_detail_returns_room(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-detail", kwargs={"uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["uuid"], room.uuid)
+        self.assertEqual(res.data["client"], room.client)
+
+    def test_room_detail_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-detail", kwargs={"uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_room_detail_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-detail", kwargs={"uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('about/', views.about, name='about'),
     path('api/app-settings/', views.get_app_settings, name='app-settings'),
-    path('api/user-agent/', views.get_user_agent, name='user-agent'),
+    path('api/user-agent-echo/', views.get_user_agent, name='user-agent'),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -9,7 +9,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **attachmentManager**                        | 🔲 | 🔲 |
 | **axiosInstance**                            | 🔲 | 🔲 |
 | **cid**                                      | ✅ | ✅ |
-| **channel**                                  | ✅ | 🔲 |
+| **channel**                                  | ✅ | ✅ |
 | **clear**                                    | 🔲 | 🔲 |
 | **clientID**                                 | ✅ | 🔲 |
 | **compose**                                  | 🔲 | 🔲 |


### PR DESCRIPTION
## Summary
- add Django tests for Room detail view
- disambiguate user-agent endpoint to avoid method conflicts
- mark channel backend support in adapter TODO

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68501a69e3fc83268b942c26d3e1a3e3