### PR TITLE
feat(adapter): implement sendAction

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -305,6 +305,24 @@ class MessagePinView(APIView):
         return Response({"pin": PinSerializer(pin).data}, status=201)
 
 
+class MessageActionView(APIView):
+    """Record an action on a message."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, message_id):
+        msg = get_object_or_404(Message, id=message_id)
+        data = request.data or {}
+        custom = msg.custom_data or {}
+        actions = custom.get("actions", [])
+        actions.append(data)
+        custom["actions"] = actions
+        msg.custom_data = custom
+        msg.save(update_fields=["custom_data"])
+        return Response({"action": data}, status=201)
+
+
 
 class PollOptionCreateView(APIView):
     """Create a new poll option."""

--- a/backend/chat/tests/test_send_action.py
+++ b/backend/chat/tests/test_send_action.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message
+
+class SendActionAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_send_action_updates_message(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        room.messages.add(msg)
+        token = self.make_token()
+        url = reverse("message-actions", kwargs={"message_id": msg.id})
+        res = self.client.post(url, {"vote": "yes"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 201)
+        msg.refresh_from_db()
+        self.assertEqual(msg.custom_data["actions"][0]["vote"], "yes")
+
+    def test_send_action_requires_auth(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        url = reverse("message-actions", kwargs={"message_id": msg.id})
+        res = self.client.post(url, {"vote": "yes"}, format="json")
+        self.assertEqual(res.status_code, 403)
+
+    def test_send_action_wrong_method(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        token = self.make_token()
+        url = reverse("message-actions", kwargs={"message_id": msg.id})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -15,6 +15,7 @@ from .api_views import (
     MessageReactionsView,
     MessageFlagView,
     MessagePinView,
+    MessageActionView,
     RoomArchiveView,
     RoomUnarchiveView,
     RoomCooldownView,
@@ -158,6 +159,11 @@ urlpatterns = [
         "api/messages/<int:message_id>/pin/",
         MessagePinView.as_view(),
         name="message-pin",
+    ),
+    path(
+        "api/messages/<int:message_id>/actions/",
+        MessageActionView.as_view(),
+        name="message-actions",
     ),
     path(
         "api/messages/<int:message_id>/reactions/<int:reaction_id>/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -79,7 +79,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **registerSubscriptions**                    | ✅ | 🔲 |
 | **reminders**                                | ✅ | ✅ |
 | **restore**                                  | ✅ | ✅ |
-| **sendAction**                               | 🔲 | 🔲 |
+| **sendAction**                               | ✅ | ✅ |
 | **sendMessage**                              | ✅ | ✅ |
 | **sendReaction**                             | ✅ | ✅ |
 | **setQuotedMessage**                         | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/sendAction.test.ts
+++ b/frontend/__tests__/adapter/sendAction.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('sendAction posts action to API', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true }),
+  });
+
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.sendAction('m1', { vote: 'yes' });
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MESSAGES}m1/actions/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer jwt1',
+    },
+    body: JSON.stringify({ vote: 'yes' }),
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -681,6 +681,20 @@ export class Channel {
         return await res.json();
     }
 
+    /** Send an action for a message */
+    async sendAction(messageId: string, action: Record<string, unknown>) {
+        const res = await fetch(`${API.MESSAGES}${messageId}/actions/`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.client['jwt']}`,
+            },
+            body: JSON.stringify(action),
+        });
+        if (!res.ok) throw new Error('sendAction failed');
+        return await res.json();
+    }
+
     /** Flag a message for moderation */
     async flagMessage(messageId: string) {
         const res = await fetch(`${API.MESSAGES}${messageId}/flag/`, {


### PR DESCRIPTION
## Summary
- support sending message actions via `sendAction`
- store message actions server-side
- test sendAction adapter and backend API
- mark sendAction as done in docs

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`

------
https://chatgpt.com/codex/tasks/task_e_68516df114d8832686b8eedfd8f672ce