### PR TITLE
feat(adapter): implement compose method

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -12,7 +12,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **channel**                                  | ✅ | ✅ |
 | **clear**                                    | 🔲 | 🔲 |
 | **clientID**                                 | ✅ | 🔲 |
-| **compose**                                  | 🔲 | 🔲 |
+| **compose**                                  | ✅ | 🔲 |
 | **compositionIsEmpty**                       | ✅ | 🔲 |
 | **config**                                   | ✅ | 🔲 |
 | **configState**                              | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/compose.test.ts
+++ b/frontend/__tests__/adapter/compose.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+/** Ensure compose builds a message when text is present */
+test('compose returns local message payload', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  // empty text -> undefined
+  let result = await channel.messageComposer.compose();
+  expect(result).toBeUndefined();
+
+  // after setting text -> returns composition object
+  channel.messageComposer.textComposer.setText('hello');
+  result = await channel.messageComposer.compose();
+  expect(result).toBeDefined();
+  expect(result!.message.text).toBe('hello');
+  expect(result!.localMessage.id).toMatch(/^local-/);
+});

--- a/frontend/src/lib/stream-adapter/composer/index.ts
+++ b/frontend/src/lib/stream-adapter/composer/index.ts
@@ -25,7 +25,19 @@ export const buildMessageComposer = (channelRef:any) => {
     textComposer,
     /* simple proxies */
     get compositionIsEmpty(){ return textComposer.state.getSnapshot().text.trim()==='' },
-    async compose(){ /* keep previous compose() implementation here */ },
+    async compose(){
+      if(this.compositionIsEmpty) return undefined;
+
+      const text=textComposer.state.getSnapshot().text.trim();
+      const now=new Date().toISOString();
+      const localMessage={
+        id:`local-${Date.now()}`,
+        text,
+        user_id:channelRef.client.user.id!,
+        created_at:now,
+      };
+      return { localMessage, message: localMessage, sendOptions:{} };
+    },
     async sendMessage(_loc:any,msg:any){ await channelRef.sendMessage({ text: msg.text }); },
 
     submit(){ textComposer.clear(); /* will be wired in Channel.ts*/ },


### PR DESCRIPTION
## Summary
- implement `compose` method for message composer
- add unit test for `compose`
- update adapter TODO

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting REST_FRAMEWORK)*

------
https://chatgpt.com/codex/tasks/task_e_68506355eaf48326bac60f53fa821cac