### PR TITLE
feat(adapter): implement listeners tracking

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -51,7 +51,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **intro**                                    | 🔲 | 🔲 |
 | **lastRead**                                 | ✅ | ✅ |
 | **linkPreviewsManager**                      | 🔲 | 🔲 |
-| **listeners**                                | 🔲 | 🔲 |
+| **listeners**                                | ✅ | 🔲 |
 | **markRead**                                 | ✅ | ✅ |
 | **markUnread**                               | ✅ | ✅ |
 | **members**                                  | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/listeners.test.ts
+++ b/frontend/__tests__/adapter/listeners.test.ts
@@ -1,0 +1,18 @@
+import { expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { EVENTS } from '../../src/lib/stream-adapter/constants';
+
+test('on stores listener in listeners map', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const spy = vi.fn();
+  client.on(EVENTS.MESSAGE_NEW, spy);
+  expect(client.listeners[EVENTS.MESSAGE_NEW]).toContain(spy);
+});
+
+test('off removes listener from listeners map', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const spy = vi.fn();
+  client.on(EVENTS.MESSAGE_NEW, spy);
+  client.off(EVENTS.MESSAGE_NEW, spy);
+  expect(client.listeners[EVENTS.MESSAGE_NEW] || []).not.toContain(spy);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -103,8 +103,19 @@ export class ChatClient {
     }
 
     /* ---------- event-bus helpers ---------- */
-    on = this.bus.on as any;
-    off = this.bus.off as any;
+    on = (event: string, cb: (...args: any[]) => void) => {
+        if (!this.listeners[event]) this.listeners[event] = [];
+        this.listeners[event].push(cb);
+        this.bus.on(event as any, cb);
+    };
+    off = (event: string, cb: (...args: any[]) => void) => {
+        this.bus.off(event as any, cb);
+        const arr = this.listeners[event];
+        if (arr) {
+            this.listeners[event] = arr.filter(fn => fn !== cb);
+            if (this.listeners[event].length === 0) delete this.listeners[event];
+        }
+    };
     emit = this.bus.emit.bind(this);
 
     /**


### PR DESCRIPTION
## Summary
- track event listeners on `ChatClient`
- add tests for storing/removing listeners
- update adapter todo

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_685071e68218832688709487e9a620ec