### PR TITLE
feat(adapter): implement muteUser

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -359,6 +359,18 @@ class MuteStatusView(APIView):
         muted = UserMute.objects.filter(user=request.user, target=target).exists()
         return Response({"muted": muted})
 
+
+class MuteUserView(APIView):
+    """Mute the given user for the current user."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, target_username):
+        target = get_object_or_404(get_user_model(), username=target_username)
+        UserMute.objects.get_or_create(user=request.user, target=target)
+        return Response({"status": "ok"})
+
       
 class LinkPreviewView(APIView):
     """Return basic metadata for a URL."""

--- a/backend/chat/tests/test_mute_user.py
+++ b/backend/chat/tests/test_mute_user.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from accounts_supabase.models import CustomUser
+from chat.models import UserMute
+
+class MuteUserAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user1 = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.user2 = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
+
+    def test_mute_user_creates_record(self):
+        token = self.make_token()
+        url = reverse("user-mute", kwargs={"target_username": "u2"})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(UserMute.objects.filter(user=self.user1, target=self.user2).exists())
+        self.assertEqual(res.data["status"], "ok")
+
+    def test_mute_user_requires_auth(self):
+        url = reverse("user-mute", kwargs={"target_username": "u2"})
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_mute_user_wrong_method(self):
+        token = self.make_token()
+        url = reverse("user-mute", kwargs={"target_username": "u2"})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -26,6 +26,7 @@ from .api_views import (
     RoomShowView,
     ReactionDetailView,
     MuteStatusView,
+    MuteUserView,
 )
 
 router = DefaultRouter()
@@ -136,5 +137,10 @@ urlpatterns = [
         "api/mute-status/<str:target_username>/",
         MuteStatusView.as_view(),
         name="mute-status",
+    ),
+    path(
+        "api/mute/<str:target_username>/",
+        MuteUserView.as_view(),
+        name="user-mute",
     ),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -58,7 +58,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **messageComposer**                          | ✅ | ✅ |
 | **messages**                                 | ✅ | ✅ |
 | **muteStatus**                               | ✅ | ✅ |
-| **muteUser**                                 | 🔲 | 🔲 |
+| **muteUser**                                 | ✅ | ✅ |
 | **mutedChannels**                            | 🔲 | 🔲 |
 | **mutedUsers**                               | 🔲 | 🔲 |
 | **name**                                     | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/muteUser.test.ts
+++ b/frontend/__tests__/adapter/muteUser.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('muteUser posts to backend endpoint', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  await client.muteUser('u2');
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MUTE_USER}u2/`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -349,12 +349,13 @@ export class Channel {
 
     constructor(
         id: number,
-        private uuid: string,
+        uuid: string,
         roomName: string,
         private client: ChatClient,
         extraData: Record<string, unknown> = {},
     ) {
         this.id = id;
+        this.uuid = uuid;
         this.cid = `messaging:${this.uuid}`;
         this.data = { name: roomName, ...extraData };
     }
@@ -416,7 +417,7 @@ export class Channel {
                 });
             }
 
-            const memRes = await fetch(`${API.ROOMS}${this.roomUuid}/members/`, {
+            const memRes = await fetch(`${API.ROOMS}${this.uuid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {
@@ -615,7 +616,7 @@ export class Channel {
 
     /** Hide this channel */
     async hide() {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/hide/`, {
+        const res = await fetch(`/api/rooms/${this.uuid}/hide/`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
@@ -625,7 +626,7 @@ export class Channel {
 
     /** Show this channel */
     async show() {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/show/`, {
+        const res = await fetch(`/api/rooms/${this.uuid}/show/`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -292,6 +292,15 @@ export class ChatClient {
         return data.muted;
     }
 
+    /** Mute a user */
+    async muteUser(userId: string) {
+        const res = await fetch(`${API.MUTE_USER}${userId}/`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${this.jwt}` },
+        });
+        if (!res.ok) throw new Error('muteUser failed');
+    }
+
     /** Create a poll option */
     async createPollOption(pollId: string, option: { text: string }) {
         const res = await fetch(`${API.POLLS}${pollId}/options/`, {

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -14,6 +14,8 @@ export const API = {
   LINK_PREVIEW: '/api/link-preview/',
   COOLDOWN: '/api/rooms/',
   MUTE_STATUS: '/api/mute-status/',
+  MUTE_USER: '/api/mute/',
+  UNMUTE_USER: '/api/unmute/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- add adapter and backend support for muteUser
- create tests for muteUser on both frontend and backend
- expose mute endpoints in adapter constants
- document completed surface

## Testing
- `pnpm turbo build`
- `pnpm --filter frontend test`
- `python backend/manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68509a7c35c483269115dccc5a5d97af