### PR TITLE
Implement draft retrieval API in adapter

### DIFF
--- a/backend/chat/tests/test_create_draft.py
+++ b/backend/chat/tests/test_create_draft.py
@@ -34,3 +34,11 @@ class CreateDraftAPITests(APITestCase):
         url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
         res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 405)
+
+    def test_get_empty_draft(self):
+        room = Room.objects.create(uuid="r2", client="c1")
+        token = self.make_token()
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["text"], "")

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -31,7 +31,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **disconnectUser**                           | ✅ | ✅ |
 | **disconnected**                             | ✅ | 🔲 |
 | **dispatchEvent**                            | ✅ | 🔲 |
-| **draft**                                    | ✅ | 🔲 |
+| **draft**                                    | ✅ | ✅ |
 | **editedMessage**                            | 🔲 | 🔲 |
 | **editingAuditState**                        | 🔲 | 🔲 |
 | **editedMessage**                            | ✅ | ✅ |

--- a/frontend/__tests__/adapter/getDraft.test.ts
+++ b/frontend/__tests__/adapter/getDraft.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getDraft fetches saved draft and updates text', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => ({ text: 'hello' }),
+  });
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+
+  const text = await (channel.messageComposer as any).getDraft();
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/draft/', {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(text).toBe('hello');
+  expect(channel.messageComposer.textComposer.state.getSnapshot().text).toBe('hello');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -313,6 +313,20 @@ export class Channel {
                 get draft() { return textStore.getSnapshot().text; },
                 set draft(v: string) { textStore._set({ text: v }); },
 
+                /** Fetch draft from the backend and sync local state */
+                async getDraft() {
+                    const token = channelRef.client['jwt'];
+                    if (!token) return '';
+                    const res = await fetch(`/api/rooms/${channelRef.uuid}/draft/`, {
+                        headers: { Authorization: `Bearer ${token}` },
+                    });
+                    if (!res.ok) throw new Error('getDraft failed');
+                    const data = await res.json().catch(() => ({ text: '' }));
+                    const text = typeof data.text === 'string' ? data.text : '';
+                    textStore._set({ text });
+                    return text;
+                },
+
                 // pollComposer: {
                 // state: new MiniStore({            // shape is all Stream-UI needs
                 //     question: '', options: [] as any[],


### PR DESCRIPTION
## Summary
- add `getDraft()` method to Channel messageComposer to fetch draft from backend
- test draft retrieval in adapter
- test empty draft retrieval in backend API
- update draft row in adapter todo checklist

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`


------
https://chatgpt.com/codex/tasks/task_e_6851ff00bcc08326aadc441b6497fd76