### PR TITLE
feat(adapter): implement editedMessage surface

### DIFF
--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -32,7 +32,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **disconnected**                             | ✅ | 🔲 |
 | **dispatchEvent**                            | ✅ | 🔲 |
 | **draft**                                    | ✅ | ✅ |
-| **editedMessage**                            | 🔲 | 🔲 |
+| **editedMessage**                            | ✅ | ✅ |
 | **editingAuditState**                        | 🔲 | 🔲 |
 | **editedMessage**                            | ✅ | ✅ |
 | **editingAuditState**                        | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/editedMessage_fetch.test.ts
+++ b/frontend/__tests__/adapter/editedMessage_fetch.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: async () => ({
+        id: 'm1',
+        text: 'edited',
+        user_id: 'u1',
+        created_at: '2025-01-01T00:00:00Z',
+      }),
+    })
+  );
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+test('editedMessage fetches message and updates state', async () => {
+  const client = new ChatClient('u1', 'jwt1');
+  const channel = client.channel('messaging', 'room1');
+  (channel.state as any).messages = [
+    { id: 'm1', text: 'old', user_id: 'u1', created_at: '2025-01-01T00:00:00Z' },
+  ];
+  (channel.state as any).latestMessages = [...(channel.state as any).messages];
+
+  const msg = await (channel as any).editedMessage('m1');
+
+  expect(global.fetch).toHaveBeenCalledWith(`${API.MESSAGES}m1/`, {
+    headers: { Authorization: 'Bearer jwt1' },
+  });
+  expect(channel.state.messages[0].text).toBe('edited');
+  expect(msg.id).toBe('m1');
+});

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -745,6 +745,20 @@ export class Channel {
         return updated;
     }
 
+    /** Fetch a single message by id and update local state */
+    async editedMessage(messageId: string) {
+        const res = await fetch(`${API.MESSAGES}${messageId}/`, {
+            headers: { Authorization: `Bearer ${this.client['jwt']}` },
+        });
+        if (!res.ok) throw new Error('editedMessage failed');
+        const msg = await res.json() as Message;
+        this.bump({
+            messages: this._state.messages.map(m => m.id === messageId ? msg : m),
+            latestMessages: this._state.latestMessages.map(m => m.id === messageId ? msg : m),
+        });
+        return msg;
+    }
+
     /** Restore a previously deleted message */
     async restore(messageId: string) {
         const res = await fetch(`${API.MESSAGES}${messageId}/restore/`, {


### PR DESCRIPTION
## Summary
- add `editedMessage` method to Channel
- test `editedMessage` fetching logic
- mark `editedMessage` row as done in docs

## Testing
- `pnpm turbo run build test`

------
https://chatgpt.com/codex/tasks/task_e_685213c8ebf083269ec73bde17641191