### PR TITLE
feat(adapter): implement updateMessage surface

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -99,7 +99,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **unmuteUser**                               | ✅ | ✅ |
 | **unpin**                                    | ✅ | ✅ |
 | **unpinMessage**                             | ✅ | ✅ |
-| **updateMessage**                            | 🔲 | 🔲 |
+| **updateMessage**                            | ✅ | ✅ |
 | **updated**                                  | 🔲 | 🔲 |
 | **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/updateMessage.test.ts
+++ b/frontend/__tests__/adapter/updateMessage.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: async () => ({ id: 'm1', text: 'edited', user_id: 'u1', created_at: '2025-01-01T00:00:00Z' }),
+    })
+  );
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('updateMessage PUTs to backend and updates state', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  (channel.state as any).messages = [
+    { id: 'm1', text: 'old', user_id: 'u1', created_at: '2025-01-01T00:00:00Z' },
+  ];
+  (channel.state as any).latestMessages = [...(channel.state as any).messages];
+
+  const result = await channel.updateMessage('m1', 'edited');
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MESSAGES}m1/`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer jwt1',
+    },
+    body: JSON.stringify({ text: 'edited' }),
+  });
+
+  expect(channel.state.messages[0].text).toBe('edited');
+  expect(result.text).toBe('edited');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -688,6 +688,25 @@ export class Channel {
         return updated;
     }
 
+    /** Update a message's text */
+    async updateMessage(messageId: string, text: string) {
+        const res = await fetch(`${API.MESSAGES}${messageId}/`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.client['jwt']}`,
+            },
+            body: JSON.stringify({ text }),
+        });
+        if (!res.ok) throw new Error('updateMessage failed');
+        const updated = await res.json() as Message;
+        this.bump({
+            messages: this._state.messages.map(m => m.id === messageId ? updated : m),
+            latestMessages: this._state.latestMessages.map(m => m.id === messageId ? updated : m),
+        });
+        return updated;
+    }
+
     /** Restore a previously deleted message */
     async restore(messageId: string) {
         const res = await fetch(`${API.MESSAGES}${messageId}/restore/`, {


### PR DESCRIPTION
## Summary
- implement `updateMessage` in Channel adapter
- add unit test covering updateMessage
- mark updateMessage surface as complete in docs

## Testing
- `pnpm -r test`
- `pnpm -r build`


------
https://chatgpt.com/codex/tasks/task_e_6851e7bba354832681f4e0f8fc442d5d