### PR TITLE
Implement 'type' surface

### DIFF
--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -40,12 +40,16 @@ class RoomSerializer(serializers.ModelSerializer):
     messages = MessageSerializer(many=True, read_only=True)
     cid = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
 
     def get_cid(self, obj: Room) -> str:
         return f"messaging:{obj.uuid}"
 
     def get_name(self, obj: Room) -> str | None:
         return obj.data.get("name") if obj.data else None
+
+    def get_type(self, obj: Room) -> str:
+        return "messaging"
 
     class Meta:
         model = Room
@@ -54,6 +58,7 @@ class RoomSerializer(serializers.ModelSerializer):
             "uuid",
             "cid",
             "name",
+            "type",
             "client",
             "agent",
             "messages",

--- a/backend/chat/tests/test_room_type.py
+++ b/backend/chat/tests/test_room_type.py
@@ -1,0 +1,26 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class RoomTypeAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_room_list_includes_type(self):
+        Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-list")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data[0]["type"], "messaging")
+
+    def test_room_detail_includes_type(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-detail", kwargs={"uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["type"], "messaging")

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -94,7 +94,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **tokenManager**                             | ✅ | ✅ |
 | **truncate**                                 | ✅ | ✅ |
 | **truncated**                                | ✅ | ✅ |
-| **type**                                     | 🔲 | 🔲 |
+| **type**                                     | ✅ | ✅ |
 | **unarchive**                                | ✅ | ✅ |
 | **unmuteUser**                               | ✅ | ✅ |
 | **unpin**                                    | ✅ | ✅ |

--- a/frontend/__tests__/adapter/type.test.ts
+++ b/frontend/__tests__/adapter/type.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+test('channel.type is messaging', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  expect(channel.type).toBe('messaging');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -13,6 +13,8 @@ export class Channel {
     readonly id: number;
     readonly uuid!: string;
     readonly cid: string;
+    /** Channel type (always 'messaging' for now) */
+    readonly type: string;
     data: { name: string } & Record<string, unknown>;
 
     private roomUuid!: string;
@@ -417,7 +419,8 @@ export class Channel {
         this.id = id;
         this.uuid = uuid;
         this.roomUuid = uuid;
-        this.cid = `messaging:${this.uuid}`;
+        this.type = 'messaging';
+        this.cid = `${this.type}:${this.uuid}`;
         this.data = { name: roomName, ...extraData };
     }
 


### PR DESCRIPTION
## Summary
- expose `type` on frontend Channel
- support `type` field in RoomSerializer
- tests for Channel.type and API responses
- update checklist

## Testing
- `pnpm turbo build`
- `pnpm test` in frontend
- `python manage.py test chat`

------
https://chatgpt.com/codex/tasks/task_e_6851e3c4d1908326a589d1f8a5d1a574