### PR TITLE
feat(adapter): implement visible surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -651,6 +651,18 @@ class RoomShowView(APIView):
         return Response({"status": "ok"})
 
 
+class RoomVisibleView(APIView):
+    """Return whether a room is visible (not hidden)."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        hidden = (room.data or {}).get("hidden", False)
+        return Response({"visible": not hidden})
+
+
 class RoomTruncateView(APIView):
     """Remove all messages from a room."""
 

--- a/backend/chat/tests/test_visible.py
+++ b/backend/chat/tests/test_visible.py
@@ -1,0 +1,32 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class RoomVisibleAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_visible_true_when_not_hidden(self):
+        room = Room.objects.create(uuid="r1", client="c1", data={})
+        token = self.make_token()
+        url = reverse("room-visible", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["visible"], True)
+
+    def test_visible_false_when_hidden(self):
+        room = Room.objects.create(uuid="r2", client="c1", data={"hidden": True})
+        token = self.make_token()
+        url = reverse("room-visible", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["visible"], False)
+
+    def test_requires_auth(self):
+        room = Room.objects.create(uuid="r3", client="c1")
+        url = reverse("room-visible", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -34,6 +34,7 @@ from .api_views import (
     PollOptionCreateView,
     RoomHideView,
     RoomShowView,
+    RoomVisibleView,
     ReactionDetailView,
     MuteStatusView,
     MessageRestoreView,
@@ -138,6 +139,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/show/",
         RoomShowView.as_view(),
         name="room-show",
+    ),
+    path(
+        "api/rooms/<str:room_uuid>/visible/",
+        RoomVisibleView.as_view(),
+        name="room-visible",
     ),
     path(
         "api/messages/<int:message_id>/",

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -104,7 +104,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | 🔲 |
 | **userToken**                                | ✅ | ✅ |
-| **visible**                                  | 🔲 | 🔲 |
+| **visible**                                  | ✅ | ✅ |
 | **watch**                                    | ✅ | ✅ |
 | **wsPromise**                                | 🔲 | 🔲 |
 

--- a/frontend/__tests__/adapter/visible.test.ts
+++ b/frontend/__tests__/adapter/visible.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('visible reflects hidden state changes', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  expect(channel.visible).toBe(true);
+
+  await channel.hide();
+  expect(channel.visible).toBe(false);
+
+  await channel.show();
+  expect(channel.visible).toBe(true);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -431,6 +431,9 @@ export class Channel {
     /** Whether this channel is hidden */
     get hidden() { return !!this.data.hidden; }
 
+    /** Whether this channel is visible */
+    get visible() { return !this.hidden; }
+
     /** Whether this channel has been truncated */
     get truncated() { return !!this.data.truncated; }
 


### PR DESCRIPTION
## Summary
- expose `visible` flag in `Channel`
- add backend endpoint to retrieve visibility state
- test visibility handling
- document new coverage status

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851de63f6e083268e19dbf004308711