### PR TITLE
feat(adapter): add compositionIsEmpty test

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -13,7 +13,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **clear**                                    | 🔲 | 🔲 |
 | **clientID**                                 | ✅ | 🔲 |
 | **compose**                                  | 🔲 | 🔲 |
-| **compositionIsEmpty**                       | 🔲 | 🔲 |
+| **compositionIsEmpty**                       | ✅ | 🔲 |
 | **config**                                   | 🔲 | 🔲 |
 | **configState**                              | 🔲 | 🔲 |
 | **connectUser**                              | ✅ | ✅ |

--- a/frontend/__tests__/adapter/compositionIsEmpty.test.ts
+++ b/frontend/__tests__/adapter/compositionIsEmpty.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+/** Ensure compositionIsEmpty reflects text composer state */
+test('compositionIsEmpty mirrors text composer', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  // initially empty
+  expect(channel.messageComposer.compositionIsEmpty).toBe(true);
+
+  // after setting text it becomes false
+  channel.messageComposer.textComposer.setText('hello');
+  expect(channel.messageComposer.compositionIsEmpty).toBe(false);
+
+  // clearing returns to true
+  channel.messageComposer.textComposer.clear();
+  expect(channel.messageComposer.compositionIsEmpty).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a unit test covering messageComposer.compositionIsEmpty
- mark the adapter surface completed in docs

## Testing
- `pnpm -r build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685033c34d108326a6fb5fea2dd2262e