### PR TITLE
feat(adapter): add disconnected flag

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -29,7 +29,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **deleteReaction**                           | 🔲 | 🔲 |
 | **deleted**                                  | 🔲 | 🔲 |
 | **disconnectUser**                           | ✅ | ✅ |
-| **disconnected**                             | 🔲 | 🔲 |
+| **disconnected**                             | ✅ | 🔲 |
 | **dispatchEvent**                            | 🔲 | 🔲 |
 | **draft**                                    | 🔲 | 🔲 |
 | **editedMessage**                            | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/disconnected.test.ts
+++ b/frontend/__tests__/adapter/disconnected.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('disconnected flag toggles on connect and disconnect', async () => {
+  const client = new ChatClient(null, null);
+  expect(client.disconnected).toBe(true);
+
+  await client.connectUser({ id: 'u1' }, 'jwt1');
+  expect(client.disconnected).toBe(false);
+
+  client.disconnectUser();
+  expect(client.disconnected).toBe(true);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -24,6 +24,8 @@ export class ChatClient {
     clientID: string;
     /** Unique ID for the current connection (null until connected) */
     connectionId: string | null = null;
+    /** Whether the client is currently disconnected */
+    disconnected = true;
 
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
@@ -158,6 +160,7 @@ export class ChatClient {
         const body = await res.json().catch(() => null);
         if (body) this._user = body;
         this.connectionId = crypto.randomUUID();
+        this.disconnected = false;
         this.emit('connection.changed', { online: true });
     }
 
@@ -178,6 +181,7 @@ export class ChatClient {
         this.userId = null;
         this.jwt = null;
         this.connectionId = null;
+        this.disconnected = true;
         this.emit('connection.changed', { online: false });
     }
 


### PR DESCRIPTION
## Summary
- implement `disconnected` flag on `ChatClient`
- test the `disconnected` flag
- document adapter surface coverage

## Testing
- `pnpm turbo run build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685063c475288326a998181e677cadc4