### PR TITLE
feat(adapter): expose draft property

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -31,7 +31,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **disconnectUser**                           | ✅ | ✅ |
 | **disconnected**                             | ✅ | 🔲 |
 | **dispatchEvent**                            | ✅ | 🔲 |
-| **draft**                                    | 🔲 | 🔲 |
+| **draft**                                    | ✅ | 🔲 |
 | **editedMessage**                            | 🔲 | 🔲 |
 | **editingAuditState**                        | 🔲 | 🔲 |
 | **editedMessage**                            | ✅ | ✅ |

--- a/frontend/__tests__/adapter/draft.test.ts
+++ b/frontend/__tests__/adapter/draft.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+/** Ensure draft getter/setter mirror text composer */
+test('draft property mirrors text composer', () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  // default empty
+  expect(channel.messageComposer.draft).toBe('');
+
+  channel.messageComposer.textComposer.setText('hello');
+  expect(channel.messageComposer.draft).toBe('hello');
+
+  channel.messageComposer.draft = 'bye';
+  expect(channel.messageComposer.textComposer.state.getSnapshot().text).toBe('bye');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -309,6 +309,10 @@ export class Channel {
                 },
                 discardDraft() { localStorage.removeItem(getRoomKey()); logDraftUpdateTimestamp(); },
 
+                /** Current draft text */
+                get draft() { return textStore.getSnapshot().text; },
+                set draft(v: string) { textStore._set({ text: v }); },
+
                 // pollComposer: {
                 // state: new MiniStore({            // shape is all Stream-UI needs
                 //     question: '', options: [] as any[],


### PR DESCRIPTION
## Summary
- expose `draft` getter and setter in the message composer
- test `draft` property behaviour
- mark adapter draft row as done in docs

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_6851fb725458832691bf05a28580b913