### PR TITLE
feat(adapter): implement toggleShowReplyInChannel

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -90,7 +90,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **textComposer**                             | ✅ | ✅ |
 | **threadId**                                 | ✅ | ✅ |
 | **threads**                                  | ✅ | ✅ |
-| **toggleShowReplyInChannel**                 | 🔲 | 🔲 |
+| **toggleShowReplyInChannel**                 | ✅ | 🔲 |
 | **tokenManager**                             | 🔲 | 🔲 |
 | **truncate**                                 | 🔲 | 🔲 |
 | **truncated**                                | 🔲 | 🔲 |

--- a/frontend/__tests__/adapter/toggleShowReplyInChannel.test.ts
+++ b/frontend/__tests__/adapter/toggleShowReplyInChannel.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ id: 'm2', text: 'hi', user_id: 'u1', created_at: '2025-01-01T00:00:00Z' }),
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('toggleShowReplyInChannel toggles state and affects sendMessage', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  expect(channel.messageComposer.showReplyInChannel).toBe(false);
+
+  channel.messageComposer.toggleShowReplyInChannel();
+  expect(channel.messageComposer.showReplyInChannel).toBe(true);
+
+  await channel.sendMessage({ text: 'hi' });
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.ROOMS}room1/messages/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer jwt1',
+    },
+    body: JSON.stringify({ text: 'hi', show_in_channel: true }),
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -96,7 +96,10 @@ export class Channel {
                 },
 
                 /* ——— composer‑level stores ——— */
-                state: new MiniStore({ quotedMessage: undefined as any }),
+                state: new MiniStore({
+                    quotedMessage: undefined as any,
+                    showReplyInChannel: false,
+                }),
                 editingAuditState,
                 linkPreviewsManager: (() => {
                     const store = new MiniStore({ previews: [] as any[] });
@@ -363,6 +366,17 @@ export class Channel {
                     (this as any).threadId = id;
                 },
 
+                /** Toggle whether replies are shown in-channel */
+                toggleShowReplyInChannel() {
+                    const cur = this.state.getSnapshot().showReplyInChannel;
+                    this.state._set({ showReplyInChannel: !cur });
+                },
+
+                /** Current flag for showing replies in-channel */
+                get showReplyInChannel() {
+                    return this.state.getSnapshot().showReplyInChannel;
+                },
+
                 /** Reset composer state optionally from an existing message */
                 initState({ composition }: { composition?: Message } = {}) {
                     this.attachmentManager.state._set({ attachments: [] });
@@ -622,6 +636,9 @@ export class Channel {
         if (poll) payload.poll = poll;
         const threadId = this.messageComposer.threadId;
         if (threadId) payload.reply_to = threadId;
+        if (this.messageComposer.state.getSnapshot().showReplyInChannel) {
+            payload.show_in_channel = true;
+        }
         const res = await fetch(`${API.ROOMS}${this.uuid}/messages/`, {
             method: 'POST',
             headers: {


### PR DESCRIPTION
## Summary
- implement `toggleShowReplyInChannel` in adapter
- support `show_in_channel` flag in message posting
- add unit test for toggling behavior
- mark adapter row in documentation

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_6851bfd4a8bc8326b7df37577670e3ca