### PR TITLE
feat(adapter): implement mutedChannels

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -9,7 +9,7 @@ from accounts.authentication import SupabaseJWTAuthentication
 from django.utils import timezone
 
 from urllib.parse import urlparse
-from .models import Room, Message, ReadState, Draft, Notification, Reaction, PollOption, Flag, UserMute
+from .models import Room, Message, ReadState, Draft, Notification, Reaction, PollOption, Flag, UserMute, RoomMute
 
 from .serializers import (
     RoomSerializer,
@@ -346,6 +346,19 @@ class NotificationListView(APIView):
     def get(self, request):
         notes = Notification.objects.filter(user=request.user)
         serializer = NotificationSerializer(notes, many=True)
+        return Response(serializer.data)
+
+
+class MutedChannelListView(APIView):
+    """Return channels muted by the current user."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        mutes = RoomMute.objects.filter(user=request.user)
+        rooms = [m.room for m in mutes]
+        serializer = RoomSerializer(rooms, many=True)
         return Response(serializer.data)
 
 

--- a/backend/chat/migrations/0010_room_mute.py
+++ b/backend/chat/migrations/0010_room_mute.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('chat', '0009_merge_20250616_1945'),
+        ('chat', '0009_merge_20250616_1951'),
+        ('chat', '0009_merge_20250616_1956'),
+        ('chat', '0009_user_mute'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RoomMute',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('room', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='chat.room')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'unique_together': {('user', 'room')},
+            },
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -129,3 +129,14 @@ class UserMute(models.Model):
 
     class Meta:
         unique_together = ("user", "target")
+
+
+class RoomMute(models.Model):
+    """Record that `user` muted `room`."""
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    room = models.ForeignKey(Room, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("user", "room")

--- a/backend/chat/tests/test_muted_channels.py
+++ b/backend/chat/tests/test_muted_channels.py
@@ -1,0 +1,37 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, RoomMute
+from accounts_supabase.models import CustomUser
+
+class MutedChannelsAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user1 = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.user2 = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
+        self.room1 = Room.objects.create(uuid="r1", client="c1")
+        self.room2 = Room.objects.create(uuid="r2", client="c2")
+        RoomMute.objects.create(user=self.user1, room=self.room1)
+
+    def test_list_muted_channels(self):
+        token = self.make_token()
+        url = reverse("muted-channels")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["uuid"], "r1")
+
+    def test_muted_channels_requires_auth(self):
+        url = reverse("muted-channels")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_muted_channels_wrong_method(self):
+        token = self.make_token()
+        url = reverse("muted-channels")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -20,6 +20,7 @@ from .api_views import (
     ActiveRoomListView,
     RoomDraftView,
     NotificationListView,
+    MutedChannelListView,
     LinkPreviewView,
     PollOptionCreateView,
     RoomHideView,
@@ -111,6 +112,7 @@ urlpatterns = [
         name="message-replies",
     ),
     path("api/notifications/", NotificationListView.as_view(), name="notifications"),
+    path("api/muted-channels/", MutedChannelListView.as_view(), name="muted-channels"),
     path(
         "api/messages/<int:message_id>/reactions/",
         MessageReactionsView.as_view(),

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -59,7 +59,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **messages**                                 | ✅ | ✅ |
 | **muteStatus**                               | ✅ | ✅ |
 | **muteUser**                                 | 🔲 | 🔲 |
-| **mutedChannels**                            | 🔲 | 🔲 |
+| **mutedChannels**                            | ✅ | ✅ |
 | **mutedUsers**                               | 🔲 | 🔲 |
 | **name**                                     | 🔲 | 🔲 |
 | **notifications**                            | ✅ | ✅ |

--- a/frontend/__tests__/adapter/getMutedChannels.test.ts
+++ b/frontend/__tests__/adapter/getMutedChannels.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getMutedChannels fetches muted rooms and updates client list', async () => {
+  const rooms = [{ id: 1, uuid: 'r1', name: 'Room 1' }];
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => rooms });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channels = await client.getMutedChannels();
+
+  expect(global.fetch).toHaveBeenCalledWith(API.MUTED_CHANNELS, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channels).toHaveLength(1);
+  expect(client.mutedChannels).toHaveLength(1);
+  expect(channels[0].cid).toBe('messaging:r1');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -10,7 +10,7 @@ import { API, EVENTS } from './constants';
 
 export class Channel {
     readonly id: number;
-    readonly uuid: string;
+    readonly uuid!: string;
     readonly cid: string;
     data: { name: string } & Record<string, unknown>;
 
@@ -349,12 +349,13 @@ export class Channel {
 
     constructor(
         id: number,
-        private uuid: string,
+        uuid: string,
         roomName: string,
         private client: ChatClient,
         extraData: Record<string, unknown> = {},
     ) {
         this.id = id;
+        this.uuid = uuid;
         this.cid = `messaging:${this.uuid}`;
         this.data = { name: roomName, ...extraData };
     }
@@ -416,7 +417,7 @@ export class Channel {
                 });
             }
 
-            const memRes = await fetch(`${API.ROOMS}${this.roomUuid}/members/`, {
+            const memRes = await fetch(`${API.ROOMS}${this.uuid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {
@@ -615,7 +616,7 @@ export class Channel {
 
     /** Hide this channel */
     async hide() {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/hide/`, {
+        const res = await fetch(`/api/rooms/${this.uuid}/hide/`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
@@ -625,7 +626,7 @@ export class Channel {
 
     /** Show this channel */
     async show() {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/show/`, {
+        const res = await fetch(`/api/rooms/${this.uuid}/show/`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -282,6 +282,19 @@ export class ChatClient {
         return rooms.map(r => new Channel(r.id, r.uuid, r.name ?? r.uuid, this, r.data || {}));
     }
 
+    /** list of muted channels for the current user */
+    async getMutedChannels() {
+        const res = await fetch(API.MUTED_CHANNELS, {
+            headers: this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {},
+        });
+        if (!res.ok) throw new Error('getMutedChannels failed');
+        const rooms = await res.json() as Room[];
+        this.mutedChannels = rooms.map(
+            r => new Channel(r.id, r.uuid, r.name ?? r.uuid, this, r.data || {})
+        );
+        return this.mutedChannels;
+    }
+
     /** Check if a given user is muted */
     async muteStatus(userId: string) {
         const res = await fetch(`${API.MUTE_STATUS}${userId}/`, {

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -14,6 +14,7 @@ export const API = {
   LINK_PREVIEW: '/api/link-preview/',
   COOLDOWN: '/api/rooms/',
   MUTE_STATUS: '/api/mute-status/',
+  MUTED_CHANNELS: '/api/muted-channels/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- implement `mutedChannels` surface in adapter and backend
- add `/api/muted-channels/` endpoint with tests
- expose `getMutedChannels` method in ChatClient
- update docs coverage table

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68509aa32dac8326a9d3dce707c3b9fd