### PR TITLE
feat(adapter): implement visible property

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -104,7 +104,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | 🔲 |
 | **userToken**                                | ✅ | ✅ |
-| **visible**                                  | 🔲 | 🔲 |
+| **visible**                                  | ✅ | 🔲 |
 | **watch**                                    | ✅ | ✅ |
 | **wsPromise**                                | ✅ | ✅ |
 

--- a/frontend/__tests__/adapter/visible.test.ts
+++ b/frontend/__tests__/adapter/visible.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('channel.visible reflects hidden status', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  expect(channel.visible).toBe(true);
+
+  await channel.hide();
+  expect(channel.visible).toBe(false);
+
+  await channel.show();
+  expect(channel.visible).toBe(true);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -434,6 +434,9 @@ export class Channel {
     /** Whether this channel is hidden */
     get hidden() { return !!this.data.hidden; }
 
+    /** Whether this channel is visible */
+    get visible() { return !this.hidden; }
+
     /** Whether this channel has been truncated */
     get truncated() { return !!this.data.truncated; }
 


### PR DESCRIPTION
## Summary
- expose `channel.visible` based on hidden flag
- test visibility logic
- update adapter checklist

## Testing
- `pnpm turbo build`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6851f2a4638c83268d764e27ca374b47