### PR TITLE
feat(adapter): implement hasSendableData

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -43,7 +43,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **getConfig**                                | ✅ | ✅ |
 | **getReplies**                               | ✅ | ✅ |
 | **getUserAgent**                             | ✅ | ✅ |
-| **hasSendableData**                          | 🔲 | 🔲 |
+| **hasSendableData**                          | ✅ | 🔲 |
 | **hidden**                                   | 🔲 | 🔲 |
 | **id**                                       | 🔲 | 🔲 |
 | **initState**                                | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/hasSendableData.test.ts
+++ b/frontend/__tests__/adapter/hasSendableData.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+/** Ensure hasSendableData reflects composer state */
+test('hasSendableData returns true when text or other data present', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  const comp: any = channel.messageComposer;
+
+  // initially empty
+  expect(comp.hasSendableData).toBe(false);
+
+  // text makes it true
+  comp.textComposer.setText('hi');
+  expect(comp.hasSendableData).toBe(true);
+  comp.textComposer.clear();
+  expect(comp.hasSendableData).toBe(false);
+
+  // attachments make it true
+  comp.attachmentManager.state._set({ attachments: [{ id: 'a1' }] });
+  expect(comp.hasSendableData).toBe(true);
+  comp.attachmentManager.state._set({ attachments: [] });
+  expect(comp.hasSendableData).toBe(false);
+
+  // custom data makes it true
+  comp.customDataManager.set('foo', 1);
+  expect(comp.hasSendableData).toBe(true);
+  comp.customDataManager.clear();
+  expect(comp.hasSendableData).toBe(false);
+
+  // poll data makes it true
+  comp.pollComposer.state._set({ poll: { question: 'q1' } });
+  expect(comp.hasSendableData).toBe(true);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -179,6 +179,20 @@ export class Channel {
                     return this.textComposer.state.getSnapshot().text.trim() === '';
                 },
 
+                /* 2️⃣  Check if any payload (text, attachment, poll, custom) is present */
+                get hasSendableData() {
+                    const text = this.textComposer.state.getSnapshot().text.trim();
+                    const atts = this.attachmentManager.state.getSnapshot().attachments;
+                    const poll = this.pollComposer.state.getSnapshot().poll;
+                    const custom = this.customDataManager.state.getSnapshot().customData;
+                    return (
+                        text !== '' ||
+                        atts.length > 0 ||
+                        !!poll ||
+                        Object.keys(custom).length > 0
+                    );
+                },
+
                 /* 2️⃣  Build the composition object that <MessageInput> expects */
                 async compose() {
                     if (this.compositionIsEmpty) return undefined;


### PR DESCRIPTION
## Summary
- implement `hasSendableData` getter in the adapter messageComposer
- add unit tests
- update TODO list

## Testing
- `pnpm turbo build`
- `pnpm turbo test`


------
https://chatgpt.com/codex/tasks/task_e_6850714c2bb48326b6d5f62b31de99d0