### PR TITLE
feat(adapter): implement subarray

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -633,3 +633,19 @@ class RecoverStateView(APIView):
         return Response({"rooms": room_data, "notifications": note_data})
 
 
+class SubarrayView(APIView):
+    """Return a slice of the given array."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        array = request.data.get("array", [])
+        start = int(request.data.get("start", 0))
+        end = request.data.get("end")
+        if not isinstance(array, list):
+            return Response({"error": "array must be a list"}, status=400)
+        slice_result = array[start:end] if end is not None else array[start:]
+        return Response({"result": slice_result})
+
+

--- a/backend/chat/tests/test_subarray.py
+++ b/backend/chat/tests/test_subarray.py
@@ -1,0 +1,26 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class SubarrayAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_subarray_returns_slice(self):
+        token = self.make_token()
+        url = reverse("subarray")
+        res = self.client.post(url, {"array": [1,2,3,4], "start": 1, "end": 3}, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["result"], [2,3])
+
+    def test_subarray_requires_auth(self):
+        url = reverse("subarray")
+        res = self.client.post(url, {"array": [1]})
+        self.assertEqual(res.status_code, 403)
+
+    def test_subarray_wrong_method(self):
+        token = self.make_token()
+        url = reverse("subarray")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -38,6 +38,7 @@ from .api_views import (
     UnmuteUserView,
     ReminderListCreateView,
     RecoverStateView,
+    SubarrayView,
 )
 
 router = DefaultRouter()
@@ -207,4 +208,5 @@ urlpatterns = [
         name="user-unmute",
     ),
     path("api/recover-state/", RecoverStateView.as_view(), name="recover-state"),
+    path("api/subarray/", SubarrayView.as_view(), name="subarray"),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -85,7 +85,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **setQuotedMessage**                         | ✅ | 🔲 |
 | **setUserAgent**                             | ✅ | ✅ |
 | **state**                                    | ✅ | 🔲 |
-| **subarray**                                 | 🔲 | 🔲 |
+| **subarray**                                 | ✅ | ✅ |
 | **tag**                                      | 🔲 | 🔲 |
 | **textComposer**                             | 🔲 | 🔲 |
 | **threadId**                                 | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/subarray.test.ts
+++ b/frontend/__tests__/adapter/subarray.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ result: [2,3] }) });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('subarray posts to backend and returns slice', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const result = await client.subarray([1,2,3,4], 1, 3);
+
+  expect(global.fetch).toHaveBeenCalledWith(API.SUBARRAY, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer jwt1' },
+    body: JSON.stringify({ array: [1,2,3,4], start: 1, end: 3 }),
+  });
+  expect(result).toEqual([2,3]);
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -425,4 +425,22 @@ export class ChatClient {
     getClient() {
         return this;
     }
+
+    /**
+     * Return a slice of the provided array.
+     * This mirrors TypedArray.subarray from Stream's SDK.
+     */
+    async subarray<T>(arr: T[], start: number, end?: number): Promise<T[]> {
+        const res = await fetch(API.SUBARRAY, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(this.jwt ? { Authorization: `Bearer ${this.jwt}` } : {}),
+            },
+            body: JSON.stringify({ array: arr, start, end }),
+        });
+        if (!res.ok) throw new Error('subarray failed');
+        const data = await res.json() as { result: T[] };
+        return data.result;
+    }
 }

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -20,6 +20,7 @@ export const API = {
   MUTE_USER: '/api/mute/',
   UNMUTE_USER: '/api/unmute/',
   RECOVER_STATE: '/api/recover-state/',
+  SUBARRAY: '/api/subarray/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- implement `subarray` helper in ChatClient
- expose `/api/subarray/` endpoint for array slicing
- document completion in todo
- add unit tests for adapter and backend

## Testing
- `pnpm exec turbo run build`
- `pnpm exec turbo run test`
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_6851825f69fc8326813998961b350c46