### PR TITLE
feat(adapter): implement read surface

### DIFF
--- a/backend/chat/tests/test_read.py
+++ b/backend/chat/tests/test_read.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message, ReadState
+from accounts_supabase.models import CustomUser
+from django.utils import timezone
+
+class ReadAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.room = Room.objects.create(uuid="r1", client="u1")
+        self.msg = Message.objects.create(body="hi", sent_by="u1")
+        self.room.messages.add(self.msg)
+        ReadState.objects.create(user=self.user, room=self.room, last_read=timezone.now())
+
+    def test_read_lists_states(self):
+        token = self.make_token()
+        url = reverse("room-read", kwargs={"room_uuid": self.room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["user"], "u1")
+
+    def test_read_requires_auth(self):
+        url = reverse("room-read", kwargs={"room_uuid": self.room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_read_wrong_method(self):
+        token = self.make_token()
+        url = reverse("room-read", kwargs={"room_uuid": self.room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -8,6 +8,7 @@ from .api_views import (
     RoomMarkUnreadView,
     RoomCountUnreadView,
     RoomLastReadView,
+    RoomReadView,
     RoomConfigView,
     MessageDetailView,
     MessageRepliesView,
@@ -65,6 +66,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/last_read/",
         RoomLastReadView.as_view(),
         name="room-last-read",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/read/",
+        RoomReadView.as_view(),
+        name="room-read",
     ),
     path(
         "api/rooms/<str:room_uuid>/draft/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -74,7 +74,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **queryChannels**                            | ✅ | ✅ |
 | **queryReactions**                           | ✅ | ✅ |
 | **queryUsers**                               | ✅ | ✅ |
-| **read**                                     | 🔲 | 🔲 |
+| **read**                                     | ✅ | ✅ |
 | **recoverStateOnReconnect**                  | 🔲 | 🔲 |
 | **registerSubscriptions**                    | 🔲 | 🔲 |
 | **reminders**                                | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/read.test.ts
+++ b/frontend/__tests__/adapter/read.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('read fetches states and updates channel', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => [
+      { user: 'u1', last_read: '2025-01-01T00:00:00Z', unread_messages: 0 },
+      { user: 'u2', last_read: '2025-01-02T00:00:00Z', unread_messages: 1 },
+    ],
+  });
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  const map = await channel.read();
+
+  expect(global.fetch).toHaveBeenCalledWith(`/api/rooms/room1/read/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(map.u2.unread_messages).toBe(1);
+  expect(channel.state.read.u1.last_read).toBe('2025-01-01T00:00:00Z');
+});


### PR DESCRIPTION
## Summary
- add `Channel.read()` method with corresponding tests
- provide `/api/rooms/<uuid>/read/` endpoint in Django
- create backend tests for `room-read`
- update todo list

## Testing
- `pnpm turbo build`
- `pnpm turbo test`


------
https://chatgpt.com/codex/tasks/task_e_68515c89f58483269975584c00073e1f