### PR TITLE
feat(adapter): implement truncated surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -648,6 +648,10 @@ class RoomTruncateView(APIView):
     def post(self, request, room_uuid):
         room = get_object_or_404(Room, uuid=room_uuid)
         room.messages.clear()
+        data = room.data or {}
+        data["truncated"] = True
+        room.data = data
+        room.save(update_fields=["data"])
         return Response({"status": "ok"})
 
 

--- a/backend/chat/tests/test_truncate_room.py
+++ b/backend/chat/tests/test_truncate_room.py
@@ -22,6 +22,15 @@ class TruncateRoomAPITests(APITestCase):
         self.assertEqual(room.messages.count(), 0)
         self.assertEqual(res.data["status"], "ok")
 
+    def test_truncate_room_sets_truncated_flag(self):
+        room = Room.objects.create(uuid="r1", client="c1", data={})
+        token = self.make_token()
+        url = reverse("room-truncate", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        room.refresh_from_db()
+        self.assertTrue(room.data.get("truncated"))
+
     def test_truncate_room_requires_auth(self):
         room = Room.objects.create(uuid="r1", client="c1")
         url = reverse("room-truncate", kwargs={"room_uuid": room.uuid})

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -93,7 +93,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **toggleShowReplyInChannel**                 | ✅ | 🔲 |
 | **tokenManager**                             | ✅ | ✅ |
 | **truncate**                                 | ✅ | ✅ |
-| **truncated**                                | 🔲 | 🔲 |
+| **truncated**                                | ✅ | ✅ |
 | **type**                                     | 🔲 | 🔲 |
 | **unarchive**                                | ✅ | ✅ |
 | **unmuteUser**                               | ✅ | ✅ |

--- a/frontend/__tests__/adapter/truncated.test.ts
+++ b/frontend/__tests__/adapter/truncated.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('truncate sets truncated flag', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.truncate();
+
+  expect(channel.truncated).toBe(true);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -431,6 +431,9 @@ export class Channel {
     /** Whether this channel is hidden */
     get hidden() { return !!this.data.hidden; }
 
+    /** Whether this channel has been truncated */
+    get truncated() { return !!this.data.truncated; }
+
     /** Human readable channel name if provided */
     get name() { return this.data.name; }
 
@@ -828,6 +831,7 @@ export class Channel {
         });
         if (!res.ok) throw new Error('truncate failed');
         this.bump({ messages: [], latestMessages: [] });
+        this.data.truncated = true;
     }
 
     /** Fetch cooldown value for this channel */


### PR DESCRIPTION
## Summary
- add `truncated` flag to Channel
- persist truncated state in backend Room
- cover new functionality with tests
- update adapter TODO

## Testing
- `pnpm -r test`
- `python backend/manage.py test chat`
- `pnpm -r build`


------
https://chatgpt.com/codex/tasks/task_e_6851d2d349f08326845ca2814b1797a0