### PR TITLE
feat(adapter): implement polls listing, backend endpoint

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -276,10 +276,15 @@ class PollOptionCreateView(APIView):
 
 
 class PollListCreateView(APIView):
-    """Create a new poll."""
+    """List or create polls."""
 
     authentication_classes = [SupabaseJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        polls = Poll.objects.all()
+        serializer = PollSerializer(polls, many=True)
+        return Response(serializer.data)
 
     def post(self, request):
         serializer = PollSerializer(data=request.data)

--- a/backend/chat/tests/test_list_polls.py
+++ b/backend/chat/tests/test_list_polls.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from accounts_supabase.models import CustomUser
+from chat.models import Poll
+
+class PollListAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        Poll.objects.create(question="q1", user=self.user)
+        Poll.objects.create(question="q2", user=self.user)
+
+    def test_list_polls(self):
+        token = self.make_token()
+        url = reverse("poll-create")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 2)
+
+    def test_polls_requires_auth(self):
+        url = reverse("poll-create")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_polls_wrong_method(self):
+        token = self.make_token()
+        url = reverse("poll-create")
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -69,7 +69,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **pinMessage**                               | ✅ | ✅ |
 | **pinnedMessages**                           | ✅ | ✅ |
 | **pollComposer**                             | ✅ | ✅ |
-| **polls**                                    | 🔲 | 🔲 |
+| **polls**                                    | ✅ | ✅ |
 | **query**                                    | ✅ | ✅ |
 | **queryChannels**                            | ✅ | ✅ |
 | **queryReactions**                           | ✅ | ✅ |

--- a/frontend/__tests__/adapter/polls.test.ts
+++ b/frontend/__tests__/adapter/polls.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getPolls fetches list and updates store', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => [{ id: 'p1' }] });
+  const client = new ChatClient('u1', 'jwt1');
+  const res = await client.getPolls();
+
+  expect(global.fetch).toHaveBeenCalledWith(API.POLLS, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(res).toEqual([{ id: 'p1' }]);
+  expect(client.polls.store.getSnapshot().polls).toEqual([{ id: 'p1' }]);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -42,7 +42,7 @@ export class ChatClient {
 
     /* feature-module placeholders Stream-UI imports & tears-down */
     threads   !: { registerSubscriptions(): void; unregisterSubscriptions(): void };
-    polls     !: { registerSubscriptions(): void; unregisterSubscriptions(): void };
+    polls     !: { store: MiniStore<{ polls: any[] }>; registerSubscriptions(): void; unregisterSubscriptions(): void };
     reminders !: {
         registerSubscriptions(): void; unregisterSubscriptions(): void;
         initTimers(): void; clearTimers(): void;
@@ -84,7 +84,12 @@ export class ChatClient {
         this.clientID = randomId();
 
         /* no-op stubs keep Stream-UI happy */
-        this.threads = this.polls = {
+        this.threads = {
+            registerSubscriptions() {/* noop */ },
+            unregisterSubscriptions() {/* noop */ },
+        };
+        this.polls = {
+            store: new MiniStore({ polls: [] as any[] }),
             registerSubscriptions() {/* noop */ },
             unregisterSubscriptions() {/* noop */ },
         };
@@ -271,6 +276,17 @@ export class ChatClient {
         if (!res.ok) throw new Error('getNotifications failed');
         const list = await res.json() as any[];
         this.notifications.store._set({ notifications: list });
+        return list;
+    }
+
+    /** fetch list of polls */
+    async getPolls() {
+        const res = await fetch(API.POLLS, {
+            headers: this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {},
+        });
+        if (!res.ok) throw new Error('getPolls failed');
+        const list = await res.json() as any[];
+        this.polls.store._set({ polls: list });
         return list;
     }
 


### PR DESCRIPTION
## Summary
- add GET /api/polls/ to list polls
- expose `polls` store and `getPolls()` in ChatClient
- document surface coverage in adapter-todo
- add unit tests for adapter and backend

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python manage.py test` *(fails: Conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_685159e7090083268912f4685ee7e9c8