### PR TITLE
feat(adapter): track client initialization

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -47,7 +47,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **hidden**                                   | 🔲 | 🔲 |
 | **id**                                       | 🔲 | 🔲 |
 | **initState**                                | 🔲 | 🔲 |
-| **initialized**                              | 🔲 | 🔲 |
+| **initialized**                              | ✅ | 🔲 |
 | **intro**                                    | 🔲 | 🔲 |
 | **lastRead**                                 | ✅ | ✅ |
 | **linkPreviewsManager**                      | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/initialized.test.ts
+++ b/frontend/__tests__/adapter/initialized.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('initialized flag toggles on connect and disconnect', async () => {
+  const client = new ChatClient(null, null);
+  expect(client.initialized).toBe(false);
+
+  await client.connectUser({ id: 'u1' }, 'jwt1');
+  expect(client.initialized).toBe(true);
+
+  client.disconnectUser();
+  expect(client.initialized).toBe(false);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -26,6 +26,8 @@ export class ChatClient {
     connectionId: string | null = null;
     /** Whether the client is currently disconnected */
     disconnected = true;
+    /** Whether the client finished initialization */
+    initialized = false;
 
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
@@ -174,6 +176,7 @@ export class ChatClient {
         const body = await res.json().catch(() => null);
         if (body) this._user = body;
         this.connectionId = crypto.randomUUID();
+        this.initialized = true;
         this.disconnected = false;
         this.emit('connection.changed', { online: true });
     }
@@ -195,6 +198,7 @@ export class ChatClient {
         this.userId = null;
         this.jwt = null;
         this.connectionId = null;
+        this.initialized = false;
         this.disconnected = true;
         this.emit('connection.changed', { online: false });
     }


### PR DESCRIPTION
## Summary
- add `initialized` flag to `ChatClient`
- toggle flag on connect/disconnect
- document adapter support in TODO
- test initialization lifecycle

## Testing
- `pnpm -r build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68507190016483268d5b941b74b05e55