### PR TITLE
Implement clear surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -193,6 +193,11 @@ class RoomDraftView(APIView):
         draft = Draft.objects.filter(user=request.user, room=room).first()
         return Response({"text": draft.text if draft else ""})
 
+    def delete(self, request, room_uuid):
+        room = get_object_or_404(Room, uuid=room_uuid)
+        Draft.objects.filter(user=request.user, room=room).delete()
+        return Response({"status": "ok"})
+
 
 class MessageDetailView(APIView):
     """Retrieve, update or delete a single message."""

--- a/backend/chat/tests/test_delete_draft.py
+++ b/backend/chat/tests/test_delete_draft.py
@@ -1,0 +1,29 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Draft
+
+class DeleteDraftAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_delete_draft(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+        self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(Draft.objects.filter(room=room, user__username="u1").count(), 1)
+
+        res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["status"], "ok")
+        self.assertEqual(Draft.objects.filter(room=room).count(), 0)
+
+    def test_delete_draft_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, 403)
+

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -10,7 +10,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **axiosInstance**                            | ✅ | 🔲 |
 | **cid**                                      | ✅ | ✅ |
 | **channel**                                  | ✅ | ✅ |
-| **clear**                                    | 🔲 | 🔲 |
+| **clear**                                    | ✅ | ✅ |
 | **clientID**                                 | ✅ | 🔲 |
 | **compose**                                  | ✅ | 🔲 |
 | **compositionIsEmpty**                       | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/clear.test.ts
+++ b/frontend/__tests__/adapter/clear.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+  (global as any).localStorage = { removeItem: vi.fn() };
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  delete (global as any).localStorage;
+  vi.restoreAllMocks();
+});
+
+test('clear resets composer and deletes draft', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  const comp: any = channel.messageComposer;
+
+  comp.textComposer.setText('hello');
+  comp.customDataManager.set('foo', 1);
+
+  comp.clear();
+
+  expect(comp.textComposer.state.getSnapshot().text).toBe('');
+  expect(comp.customDataManager.state.getSnapshot().customData).toEqual({});
+  expect(global.fetch).toHaveBeenCalledWith(`${API.ROOMS}room1/draft/`, {
+    method: 'DELETE',
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+});
+

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -391,6 +391,18 @@ export class Channel {
                         this.setEditedMessage(undefined);
                     }
                 },
+
+                /** Clear composer state and discard any stored draft */
+                clear() {
+                    this.initState();
+                    const token = channelRef.client['jwt'];
+                    if (token) {
+                        fetch(`/api/rooms/${channelRef.uuid}/draft/`, {
+                            method: 'DELETE',
+                            headers: { Authorization: `Bearer ${token}` },
+                        }).catch(() => { /* ignore network errors */ });
+                    }
+                },
             };
         })(),   // end of IIFE
     };         // ←———————— END of _state object


### PR DESCRIPTION
## Summary
- support `messageComposer.clear` in adapter
- delete drafts via DELETE endpoint
- cover clear with frontend and backend tests
- update TODO list

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_6851f8330c0883269fc8b84b7b6e099b