### PR TITLE
feat(adapter): implement editedMessage surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -137,9 +137,24 @@ class RoomDraftView(APIView):
 
 
 class MessageDetailView(APIView):
-    """Retrieve or delete a single message."""
+    """Retrieve, update or delete a single message."""
     authentication_classes = [SupabaseJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, message_id):
+        msg = get_object_or_404(Message, id=message_id)
+        serializer = MessageSerializer(msg)
+        return Response(serializer.data)
+
+    def put(self, request, message_id):
+        msg = get_object_or_404(Message, id=message_id)
+        data = request.data.copy()
+        if "text" in data and "body" not in data:
+            data["body"] = data.pop("text")
+        serializer = MessageSerializer(msg, data=data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
 
     def delete(self, request, message_id):
         msg = get_object_or_404(Message, id=message_id)

--- a/backend/chat/tests/test_edited_message.py
+++ b/backend/chat/tests/test_edited_message.py
@@ -1,0 +1,40 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Message
+
+class EditedMessageAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_get_message_returns_message(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        token = self.make_token()
+        url = reverse("message-detail", kwargs={"message_id": msg.id})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["body"], "hi")
+
+    def test_put_message_updates_body(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        token = self.make_token()
+        url = reverse("message-detail", kwargs={"message_id": msg.id})
+        res = self.client.put(url, {"text": "edited"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        msg.refresh_from_db()
+        self.assertEqual(msg.body, "edited")
+
+    def test_put_message_requires_auth(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        url = reverse("message-detail", kwargs={"message_id": msg.id})
+        res = self.client.put(url, {"text": "edited"}, format="json")
+        self.assertEqual(res.status_code, 403)
+
+    def test_put_message_wrong_method(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        token = self.make_token()
+        url = reverse("message-detail", kwargs={"message_id": msg.id})
+        res = self.client.post(url, {}, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -32,7 +32,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **disconnected**                             | 🔲 | 🔲 |
 | **dispatchEvent**                            | 🔲 | 🔲 |
 | **draft**                                    | 🔲 | 🔲 |
-| **editedMessage**                            | 🔲 | 🔲 |
+| **editedMessage**                            | ✅ | ✅ |
 | **editingAuditState**                        | 🔲 | 🔲 |
 | **event**                                    | 🔲 | 🔲 |
 | **flagMessage**                              | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/editedMessage.test.ts
+++ b/frontend/__tests__/adapter/editedMessage.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const sampleMessage = {
+  id: 'm1',
+  text: 'hello',
+  user_id: 'u2',
+  created_at: '2025-01-01T00:00:00Z',
+};
+
+test('setEditedMessage updates composer state', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  channel.messageComposer.setEditedMessage(sampleMessage as any);
+  expect(channel.messageComposer.editedMessage).toEqual(sampleMessage);
+  expect(channel.messageComposer.textComposer.state.getSnapshot().text).toBe('hello');
+
+  channel.messageComposer.setEditedMessage(undefined);
+  expect(channel.messageComposer.editedMessage).toBeUndefined();
+  expect(channel.messageComposer.textComposer.state.getSnapshot().text).toBe('');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -241,6 +241,16 @@ export class Channel {
                 setQuotedMessage(msg: Message | undefined) {
                     this.state._set({ quotedMessage: msg });
                 },
+
+                /** Currently edited message, if any */
+                editedMessage: undefined as Message | undefined,
+
+                /** Set the message being edited and sync text composer */
+                setEditedMessage(msg: Message | undefined) {
+                    (this as any).editedMessage = msg;
+                    const text = msg ? msg.text : '';
+                    textStore._set({ text });
+                },
             };
         })(),   // end of IIFE
     };         // ←———————— END of _state object


### PR DESCRIPTION
## Summary
- support getting and updating a single message in Django API
- add `editedMessage` handling in stream adapter's message composer
- cover new behaviour with unit tests
- mark `editedMessage` as complete in TODO

## Testing
- `pnpm turbo build`
- `pnpm turbo run test`

------
https://chatgpt.com/codex/tasks/task_e_6850641768448326985df5060391cc17