### PR TITLE
feat(adapter): implement members surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -308,6 +308,21 @@ class RoomCooldownView(APIView):
         return Response({"cooldown": 0})
 
 
+class RoomMembersView(APIView):
+    """Return members (client and agent) for the given room."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        members = []
+        if room.client:
+            members.append({"id": room.client, "username": room.client})
+        if room.agent:
+            members.append({"id": room.agent.id, "username": room.agent.username})
+        return Response(members)
+
+
 class ActiveRoomListView(generics.ListAPIView):
     """Return all rooms currently marked as ACTIVE."""
     authentication_classes = [SupabaseJWTAuthentication]

--- a/backend/chat/tests/test_room_members.py
+++ b/backend/chat/tests/test_room_members.py
@@ -1,0 +1,43 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+from django.contrib.auth import get_user_model
+
+from chat.models import Room
+
+class RoomMembersAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_room_members_lists_client_and_agent(self):
+        User = get_user_model()
+        agent = User.objects.create_user(username="agent", email="a@example.com", password="x", supabase_uid="a")
+        room = Room.objects.create(uuid="r1", client="c1", agent=agent)
+        token = self.make_token()
+        url = reverse("room-members", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, [
+            {"id": "c1", "username": "c1"},
+            {"id": agent.id, "username": "agent"},
+        ])
+
+    def test_room_members_requires_auth(self):
+        User = get_user_model()
+        agent = User.objects.create_user(username="agent", email="a@example.com", password="x", supabase_uid="a")
+        room = Room.objects.create(uuid="r1", client="c1", agent=agent)
+        url = reverse("room-members", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_room_members_wrong_method(self):
+        User = get_user_model()
+        agent = User.objects.create_user(username="agent", email="a@example.com", password="x", supabase_uid="a")
+        room = Room.objects.create(uuid="r1", client="c1", agent=agent)
+        token = self.make_token()
+        url = reverse("room-members", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)
+
+

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -16,6 +16,7 @@ from .api_views import (
     RoomArchiveView,
     RoomUnarchiveView,
     RoomCooldownView,
+    RoomMembersView,
     ActiveRoomListView,
     RoomDraftView,
     NotificationListView,
@@ -69,6 +70,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/cooldown/",
         RoomCooldownView.as_view(),
         name="room-cooldown",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/members/",
+        RoomMembersView.as_view(),
+        name="room-members",
     ),
     path(
         "api/rooms/<str:room_uuid>/archive/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -54,7 +54,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **listeners**                                | 🔲 | 🔲 |
 | **markRead**                                 | ✅ | ✅ |
 | **markUnread**                               | ✅ | ✅ |
-| **members**                                  | 🔲 | 🔲 |
+| **members**                                  | ✅ | ✅ |
 | **messageComposer**                          | 🔲 | 🔲 |
 | **messages**                                 | ✅ | ✅ |
 | **muteStatus**                               | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/members.test.ts
+++ b/frontend/__tests__/adapter/members.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('fetchMembers fetches and stores channel members', async () => {
+  const members = [
+    { id: 1, username: 'u1' },
+    { id: 2, username: 'u2' },
+  ];
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => members });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  const res = await (channel as any).fetchMembers();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/members/', {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(res).toEqual(members);
+  expect(channel.members).toEqual(members);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -22,6 +22,7 @@ export class Channel {
         latestMessages: [] as Message[],
         messagePagination: { hasPrev: false, hasNext: false },
         pinnedMessages: [] as Message[],
+        members: [] as { id: number | string; username: string }[],
 
         read: {} as Record<
             string,
@@ -306,6 +307,8 @@ export class Channel {
     get state() { return this._state; }
     /** Convenience getter exposing current message list */
     get messages() { return this._state.messages; }
+    /** List of members fetched from the backend */
+    get members() { return this._state.members; }
 
     /** Return the parent ChatClient instance */
     getClient() { return this.client; }
@@ -539,6 +542,17 @@ export class Channel {
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
         if (!res.ok) throw new Error('unarchive failed');
+    }
+
+    /** Fetch members for this channel */
+    async fetchMembers() {
+        const res = await fetch(`/api/rooms/${this.roomUuid}/members/`, {
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('members failed');
+        const list = await res.json() as { id: number | string; username: string }[];
+        this.bump({ members: list });
+        return list;
     }
 
     /** Fetch cooldown value for this channel */


### PR DESCRIPTION
## Summary
- add `members` fetching to Channel and expose new state
- implement backend endpoint to list room members
- test members fetch on front-end and API
- update adapter TODO

## Testing
- `pnpm turbo build`
- `pnpm turbo test`


------
https://chatgpt.com/codex/tasks/task_e_6850720d32608326b2638390b3ab9d38