### PR TITLE
Implement deleteReaction endpoint

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -180,6 +180,20 @@ class MessageReactionsView(APIView):
         return Response(ReactionSerializer(reaction).data, status=201)
 
 
+class ReactionDetailView(APIView):
+    """Delete a single reaction."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request, message_id, reaction_id):
+        reaction = get_object_or_404(
+            Reaction, id=reaction_id, message_id=message_id
+        )
+        reaction.delete()
+        return Response(status=204)
+
+
 class PollOptionCreateView(APIView):
     """Create a new poll option."""
 

--- a/backend/chat/tests/test_delete_reaction.py
+++ b/backend/chat/tests/test_delete_reaction.py
@@ -1,0 +1,44 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message, Reaction
+from accounts_supabase.models import CustomUser
+
+class DeleteReactionAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+
+    def test_delete_reaction_removes_reaction(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        room.messages.add(msg)
+        reaction = Reaction.objects.create(message=msg, user=self.user, type="like")
+        token = self.make_token()
+        url = reverse("reaction-detail", kwargs={"message_id": msg.id, "reaction_id": reaction.id})
+        res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 204)
+        self.assertFalse(Reaction.objects.filter(id=reaction.id).exists())
+
+    def test_delete_reaction_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        room.messages.add(msg)
+        reaction = Reaction.objects.create(message=msg, user=self.user, type="like")
+        url = reverse("reaction-detail", kwargs={"message_id": msg.id, "reaction_id": reaction.id})
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_delete_reaction_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        room.messages.add(msg)
+        reaction = Reaction.objects.create(message=msg, user=self.user, type="like")
+        token = self.make_token()
+        url = reverse("reaction-detail", kwargs={"message_id": msg.id, "reaction_id": reaction.id})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -19,6 +19,7 @@ from .api_views import (
     RoomDraftView,
     NotificationListView,
     PollOptionCreateView,
+    ReactionDetailView,
 )
 
 router = DefaultRouter()
@@ -93,6 +94,11 @@ urlpatterns = [
         "api/messages/<int:message_id>/reactions/",
         MessageReactionsView.as_view(),
         name="message-reactions",
+    ),
+    path(
+        "api/messages/<int:message_id>/reactions/<int:reaction_id>/",
+        ReactionDetailView.as_view(),
+        name="reaction-detail",
     ),
     path(
         "api/polls/<str:poll_id>/options/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -26,7 +26,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **customDataManager**                        | ✅ | ✅ |
 | **data**                                     | 🔲 | 🔲 |
 | **deleteMessage**                            | ✅ | ✅ |
-| **deleteReaction**                           | 🔲 | 🔲 |
+| **deleteReaction**                           | ✅ | ✅ |
 | **deleted**                                  | 🔲 | 🔲 |
 | **disconnectUser**                           | ✅ | ✅ |
 | **disconnected**                             | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/deleteReaction.test.ts
+++ b/frontend/__tests__/adapter/deleteReaction.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('deleteReaction sends DELETE to API', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.deleteReaction('m1', 'r1');
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MESSAGES}m1/reactions/r1/`, {
+    method: 'DELETE',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});
+

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -446,6 +446,15 @@ export class Channel {
         return await res.json();
     }
 
+    /** Delete a reaction */
+    async deleteReaction(messageId: string, reactionId: string) {
+        const res = await fetch(`${API.MESSAGES}${messageId}/reactions/${reactionId}/`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('deleteReaction failed');
+    }
+
     /** Fetch replies to a given message */
     async getReplies(messageId: string) {
         const res = await fetch(`${API.MESSAGES}${messageId}/replies/`, {


### PR DESCRIPTION
## Summary
- implement deleteReaction in adapter
- wire up backend delete reaction view and route
- test deleteReaction on frontend and backend
- update adapter progress

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_685063781f2c832683ab303134ac1947