### PR TITLE
feat(adapter): implement members feature

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -308,6 +308,22 @@ class RoomCooldownView(APIView):
         return Response({"cooldown": 0})
 
 
+class RoomMembersView(APIView):
+    """Return list of members for the given room."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        names = set(room.messages.values_list("sent_by", flat=True))
+        if room.client:
+            names.add(room.client)
+        if room.agent:
+            names.add(room.agent.username)
+        return Response([{"id": name} for name in sorted(names)])
+
+
 class ActiveRoomListView(generics.ListAPIView):
     """Return all rooms currently marked as ACTIVE."""
     authentication_classes = [SupabaseJWTAuthentication]

--- a/backend/chat/tests/test_members.py
+++ b/backend/chat/tests/test_members.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message
+from accounts_supabase.models import CustomUser
+
+class RoomMembersAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_members_returns_unique_user_ids(self):
+        u1 = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        u2 = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
+        room = Room.objects.create(uuid="r1", client="u1", agent=u2)
+        room.messages.add(Message.objects.create(body="hi", sent_by="u1"))
+        room.messages.add(Message.objects.create(body="yo", sent_by="u2"))
+
+        token = self.make_token()
+        url = reverse("room-members", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        ids = {m["id"] for m in res.data}
+        self.assertEqual(ids, {"u1", "u2"})
+
+    def test_members_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-members", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_members_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-members", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -16,6 +16,7 @@ from .api_views import (
     RoomArchiveView,
     RoomUnarchiveView,
     RoomCooldownView,
+    RoomMembersView,
     ActiveRoomListView,
     RoomDraftView,
     NotificationListView,
@@ -69,6 +70,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/cooldown/",
         RoomCooldownView.as_view(),
         name="room-cooldown",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/members/",
+        RoomMembersView.as_view(),
+        name="room-members",
     ),
     path(
         "api/rooms/<str:room_uuid>/archive/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -54,7 +54,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **listeners**                                | 🔲 | 🔲 |
 | **markRead**                                 | ✅ | ✅ |
 | **markUnread**                               | ✅ | ✅ |
-| **members**                                  | 🔲 | 🔲 |
+| **members**                                  | ✅ | ✅ |
 | **messageComposer**                          | 🔲 | 🔲 |
 | **messages**                                 | ✅ | ✅ |
 | **muteStatus**                               | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/members.test.ts
+++ b/frontend/__tests__/adapter/members.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+const originalWS = (global as any).WebSocket;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  (global as any).WebSocket = vi.fn(() => ({ onmessage: null }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  (global as any).WebSocket = originalWS;
+  vi.restoreAllMocks();
+});
+
+test('members are fetched on watch', async () => {
+  (global.fetch as any)
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 'u1' }, { id: 'u2' }] });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  await channel.watch();
+
+  expect(global.fetch).toHaveBeenNthCalledWith(1, `${API.ROOMS}room1/messages/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(global.fetch).toHaveBeenNthCalledWith(2, `${API.ROOMS}room1/members/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channel.members).toEqual({
+    u1: { user: { id: 'u1' } },
+    u2: { user: { id: 'u2' } },
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -32,6 +32,7 @@ export class Channel {
                 user?: { id: string };
             }
         >,
+        members: {} as Record<string, { user: { id: string } }>,
 
         /* stub so <MessageInput> works */
         /* stub so <MessageInput> works */
@@ -306,6 +307,8 @@ export class Channel {
     get state() { return this._state; }
     /** Convenience getter exposing current message list */
     get messages() { return this._state.messages; }
+    /** Return current members map */
+    get members() { return this._state.members; }
 
     /** Return the parent ChatClient instance */
     getClient() { return this.client; }
@@ -352,6 +355,16 @@ export class Channel {
                         }
                     },
                 });
+            }
+
+            const memRes = await fetch(`${API.ROOMS}${this.roomUuid}/members/`, {
+                headers: { Authorization: `Bearer ${this.client['jwt']}` },
+            });
+            if (memRes.ok) {
+                const list = await memRes.json() as { id: string }[];
+                const map: Record<string, { user: { id: string } }> = {};
+                for (const m of list) map[m.id] = { user: { id: m.id } };
+                this.bump({ members: map });
             }
 
         } catch {/* fine for MVP */ }


### PR DESCRIPTION
## Summary
- add members endpoint on backend and tests
- fetch channel members on watch in adapter
- expose `members` getter
- document completed surface

## Testing
- `pnpm turbo build`
- `pnpm turbo run test`
- `python manage.py test` *(fails: conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_685071f854fc832691ec08ddcdc25a90