### PR TITLE
feat(adapter): add getClient method

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -37,7 +37,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **event**                                    | 🔲 | 🔲 |
 | **flagMessage**                              | 🔲 | 🔲 |
 | **getAppSettings**                           | ✅ | ✅ |
-| **getClient**                                | 🔲 | 🔲 |
+| **getClient**                                | ✅ | 🔲 |
 | **getConfig**                                | ✅ | ✅ |
 | **getReplies**                               | ✅ | ✅ |
 | **getUserAgent**                             | ✅ | ✅ |

--- a/frontend/__tests__/adapter/getClient.test.ts
+++ b/frontend/__tests__/adapter/getClient.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('getClient returns ChatClient instance', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  expect(channel.getClient()).toBe(client);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -249,6 +249,9 @@ export class Channel {
     get state() { return this._state; }
     /** Convenience getter exposing current message list */
     get messages() { return this._state.messages; }
+
+    /** Return the parent ChatClient instance */
+    getClient() { return this.client; }
     async getConfig() {
         const res = await fetch(`${API.ROOMS}${this.roomUuid}/config/`, {
             headers: { Authorization: `Bearer ${this.client['jwt']}` },


### PR DESCRIPTION
## Summary
- implement `getClient` on Channel
- add adapter tests
- update progress in docs

## Testing
- `pnpm exec turbo run build`
- `pnpm exec turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_68502307f5148326810adcf7871939bb