### PR TITLE
feat(adapter): add intro message helpers

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -48,7 +48,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **id**                                       | 🔲 | 🔲 |
 | **initState**                                | 🔲 | 🔲 |
 | **initialized**                              | 🔲 | 🔲 |
-| **intro**                                    | 🔲 | 🔲 |
+| **intro**                                    | ✅ | 🔲 |
 | **lastRead**                                 | ✅ | ✅ |
 | **linkPreviewsManager**                      | 🔲 | 🔲 |
 | **listeners**                                | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/intro.test.ts
+++ b/frontend/__tests__/adapter/intro.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { makeIntroMessage, isIntroMessage, CUSTOM_MESSAGE_TYPE } from '../../src/lib/stream-adapter';
+
+test('makeIntroMessage returns intro message', () => {
+  const msg = makeIntroMessage();
+  expect(msg.customType).toBe(CUSTOM_MESSAGE_TYPE.intro);
+  expect(typeof msg.id).toBe('string');
+});
+
+test('isIntroMessage detects intro messages', () => {
+  const msg = makeIntroMessage();
+  expect(isIntroMessage(msg)).toBe(true);
+  expect(isIntroMessage({})).toBe(false);
+});
+

--- a/frontend/src/lib/stream-adapter/index.ts
+++ b/frontend/src/lib/stream-adapter/index.ts
@@ -2,3 +2,4 @@
 export * from './types';          // re-export Room / Message / Events
 export { ChatClient } from './ChatClient';
 export { API, EVENTS } from './constants';
+export { CUSTOM_MESSAGE_TYPE, makeIntroMessage, isIntroMessage } from './intro';

--- a/frontend/src/lib/stream-adapter/intro.ts
+++ b/frontend/src/lib/stream-adapter/intro.ts
@@ -1,0 +1,18 @@
+export const CUSTOM_MESSAGE_TYPE = {
+  date: 'message.date',
+  intro: 'channel.intro',
+} as const;
+
+type IntroMessage = {
+  customType: typeof CUSTOM_MESSAGE_TYPE.intro;
+  id: string;
+};
+
+export const makeIntroMessage = (): IntroMessage => ({
+  customType: CUSTOM_MESSAGE_TYPE.intro,
+  id: Math.random().toString(36).slice(2),
+});
+
+export const isIntroMessage = (msg: unknown): msg is IntroMessage =>
+  typeof msg === 'object' && msg !== null && (msg as any).customType === CUSTOM_MESSAGE_TYPE.intro;
+


### PR DESCRIPTION
## Summary
- implement intro message utilities (makeIntroMessage, isIntroMessage)
- export intro helpers from adapter index
- add adapter tests for intro
- update TODO

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`

------
https://chatgpt.com/codex/tasks/task_e_685071a04c70832697c086d36753faf7