### PR TITLE
feat(adapter): implement unpin feature

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -311,6 +311,18 @@ class MessagePinView(APIView):
         return Response({"pin": PinSerializer(pin).data}, status=201)
 
 
+class MessageUnpinView(APIView):
+    """Remove the current user's pin from a message."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request, message_id):
+        msg = get_object_or_404(Message, id=message_id)
+        Pin.objects.filter(message=msg, user=request.user).delete()
+        return Response(status=204)
+
+
 class MessageActionView(APIView):
     """Record an action on a message."""
 

--- a/backend/chat/tests/test_unpin_message.py
+++ b/backend/chat/tests/test_unpin_message.py
@@ -1,0 +1,37 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message, Pin
+from accounts_supabase.models import CustomUser
+
+class UnpinMessageAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            username="u1", email="u1@example.com", password="x", supabase_uid="u1"
+        )
+        self.room = Room.objects.create(uuid="r1", client="c1")
+        self.msg = Message.objects.create(body="hi", sent_by="u1")
+        self.room.messages.add(self.msg)
+        self.user_token = self.make_token()
+        Pin.objects.create(message=self.msg, user=self.user)
+
+    def test_unpin_message_deletes_pin(self):
+        url = reverse("message-unpin", kwargs={"message_id": self.msg.id})
+        res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {self.user_token}")
+        self.assertEqual(res.status_code, 204)
+        self.assertFalse(Pin.objects.filter(message=self.msg, user__username="u1").exists())
+
+    def test_unpin_message_requires_auth(self):
+        url = reverse("message-unpin", kwargs={"message_id": self.msg.id})
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_unpin_message_wrong_method(self):
+        url = reverse("message-unpin", kwargs={"message_id": self.msg.id})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.user_token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -15,6 +15,7 @@ from .api_views import (
     MessageReactionsView,
     MessageFlagView,
     MessagePinView,
+    MessageUnpinView,
     MessageActionView,
     RoomArchiveView,
     RoomUnarchiveView,
@@ -172,6 +173,11 @@ urlpatterns = [
         "api/messages/<int:message_id>/pin/",
         MessagePinView.as_view(),
         name="message-pin",
+    ),
+    path(
+        "api/messages/<int:message_id>/unpin/",
+        MessageUnpinView.as_view(),
+        name="message-unpin",
     ),
     path(
         "api/messages/<int:message_id>/actions/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -97,8 +97,8 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **type**                                     | 🔲 | 🔲 |
 | **unarchive**                                | ✅ | ✅ |
 | **unmuteUser**                               | ✅ | ✅ |
-| **unpin**                                    | 🔲 | 🔲 |
-| **unpinMessage**                             | 🔲 | 🔲 |
+| **unpin**                                    | ✅ | ✅ |
+| **unpinMessage**                             | ✅ | ✅ |
 | **updateMessage**                            | 🔲 | 🔲 |
 | **updated**                                  | 🔲 | 🔲 |
 | **user**                                     | ✅ | ✅ |

--- a/frontend/__tests__/adapter/unpin.test.ts
+++ b/frontend/__tests__/adapter/unpin.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('unpin posts DELETE to API', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  await channel.unpin('m1');
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MESSAGES}m1/unpin/`, {
+    method: 'DELETE',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/__tests__/adapter/unpinMessage.test.ts
+++ b/frontend/__tests__/adapter/unpinMessage.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('unpinMessage sends DELETE to API', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  await client.unpinMessage('m1');
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MESSAGES}m1/unpin/`, {
+    method: 'DELETE',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -747,6 +747,15 @@ export class Channel {
         if (!res.ok) throw new Error('pin failed');
     }
 
+    /** Unpin a message */
+    async unpin(messageId: string) {
+        const res = await fetch(`${API.MESSAGES}${messageId}/unpin/`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('unpin failed');
+    }
+
     /** Fetch pinned messages for this channel */
     async pinnedMessages() {
         const res = await fetch(`/api/rooms/${this.uuid}/pinned/`, {

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -431,6 +431,15 @@ export class ChatClient {
         return await res.json();
     }
 
+    /** Unpin a message globally */
+    async unpinMessage(messageId: string) {
+        const res = await fetch(`${API.MESSAGES}${messageId}/unpin/`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${this.jwt}` },
+        });
+        if (!res.ok) throw new Error('unpinMessage failed');
+    }
+
     /** Create a poll option */
     async createPollOption(pollId: string, option: { text: string }) {
         const res = await fetch(`${API.POLLS}${pollId}/options/`, {


### PR DESCRIPTION
## Summary
- add `unpin`/`unpinMessage` support to the adapter
- expose `/api/messages/<id>/unpin/` endpoint in Django backend
- test unpin functionality on both frontend and backend
- update adapter coverage docs

## Testing
- `pnpm turbo build`
- `pnpm turbo test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851d5c78d888326ac95a077142ca089