### PR TITLE
feat(adapter): expose userToken getter

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -101,7 +101,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **updated**                                  | 🔲 | 🔲 |
 | **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | 🔲 |
-| **userToken**                                | 🔲 | 🔲 |
+| **userToken**                                | ✅ | ✅ |
 | **visible**                                  | 🔲 | 🔲 |
 | **watch**                                    | ✅ | ✅ |
 | **wsPromise**                                | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/userToken.test.ts
+++ b/frontend/__tests__/adapter/userToken.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('userToken reflects constructor value', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  expect(client.userToken).toBe('jwt1');
+});
+
+test('userToken updates on connectUser and clears on disconnectUser', async () => {
+  const client = new ChatClient(null, null);
+  await client.connectUser({ id: 'u2' }, 'jwt2');
+  expect(client.userToken).toBe('jwt2');
+
+  client.disconnectUser();
+  expect(client.userToken).toBeNull();
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -102,6 +102,11 @@ export class ChatClient {
         return this.userId;
     }
 
+    /** Return the JWT token currently in use, if any */
+    get userToken() {
+        return this.jwt;
+    }
+
     /** Initialize the client for a given user */
     /**
      * Register a user and emit the same events Stream’s SDK does.


### PR DESCRIPTION
## Summary
- expose `userToken` getter on ChatClient
- cover userToken with unit tests
- mark userToken surface as implemented

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_685025bfd4648326a8656feaf6e07efd