### PR TITLE
feat(adapter): implement state surface

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -84,7 +84,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **sendReaction**                             | ✅ | ✅ |
 | **setQuotedMessage**                         | ✅ | 🔲 |
 | **setUserAgent**                             | ✅ | ✅ |
-| **state**                                    | 🔲 | 🔲 |
+| **state**                                    | ✅ | 🔲 |
 | **subarray**                                 | 🔲 | 🔲 |
 | **tag**                                      | 🔲 | 🔲 |
 | **textComposer**                             | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/state.test.ts
+++ b/frontend/__tests__/adapter/state.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('client.state stores users from queryUsers', async () => {
+  const users = [
+    { id: 1, username: 'u1' },
+    { id: 2, username: 'u2' },
+  ];
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => users });
+
+  const client = new ChatClient('u1', 'jwt1');
+  await client.queryUsers();
+
+  expect(global.fetch).toHaveBeenCalledWith(API.USERS, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(client.state.users['1'].username).toBe('u1');
+  expect(client.state.users['2'].username).toBe('u2');
+});
+
+test('client.state stores user from getUser', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => ({ id: 3, username: 'me' }) });
+  const client = new ChatClient('u1', 'jwt1');
+  await client.getUser();
+  expect(global.fetch).toHaveBeenCalledWith(API.USER, { headers: { Authorization: 'Bearer jwt1' } });
+  expect(client.state.users['3'].username).toBe('me');
+});


### PR DESCRIPTION
## Summary
- add `client.state` stub that tracks users
- record users when connecting, fetching user info or listing users
- test client.state updates
- mark adapter implementation in TODO

## Testing
- `pnpm -r build`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6851755e74d0832684c60797ea048fc5