### PR TITLE
Implement configState surface

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -15,7 +15,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **compose**                                  | 🔲 | 🔲 |
 | **compositionIsEmpty**                       | ✅ | 🔲 |
 | **config**                                   | 🔲 | 🔲 |
-| **configState**                              | 🔲 | 🔲 |
+| **configState**                              | ✅ | 🔲 |
 | **connectUser**                              | ✅ | ✅ |
 | **connectionId**                             | ✅ | 🔲 |
 | **contextType**                              | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/configState.test.ts
+++ b/frontend/__tests__/adapter/configState.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('configState exposes default composer config', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  const cfg = channel.messageComposer.configState.getSnapshot();
+
+  expect(cfg).toEqual({
+    attachments: { acceptedFiles: [], maxNumberOfFilesPerMessage: 10 },
+    text: { enabled: true },
+    multipleUploads: true,
+    isUploadEnabled: true,
+  });
+});


### PR DESCRIPTION
## Summary
- add tests to cover `configState` default config
- mark `configState` adapter row complete

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_685041429af083269071eae151d149cd