### PR TITLE
feat(adapter): implement createDraft backend endpoint

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -6,6 +6,6 @@ urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
     path('api/session/', SessionView.as_view(), name='session'),
     path('api/users/', QueryUsersView.as_view(), name='query-users'),
-    path('api/user-agent/', UserAgentView.as_view(), name='user-agent')
+    path('api/user-agent/', UserAgentView.as_view(), name='user-agent'),
     path('api/user/', CurrentUserView.as_view(), name='user'),
 ]

--- a/backend/chat/migrations/0004_draft.py
+++ b/backend/chat/migrations/0004_draft.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('chat', '0003_add_reply_to'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Draft',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('text', models.TextField(blank=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('room', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='chat.room')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'unique_together': {('user', 'room')},
+            },
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -56,3 +56,15 @@ class ReadState(models.Model):
 
     class Meta:
         unique_together = ("user", "room")
+
+
+class Draft(models.Model):
+    """Store message drafts per user and room."""
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    room = models.ForeignKey(Room, on_delete=models.CASCADE)
+    text = models.TextField(blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        unique_together = ("user", "room")

--- a/backend/chat/tests/test_create_draft.py
+++ b/backend/chat/tests/test_create_draft.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Draft
+
+class CreateDraftAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_create_and_get_draft(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["status"], "ok")
+        self.assertTrue(Draft.objects.filter(room=room, user__username="u1").exists())
+
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["text"], "hello")
+
+    def test_draft_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, {"text": "x"}, format="json")
+        self.assertEqual(res.status_code, 403)
+
+    def test_draft_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -14,6 +14,7 @@ from .api_views import (
     RoomArchiveView,
     RoomUnarchiveView,
     ActiveRoomListView,
+    RoomDraftView,
 )
 
 router = DefaultRouter()
@@ -47,6 +48,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/last_read/",
         RoomLastReadView.as_view(),
         name="room-last-read",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/draft/",
+        RoomDraftView.as_view(),
+        name="room-draft",
     ),
     path(
         "api/rooms/<str:room_uuid>/config/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -21,7 +21,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **contextType**                              | 🔲 | 🔲 |
 | **cooldown**                                 | 🔲 | 🔲 |
 | **countUnread**                              | ✅ | ✅ |
-| **createDraft**                              | ✅ | 🔲 |
+| **createDraft**                              | ✅ | ✅ |
 | **createPollOption**                         | 🔲 | 🔲 |
 | **customDataManager**                        | 🔲 | 🔲 |
 | **data**                                     | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/createDraft.test.ts
+++ b/frontend/__tests__/adapter/createDraft.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
 
 let setItemSpy: any;
+const originalFetch = global.fetch;
 
 beforeEach(() => {
   setItemSpy = vi.fn();
@@ -10,17 +11,27 @@ beforeEach(() => {
     setItem: setItemSpy,
     removeItem: vi.fn(),
   };
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
 });
 
 afterEach(() => {
   delete (global as any).localStorage;
+  global.fetch = originalFetch;
 });
 
-test('createDraft saves current text to localStorage', () => {
+test('createDraft saves current text to localStorage and posts draft', () => {
   const client = new ChatClient('u1', 'jwt1');
   const channel = client.channel('messaging', 'room1');
   channel.messageComposer.textComposer.setText('draft message');
 
   channel.messageComposer.createDraft();
   expect(setItemSpy).toHaveBeenCalledWith('draft:undefined', 'draft message');
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/draft/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer jwt1',
+    },
+    body: JSON.stringify({ text: 'draft message' }),
+  });
 });

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -186,7 +186,21 @@ export class Channel {
 
                 /* ——— subscriptions & drafts ——— */
                 registerSubscriptions() { return () => { }; },
-                createDraft() { localStorage.setItem(roomKey, textStore.getSnapshot().text); },
+                createDraft() {
+                    const text = textStore.getSnapshot().text;
+                    localStorage.setItem(roomKey, text);
+                    const token = channelRef.client['jwt'];
+                    if (token) {
+                        fetch(`/api/rooms/${channelRef.roomUuid}/draft/`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                Authorization: `Bearer ${token}`,
+                            },
+                            body: JSON.stringify({ text }),
+                        }).catch(() => { /* ignore network errors */ });
+                    }
+                },
                 discardDraft() { localStorage.removeItem(roomKey); },
 
                 // pollComposer: {


### PR DESCRIPTION
## Summary
- implement channel.createDraft to POST draft data to backend
- add Draft model, API views, URL route
- add backend unit tests and migration
- extend adapter test for createDraft
- fix missing comma in accounts_supabase urls
- mark createDraft backend as done in adapter-todo

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test chat`

------
https://chatgpt.com/codex/tasks/task_e_685024156d6883268064e95bcdde59cf