### PR TITLE
feat(adapter): implement registerSubscriptions

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -76,7 +76,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **queryUsers**                               | ✅ | ✅ |
 | **read**                                     | ✅ | ✅ |
 | **recoverStateOnReconnect**                  | ✅ | ✅ |
-| **registerSubscriptions**                    | 🔲 | 🔲 |
+| **registerSubscriptions**                    | ✅ | 🔲 |
 | **reminders**                                | 🔲 | 🔲 |
 | **restore**                                  | ✅ | ✅ |
 | **sendAction**                               | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/registerSubscriptions.test.ts
+++ b/frontend/__tests__/adapter/registerSubscriptions.test.ts
@@ -1,0 +1,18 @@
+import { expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+/** ensure registerSubscriptions wires store listeners */
+test('registerSubscriptions subscribes and unsubscribes', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  const composer: any = channel.messageComposer;
+  const spy = vi.spyOn(composer, 'logStateUpdateTimestamp');
+
+  const unsubscribe = composer.registerSubscriptions();
+  composer.customDataManager.set('foo', 1);
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  unsubscribe();
+  composer.customDataManager.set('bar', 2);
+  expect(spy).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -280,7 +280,17 @@ export class Channel {
                 },
 
                 /* ——— subscriptions & drafts ——— */
-                registerSubscriptions() { return () => { }; },
+                registerSubscriptions() {
+                    const handler = this.logStateUpdateTimestamp;
+                    const unsubs = [
+                        textStore.subscribe(handler),
+                        this.attachmentManager.state.subscribe(handler),
+                        this.linkPreviewsManager.state.subscribe(handler),
+                        this.pollComposer.state.subscribe(handler),
+                        this.customDataManager.state.subscribe(handler),
+                    ];
+                    return () => { unsubs.forEach(fn => fn()); };
+                },
                 createDraft() {
                     const text = textStore.getSnapshot().text;
                     localStorage.setItem(getRoomKey(), text);


### PR DESCRIPTION
## Summary
- implement `registerSubscriptions` in adapter messageComposer
- add unit tests for subscriptions behavior
- document adapter coverage in TODO list

## Testing
- `pnpm -r build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68516777f4c883268941c0c70eb88d28