### PR TITLE
feat(adapter): implement recoverStateOnReconnect

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -75,7 +75,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **queryReactions**                           | ✅ | ✅ |
 | **queryUsers**                               | ✅ | ✅ |
 | **read**                                     | 🔲 | 🔲 |
-| **recoverStateOnReconnect**                  | 🔲 | 🔲 |
+| **recoverStateOnReconnect**                  | ✅ | 🔲 |
 | **registerSubscriptions**                    | 🔲 | 🔲 |
 | **reminders**                                | 🔲 | 🔲 |
 | **restore**                                  | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/recoverStateOnReconnect.test.ts
+++ b/frontend/__tests__/adapter/recoverStateOnReconnect.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+// ensure default value is true and can be toggled
+
+test('recoverStateOnReconnect defaults to true and can be set', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  expect(client.recoverStateOnReconnect).toBe(true);
+
+  client.recoverStateOnReconnect = false;
+  expect(client.recoverStateOnReconnect).toBe(false);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -10,7 +10,7 @@ import { API, EVENTS } from './constants';
 
 export class Channel {
     readonly id: number;
-    readonly uuid: string;
+    readonly uuid!: string;
     readonly cid: string;
     data: { name: string } & Record<string, unknown>;
 
@@ -349,12 +349,13 @@ export class Channel {
 
     constructor(
         id: number,
-        private uuid: string,
+        roomUuid: string,
         roomName: string,
         private client: ChatClient,
         extraData: Record<string, unknown> = {},
     ) {
         this.id = id;
+        this.uuid = roomUuid;
         this.cid = `messaging:${this.uuid}`;
         this.data = { name: roomName, ...extraData };
     }
@@ -416,7 +417,7 @@ export class Channel {
                 });
             }
 
-            const memRes = await fetch(`${API.ROOMS}${this.roomUuid}/members/`, {
+            const memRes = await fetch(`${API.ROOMS}${this.uuid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {
@@ -615,7 +616,7 @@ export class Channel {
 
     /** Hide this channel */
     async hide() {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/hide/`, {
+        const res = await fetch(`/api/rooms/${this.uuid}/hide/`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
@@ -625,7 +626,7 @@ export class Channel {
 
     /** Show this channel */
     async show() {
-        const res = await fetch(`/api/rooms/${this.roomUuid}/show/`, {
+        const res = await fetch(`/api/rooms/${this.uuid}/show/`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -29,6 +29,9 @@ export class ChatClient {
     /** Whether the client finished initialization */
     initialized = false;
 
+    /** Whether to auto recover channel state after reconnect */
+    recoverStateOnReconnect = true;
+
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     activeChannels: Record<string, any> = {};
     mutedChannels: unknown[] = [];


### PR DESCRIPTION
## Summary
- expose `recoverStateOnReconnect` flag on `ChatClient`
- align `Channel` constructor and usages with strict TS
- test the new adapter surface
- update todo list

## Testing
- `pnpm -r build`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68509b6b2dc88326936bfa868df6ef38