### PR TITLE
feat(adapter): implement tag surface (task)

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -86,7 +86,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **setUserAgent**                             | ✅ | ✅ |
 | **state**                                    | ✅ | 🔲 |
 | **subarray**                                 | ✅ | ✅ |
-| **tag**                                      | 🔲 | 🔲 |
+| **tag**                                      | ✅ | 🔲 | <!--TODO-backend-->
 | **textComposer**                             | 🔲 | 🔲 |
 | **threadId**                                 | 🔲 | 🔲 |
 | **threads**                                  | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/tag.test.ts
+++ b/frontend/__tests__/adapter/tag.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('messageComposer has tag "root"', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  expect(channel.messageComposer.tag).toBe('root');
+});


### PR DESCRIPTION
## Summary
- add unit tests for the `tag` property on message composer
- mark `tag` adapter surface as implemented

## Testing
- `pnpm -r build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68519699d7e4832694ee98772d890f62