### PR TITLE
Implement configState surface

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -418,6 +418,19 @@ class RoomConfigView(APIView):
             }
         )
 
+class RoomConfigStateView(APIView):
+    """Return message composer configuration for the room."""
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+    def get(self, request, room_uuid):
+        get_object_or_404(Room, uuid=room_uuid)
+        return Response({
+            "attachments": {"acceptedFiles": [], "maxNumberOfFilesPerMessage": 10},
+            "text": {"enabled": True},
+            "multipleUploads": True,
+            "isUploadEnabled": True,
+        })
+
 
 class RoomArchiveView(APIView):
     """Archive a room by setting its status to CLOSED."""

--- a/backend/chat/tests/test_config_state.py
+++ b/backend/chat/tests/test_config_state.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class ConfigStateAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_get_config_state_returns_defaults(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-config-state", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, {
+            "attachments": {"acceptedFiles": [], "maxNumberOfFilesPerMessage": 10},
+            "text": {"enabled": True},
+            "multipleUploads": True,
+            "isUploadEnabled": True,
+        })
+
+    def test_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-config-state", kwargs={"room_uuid": room.uuid})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-config-state", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -13,6 +13,7 @@ from .api_views import (
     MessageDetailView,
     MessageRepliesView,
     MessageReactionsView,
+    RoomConfigStateView,
     MessageFlagView,
     MessagePinView,
     MessageUnpinView,
@@ -96,6 +97,7 @@ urlpatterns = [
         RoomConfigView.as_view(),
         name="room-config",
     ),
+    path("api/rooms/<str:room_uuid>/config-state/", RoomConfigStateView.as_view(), name="room-config-state"),
     path(
         "api/rooms/<str:room_uuid>/cooldown/",
         RoomCooldownView.as_view(),

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -15,7 +15,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **compose**                                  | ✅ | 🔲 |
 | **compositionIsEmpty**                       | ✅ | 🔲 |
 | **config**                                   | ✅ | 🔲 |
-| **configState**                              | 🔲 | 🔲 |
+| **configState**                              | ✅ | ✅ |
 | **connectUser**                              | ✅ | ✅ |
 | **connectionId**                             | ✅ | 🔲 |
 | **contextType**                              | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/configState.test.ts
+++ b/frontend/__tests__/adapter/configState.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('getConfigState fetches config and updates store', async () => {
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => ({ text: { enabled: false } }),
+  });
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  const cfg = await (channel.messageComposer as any).getConfigState();
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/config-state/', {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(cfg.text.enabled).toBe(false);
+  expect(channel.messageComposer.configState.getSnapshot().text.enabled).toBe(false);
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -352,6 +352,16 @@ export class Channel {
                     isUploadEnabled: true,
                 }),
                 get config() { return this.configState.getLatestValue(); },
+                async getConfigState() {
+                    const token = channelRef.client["jwt"];
+                    const res = await fetch(`/api/rooms/${channelRef.uuid}/config-state/`, {
+                        headers: { Authorization: `Bearer ${token}` },
+                    });
+                    if (!res.ok) throw new Error("getConfigState failed");
+                    const data = await res.json().catch(() => ({}));
+                    this.configState._set(data);
+                    return this.configState.getLatestValue();
+                },
 
                 /* ——— simple passthrough helpers ——— */
                 getInputValue() { return textStore.getSnapshot().text; },


### PR DESCRIPTION
## Summary
- add backend endpoint to provide composer config state
- expose `getConfigState` on adapter channels
- test adapter and backend
- mark configState complete in todo

## Testing
- `pnpm turbo build`
- `pnpm turbo test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68520f9c537c8326abe62ddde6760f50