### PR TITLE
feat(adapter): implement getClient surface (task-1)

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -6,6 +6,6 @@ urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
     path('api/session/', SessionView.as_view(), name='session'),
     path('api/users/', QueryUsersView.as_view(), name='query-users'),
-    path('api/user-agent/', UserAgentView.as_view(), name='user-agent')
+    path('api/user-agent/', UserAgentView.as_view(), name='user-agent'),
     path('api/user/', CurrentUserView.as_view(), name='user'),
 ]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('about/', views.about, name='about'),
     path('api/app-settings/', views.get_app_settings, name='app-settings'),
+    path('api/core-user-agent/', views.get_user_agent, name='user-agent'),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -37,7 +37,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **event**                                    | 🔲 | 🔲 |
 | **flagMessage**                              | 🔲 | 🔲 |
 | **getAppSettings**                           | ✅ | ✅ |
-| **getClient**                                | 🔲 | 🔲 |
+| **getClient**                                | ✅ | 🔲 |
 | **getConfig**                                | ✅ | ✅ |
 | **getReplies**                               | ✅ | ✅ |
 | **getUserAgent**                             | ✅ | ✅ |

--- a/frontend/__tests__/adapter/getClient.test.ts
+++ b/frontend/__tests__/adapter/getClient.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+// getClient should return the ChatClient instance itself
+
+test('getClient returns the client instance', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  expect(client.getClient()).toBe(client);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -203,4 +203,9 @@ export class ChatClient {
     channel(_: 'messaging', roomUuid: string) {
         return new Channel(roomUuid, roomUuid, this);
     }
+
+    /** Return this client instance */
+    getClient() {
+        return this;
+    }
 }


### PR DESCRIPTION
## Summary
- implement `getClient` method on ChatClient
- add unit test for getClient
- fix syntax in accounts_supabase URLs and add core user-agent route
- update TODO checklist

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6850252b9a348326a54c0a9d825dcced