### PR TITLE
Implement pinnedMessages adapter + backend API

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -341,6 +341,19 @@ class RoomMembersView(APIView):
         return Response([{"id": name} for name in sorted(names)])
 
 
+class RoomPinnedMessagesView(APIView):
+    """Return messages pinned in the given room."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        msgs = room.messages.filter(pins__isnull=False).distinct()
+        serializer = MessageSerializer(msgs, many=True)
+        return Response(serializer.data)
+
+
 class RoomQueryView(APIView):
     """Return initial messages and members for a room."""
 

--- a/backend/chat/tests/test_pinned_messages.py
+++ b/backend/chat/tests/test_pinned_messages.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message, Pin
+from accounts_supabase.models import CustomUser
+
+class PinnedMessagesAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.room = Room.objects.create(uuid="r1", client="c1")
+        self.msg1 = Message.objects.create(body="hi", sent_by="u1")
+        self.msg2 = Message.objects.create(body="bye", sent_by="u2")
+        self.room.messages.add(self.msg1, self.msg2)
+        Pin.objects.create(message=self.msg1, user=self.user)
+
+    def test_list_pinned_messages(self):
+        token = self.make_token()
+        url = reverse("room-pinned-messages", kwargs={"room_uuid": self.room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["id"], self.msg1.id)
+
+    def test_pinned_messages_requires_auth(self):
+        url = reverse("room-pinned-messages", kwargs={"room_uuid": self.room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_pinned_messages_wrong_method(self):
+        token = self.make_token()
+        url = reverse("room-pinned-messages", kwargs={"room_uuid": self.room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -18,6 +18,7 @@ from .api_views import (
     RoomUnarchiveView,
     RoomCooldownView,
     RoomMembersView,
+    RoomPinnedMessagesView,
     RoomQueryView,
     ActiveRoomListView,
     RoomDraftView,
@@ -84,6 +85,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/members/",
         RoomMembersView.as_view(),
         name="room-members",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/pinned/",
+        RoomPinnedMessagesView.as_view(),
+        name="room-pinned-messages",
     ),
     path(
         "api/rooms/<str:room_uuid>/query/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -67,7 +67,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **on**                                       | ✅ | 🔲 |
 | **pin**                                      | ✅ | ✅ |
 | **pinMessage**                               | ✅ | ✅ |
-| **pinnedMessages**                           | 🔲 | 🔲 |
+| **pinnedMessages**                           | ✅ | ✅ |
 | **pollComposer**                             | 🔲 | 🔲 |
 | **polls**                                    | 🔲 | 🔲 |
 | **query**                                    | ✅ | ✅ |

--- a/frontend/__tests__/adapter/pinnedMessages.test.ts
+++ b/frontend/__tests__/adapter/pinnedMessages.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('pinnedMessages fetches list and updates state', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => [{ id: 'p1' }] });
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  const list = await channel.pinnedMessages();
+
+  expect(global.fetch).toHaveBeenCalledWith(`/api/rooms/room1/pinned/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(list).toEqual([{ id: 'p1' }]);
+  expect(channel.state.pinnedMessages).toEqual([{ id: 'p1' }]);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -621,6 +621,17 @@ export class Channel {
         if (!res.ok) throw new Error('pin failed');
     }
 
+    /** Fetch pinned messages for this channel */
+    async pinnedMessages() {
+        const res = await fetch(`/api/rooms/${this.uuid}/pinned/`, {
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('pinnedMessages failed');
+        const list = await res.json() as Message[];
+        this.bump({ pinnedMessages: list });
+        return list;
+    }
+
     /** Fetch reactions for a given message */
     async queryReactions(messageId: string) {
         const res = await fetch(`${API.MESSAGES}${messageId}/reactions/`, {


### PR DESCRIPTION
## Summary
- add endpoint to list pinned messages for a room
- expose `pinnedMessages()` method on adapter Channel
- cover pinned messages with unit tests
- document completed surface in adapter todo

## Testing
- `pnpm turbo build`
- `pnpm turbo test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68514f084eb88326bea761033a382976