### PR TITLE
Implement reminders adapter and backend

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -9,7 +9,21 @@ from accounts.authentication import SupabaseJWTAuthentication
 from django.utils import timezone
 
 from urllib.parse import urlparse
-from .models import Room, Message, ReadState, Draft, Notification, Reaction, PollOption, Poll, Flag, Pin, UserMute, RoomMute
+from .models import (
+    Room,
+    Message,
+    ReadState,
+    Draft,
+    Notification,
+    Reaction,
+    PollOption,
+    Poll,
+    Flag,
+    Pin,
+    UserMute,
+    RoomMute,
+    Reminder,
+)
 
 from .serializers import (
     RoomSerializer,
@@ -20,6 +34,7 @@ from .serializers import (
     PollSerializer,
     FlagSerializer,
     PinSerializer,
+    ReminderSerializer,
 )
 
 
@@ -458,6 +473,28 @@ class NotificationListView(APIView):
         notes = Notification.objects.filter(user=request.user)
         serializer = NotificationSerializer(notes, many=True)
         return Response(serializer.data)
+
+
+class ReminderListCreateView(APIView):
+    """List or create reminders for the current user."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        reminders = Reminder.objects.filter(user=request.user)
+        serializer = ReminderSerializer(reminders, many=True)
+        return Response(serializer.data)
+
+    def post(self, request):
+        serializer = ReminderSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        reminder = Reminder.objects.create(
+            user=request.user,
+            text=serializer.validated_data["text"],
+            remind_at=serializer.validated_data["remind_at"],
+        )
+        return Response({"reminder": ReminderSerializer(reminder).data}, status=201)
 
 
 class MutedChannelListView(APIView):

--- a/backend/chat/migrations/0012_reminder.py
+++ b/backend/chat/migrations/0012_reminder.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.conf import settings
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('chat', '0011_pin'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Reminder',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('text', models.TextField()),
+                ('remind_at', models.DateTimeField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={'ordering': ('remind_at',)},
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -82,6 +82,18 @@ class Notification(models.Model):
 
     class Meta:
         ordering = ("-created_at",)
+
+
+class Reminder(models.Model):
+    """Simple reminder item for a user."""
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    text = models.TextField()
+    remind_at = models.DateTimeField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ("remind_at",)
         
         
 class Reaction(models.Model):

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -1,6 +1,15 @@
 from rest_framework import serializers
-from .models import Room, Message, Notification, Reaction, PollOption, Poll, Flag
-from .models import Pin
+from .models import (
+    Room,
+    Message,
+    Notification,
+    Reaction,
+    PollOption,
+    Poll,
+    Flag,
+    Reminder,
+    Pin,
+)
 
 
 class MessageSerializer(serializers.ModelSerializer):
@@ -98,3 +107,10 @@ class PollSerializer(serializers.ModelSerializer):
         model = Poll
         fields = ["id", "question", "user_id", "created_at"]
         read_only_fields = ["id", "user_id", "created_at"]
+
+
+class ReminderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Reminder
+        fields = ["id", "text", "remind_at", "created_at"]
+        read_only_fields = ["id", "created_at"]

--- a/backend/chat/tests/test_reminders.py
+++ b/backend/chat/tests/test_reminders.py
@@ -1,0 +1,45 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from accounts_supabase.models import CustomUser
+from chat.models import Reminder
+
+class ReminderAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.other = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
+        Reminder.objects.create(user=self.user, text="hi", remind_at="2025-01-01T00:00:00Z")
+        Reminder.objects.create(user=self.other, text="bye", remind_at="2025-01-02T00:00:00Z")
+
+    def test_list_reminders(self):
+        token = self.make_token()
+        url = reverse("reminders")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["text"], "hi")
+
+    def test_reminders_requires_auth(self):
+        url = reverse("reminders")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_reminders_wrong_method(self):
+        token = self.make_token()
+        url = reverse("reminders")
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)
+
+    def test_create_reminder(self):
+        token = self.make_token()
+        url = reverse("reminders")
+        res = self.client.post(url, {"text": "new", "remind_at": "2025-01-03T00:00:00Z"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(Reminder.objects.filter(text="new").count(), 1)
+        self.assertEqual(res.data["reminder"]["text"], "new")
+

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -34,6 +34,7 @@ from .api_views import (
     MessageRestoreView,
     MutedUsersView,
     MuteUserView,
+    ReminderListCreateView,
     RecoverStateView,
 )
 
@@ -140,6 +141,7 @@ urlpatterns = [
         name="message-replies",
     ),
     path("api/notifications/", NotificationListView.as_view(), name="notifications"),
+    path("api/reminders/", ReminderListCreateView.as_view(), name="reminders"),
     path("api/muted-channels/", MutedChannelListView.as_view(), name="muted-channels"),
     path(
         "api/messages/<int:message_id>/reactions/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -77,7 +77,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **read**                                     | ✅ | ✅ |
 | **recoverStateOnReconnect**                  | ✅ | ✅ |
 | **registerSubscriptions**                    | ✅ | 🔲 |
-| **reminders**                                | 🔲 | 🔲 |
+| **reminders**                                | ✅ | ✅ |
 | **restore**                                  | ✅ | ✅ |
 | **sendAction**                               | 🔲 | 🔲 |
 | **sendMessage**                              | ✅ | ✅ |

--- a/frontend/__tests__/adapter/reminders.test.ts
+++ b/frontend/__tests__/adapter/reminders.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getReminders fetches list and updates store', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => [{ id: 1, text: 'rem', remind_at: '2025-01-01T00:00:00Z' }],
+  });
+  const client = new ChatClient('u1', 'jwt1');
+  const res = await client.getReminders();
+  expect(global.fetch).toHaveBeenCalledWith(API.REMINDERS, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(res).toEqual([{ id: 1, text: 'rem', remind_at: '2025-01-01T00:00:00Z' }]);
+  expect(client.reminders.store.getSnapshot().reminders.length).toBe(1);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -44,6 +44,7 @@ export class ChatClient {
     threads   !: { registerSubscriptions(): void; unregisterSubscriptions(): void };
     polls     !: { store: MiniStore<{ polls: any[] }>; registerSubscriptions(): void; unregisterSubscriptions(): void };
     reminders !: {
+        store: MiniStore<{ reminders: any[] }>;
         registerSubscriptions(): void; unregisterSubscriptions(): void;
         initTimers(): void; clearTimers(): void;
     };
@@ -94,6 +95,7 @@ export class ChatClient {
             unregisterSubscriptions() {/* noop */ },
         };
         this.reminders = {
+            store: new MiniStore({ reminders: [] as any[] }),
             registerSubscriptions() {/* noop */ },
             unregisterSubscriptions() {/* noop */ },
             initTimers() {/* noop */ },
@@ -287,6 +289,17 @@ export class ChatClient {
         if (!res.ok) throw new Error('getPolls failed');
         const list = await res.json() as any[];
         this.polls.store._set({ polls: list });
+        return list;
+    }
+
+    /** fetch list of reminders */
+    async getReminders() {
+        const res = await fetch(API.REMINDERS, {
+            headers: this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {},
+        });
+        if (!res.ok) throw new Error('getReminders failed');
+        const list = await res.json() as any[];
+        this.reminders.store._set({ reminders: list });
         return list;
     }
 

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -11,6 +11,7 @@ export const API = {
   USER_AGENT: '/api/core-user-agent/',
   NOTIFICATIONS: '/api/notifications/',
   POLLS: '/api/polls/',
+  REMINDERS: '/api/reminders/',
   LINK_PREVIEW: '/api/link-preview/',
   COOLDOWN: '/api/rooms/',
   MUTE_STATUS: '/api/mute-status/',


### PR DESCRIPTION
## Summary
- implement reminders store & API binding in `ChatClient`
- expose `/api/reminders/` with Django model, serializer, and view
- add vitest and Django tests for reminders
- track progress in adapter todo

## Testing
- `pnpm turbo build`
- `pnpm turbo test`


------
https://chatgpt.com/codex/tasks/task_e_68516b58e310832694f57060f1922ee1