### PR TITLE
Fix endpoint drift and draft storage

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,4 @@ typing_extensions==4.5.0
 zope.interface==6.0
 djangorestframework==3.14.0
 PyJWT==2.8.0
+Pillow

--- a/frontend/__tests__/adapter/createDraft.test.ts
+++ b/frontend/__tests__/adapter/createDraft.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
 
 let setItemSpy: any;
 const originalFetch = global.fetch;
@@ -25,8 +26,8 @@ test('createDraft saves current text to localStorage and posts draft', () => {
   channel.messageComposer.textComposer.setText('draft message');
 
   channel.messageComposer.createDraft();
-  expect(setItemSpy).toHaveBeenCalledWith('draft:undefined', 'draft message');
-  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/draft/', {
+  expect(setItemSpy).toHaveBeenCalledWith('draft:room1', 'draft message');
+  expect(global.fetch).toHaveBeenCalledWith(`${API.ROOMS}room1/draft/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -38,11 +38,11 @@ export class Channel {
         /* ──────────────── messageComposer shim ──────────────── */
         messageComposer: (() => {
             const channelRef = this;                         // capture parent
-            const roomKey = `draft:${channelRef.cid}`;
+            const getRoomKey = () => `draft:${channelRef.roomUuid}`;
 
             /* load any previously‑saved draft */
             const loadDraft = () => {
-                try { return localStorage.getItem(roomKey) ?? ''; }
+                try { return localStorage.getItem(getRoomKey()) ?? ''; }
                 catch { return ''; }
             };
 
@@ -137,7 +137,7 @@ export class Channel {
 
                         /* clear draft + saved localStorage copy */
                         this.clear();
-                        localStorage.removeItem(roomKey);
+                        localStorage.removeItem(getRoomKey());
                     },
                 },  /* ← end of textComposer */
 
@@ -188,7 +188,7 @@ export class Channel {
                 registerSubscriptions() { return () => { }; },
                 createDraft() {
                     const text = textStore.getSnapshot().text;
-                    localStorage.setItem(roomKey, text);
+                    localStorage.setItem(getRoomKey(), text);
                     const token = channelRef.client['jwt'];
                     if (token) {
                         fetch(`/api/rooms/${channelRef.roomUuid}/draft/`, {
@@ -201,7 +201,7 @@ export class Channel {
                         }).catch(() => { /* ignore network errors */ });
                     }
                 },
-                discardDraft() { localStorage.removeItem(roomKey); },
+                discardDraft() { localStorage.removeItem(getRoomKey()); },
 
                 // pollComposer: {
                 // state: new MiniStore({            // shape is all Stream-UI needs

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -8,7 +8,7 @@ export const API = {
   MARK_UNREAD: '/api/rooms/',
   USERS: '/api/users/',
   USER: '/api/user/',
-  USER_AGENT: '/api/user-agent/',
+  USER_AGENT: '/api/core-user-agent/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- sync user agent constant with new core route
- store drafts per-room instead of `draft:undefined`
- use API constant in draft test
- pin Pillow for Django tests

## Testing
- `pnpm test` in `frontend`
- `python manage.py test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68502fcbe5fc8326917dc7f62b3720fe