### PR TITLE
feat(adapter): add wsPromise handshake

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -727,3 +727,13 @@ class TextComposerView(APIView):
     def post(self, request):
         text = request.data.get("text", "")
         return Response({"text": text})
+
+
+class WsAuthView(APIView):
+    """Simple handshake endpoint for websocket connections."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        return Response({"status": "ok"})

--- a/backend/chat/tests/test_ws_auth.py
+++ b/backend/chat/tests/test_ws_auth.py
@@ -1,0 +1,26 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class WsAuthAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_ws_auth_ok(self):
+        token = self.make_token()
+        url = reverse("ws-auth")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, {"status": "ok"})
+
+    def test_ws_auth_requires_auth(self):
+        url = reverse("ws-auth")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_ws_auth_wrong_method(self):
+        token = self.make_token()
+        url = reverse("ws-auth")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -45,6 +45,7 @@ from .api_views import (
     RecoverStateView,
     TextComposerView,
     SubarrayView,
+    WsAuthView,
 )
 
 router = DefaultRouter()
@@ -227,4 +228,5 @@ urlpatterns = [
     path("api/recover-state/", RecoverStateView.as_view(), name="recover-state"),
     path("api/text-composer/", TextComposerView.as_view(), name="text-composer"),
     path("api/subarray/", SubarrayView.as_view(), name="subarray"),
+    path("api/ws-auth/", WsAuthView.as_view(), name="ws-auth"),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -106,7 +106,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **userToken**                                | ✅ | ✅ |
 | **visible**                                  | 🔲 | 🔲 |
 | **watch**                                    | ✅ | ✅ |
-| **wsPromise**                                | 🔲 | 🔲 |
+| **wsPromise**                                | ✅ | ✅ |
 
 ### How to tick items
 * When a **front-end shim** is fully implemented & covered by tests → change the adapter column to **✅**.

--- a/frontend/__tests__/adapter/wsPromise.test.ts
+++ b/frontend/__tests__/adapter/wsPromise.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('wsPromise is set and awaited during connectUser', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  await client.connectUser({ id: 'u1' }, 'jwt1');
+
+  expect(client.wsPromise).toBeInstanceOf(Promise);
+  expect(global.fetch).toHaveBeenCalledWith(API.SYNC_USER, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(global.fetch).toHaveBeenCalledWith(API.WS_AUTH, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -29,6 +29,8 @@ export class ChatClient {
     disconnected = true;
     /** Whether the client finished initialization */
     initialized = false;
+    /** Promise resolving when websocket auth completes */
+    wsPromise: Promise<void> | null = null;
 
     private userAgent = 'custom-chat-client/0.0.1 stream-chat-react-adapter';
     tokenManager: TokenManager;
@@ -230,6 +232,10 @@ export class ChatClient {
             this._user = body;
             this.state.users[String(body.id)] = body;
         }
+        this.wsPromise = fetch(API.WS_AUTH, {
+            headers: { Authorization: `Bearer ${token}` },
+        }).then(() => undefined);
+        await this.wsPromise;
         this.connectionId = crypto.randomUUID();
         this.initialized = true;
         this.disconnected = false;

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -23,6 +23,7 @@ export const API = {
   RECOVER_STATE: '/api/recover-state/',
   REFRESH_TOKEN: '/api/refresh-token/',
   SUBARRAY: '/api/subarray/',
+  WS_AUTH: '/api/ws-auth/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- implement wsPromise on ChatClient
- add WS_AUTH API constant
- create backend ws-auth endpoint with tests
- test wsPromise behavior in the adapter
- update surface checklist

## Testing
- `pnpm turbo build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851ed1d9af883268cc86bc02ab76033