### PR TITLE
Implement unmuteUser surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -560,6 +560,18 @@ class MuteUserView(APIView):
         target = get_object_or_404(get_user_model(), username=target_username)
         UserMute.objects.get_or_create(user=request.user, target=target)
         return Response({"status": "ok"})
+
+
+class UnmuteUserView(APIView):
+    """Remove mute record for the given user."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, target_username):
+        target = get_object_or_404(get_user_model(), username=target_username)
+        UserMute.objects.filter(user=request.user, target=target).delete()
+        return Response({"status": "ok"})
       
       
 class LinkPreviewView(APIView):

--- a/backend/chat/tests/test_unmute_user.py
+++ b/backend/chat/tests/test_unmute_user.py
@@ -1,0 +1,35 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from accounts_supabase.models import CustomUser
+from chat.models import UserMute
+
+class UnmuteUserAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user1 = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.user2 = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
+        UserMute.objects.create(user=self.user1, target=self.user2)
+
+    def test_unmute_user_deletes_record(self):
+        token = self.make_token()
+        url = reverse("user-unmute", kwargs={"target_username": "u2"})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(UserMute.objects.filter(user=self.user1, target=self.user2).exists())
+        self.assertEqual(res.data["status"], "ok")
+
+    def test_unmute_user_requires_auth(self):
+        url = reverse("user-unmute", kwargs={"target_username": "u2"})
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_unmute_user_wrong_method(self):
+        token = self.make_token()
+        url = reverse("user-unmute", kwargs={"target_username": "u2"})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -35,6 +35,7 @@ from .api_views import (
     MessageRestoreView,
     MutedUsersView,
     MuteUserView,
+    UnmuteUserView,
     ReminderListCreateView,
     RecoverStateView,
 )
@@ -199,6 +200,11 @@ urlpatterns = [
         "api/mute/<str:target_username>/",
         MuteUserView.as_view(),
         name="user-mute",
+    ),
+    path(
+        "api/unmute/<str:target_username>/",
+        UnmuteUserView.as_view(),
+        name="user-unmute",
     ),
     path("api/recover-state/", RecoverStateView.as_view(), name="recover-state"),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -96,7 +96,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **truncated**                                | 🔲 | 🔲 |
 | **type**                                     | 🔲 | 🔲 |
 | **unarchive**                                | ✅ | ✅ |
-| **unmuteUser**                               | 🔲 | 🔲 |
+| **unmuteUser**                               | ✅ | ✅ |
 | **unpin**                                    | 🔲 | 🔲 |
 | **unpinMessage**                             | 🔲 | 🔲 |
 | **updateMessage**                            | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/unmuteUser.test.ts
+++ b/frontend/__tests__/adapter/unmuteUser.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('unmuteUser posts to backend endpoint', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  await client.unmuteUser('u2');
+  expect(global.fetch).toHaveBeenCalledWith(`${API.UNMUTE_USER}u2/`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -355,6 +355,15 @@ export class ChatClient {
         if (!res.ok) throw new Error('muteUser failed');
     }
 
+    /** Unmute a user */
+    async unmuteUser(userId: string) {
+        const res = await fetch(`${API.UNMUTE_USER}${userId}/`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${this.jwt}` },
+        });
+        if (!res.ok) throw new Error('unmuteUser failed');
+    }
+
     /** Pin a message globally */
     async pinMessage(messageId: string) {
         const res = await fetch(`${API.MESSAGES}${messageId}/pin/`, {


### PR DESCRIPTION
## Summary
- support unmuteUser in ChatClient
- back Django endpoint for unmute
- add adapter and API unit tests
- mark docs surface as implemented

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test` *(fails: Conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_6851706c2400832692c4c422f042d428