### PR TITLE
feat(adapter): implement updated surface

### DIFF
--- a/backend/chat/migrations/0014_message_updated_at.py
+++ b/backend/chat/migrations/0014_message_updated_at.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0013_merge_0010_poll_0011_merge_room_mute_0012_reminder"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="message",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True, null=True, blank=True),
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -9,6 +9,7 @@ class Message(models.Model):
     body = models.TextField()
     sent_by = models.CharField(max_length=255)
     created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
     deleted_at = models.DateTimeField(null=True, blank=True)
     custom_data = models.JSONField(default=dict, blank=True)
     reply_to = models.ForeignKey(

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -25,13 +25,14 @@ class MessageSerializer(serializers.ModelSerializer):
             "body",
             "sent_by",
             "created_at",
+            "updated_at",
             "deleted_at",
             "custom_data",
             "created_by",
             "reply_to",
             "event",
         ]
-        read_only_fields = ["id", "created_at", "created_by"]
+        read_only_fields = ["id", "created_at", "updated_at", "created_by"]
 
     def get_event(self, obj):
         return obj.custom_data.get("event")

--- a/backend/chat/tests/test_message_updated.py
+++ b/backend/chat/tests/test_message_updated.py
@@ -1,0 +1,30 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+from django.utils import timezone
+
+from chat.models import Room, Message
+
+class MessageUpdatedAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_update_message_sets_timestamp(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        room.messages.add(msg)
+        token = self.make_token()
+        url = reverse("message-detail", kwargs={"message_id": msg.id})
+        before = msg.updated_at
+        res = self.client.put(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        msg.refresh_from_db()
+        self.assertGreater(msg.updated_at, before)
+        self.assertEqual(res.data["updated_at"].split("T")[0], msg.updated_at.isoformat().split("T")[0])
+
+    def test_update_message_requires_auth(self):
+        msg = Message.objects.create(body="hi", sent_by="u1")
+        url = reverse("message-detail", kwargs={"message_id": msg.id})
+        res = self.client.put(url, {"text": "x"}, format="json")
+        self.assertEqual(res.status_code, 403)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -100,7 +100,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **unpin**                                    | ✅ | ✅ |
 | **unpinMessage**                             | ✅ | ✅ |
 | **updateMessage**                            | ✅ | ✅ |
-| **updated**                                  | 🔲 | 🔲 |
+| **updated**                                  | ✅ | ✅ |
 | **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | 🔲 |
 | **userToken**                                | ✅ | ✅ |

--- a/frontend/__tests__/adapter/updateMessage.test.ts
+++ b/frontend/__tests__/adapter/updateMessage.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   global.fetch = vi.fn(() =>
     Promise.resolve({
       ok: true,
-      json: async () => ({ id: 'm1', text: 'edited', user_id: 'u1', created_at: '2025-01-01T00:00:00Z' }),
+      json: async () => ({ id: 'm1', text: 'edited', user_id: 'u1', created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:01:00Z' }),
     })
   );
 });
@@ -38,5 +38,7 @@ test('updateMessage PUTs to backend and updates state', async () => {
   });
 
   expect(channel.state.messages[0].text).toBe('edited');
+  expect(channel.state.messages[0].updated_at).toBe('2025-01-01T00:01:00Z');
   expect(result.text).toBe('edited');
+  expect(result.updated_at).toBe('2025-01-01T00:01:00Z');
 });

--- a/frontend/__tests__/adapter/watch.test.ts
+++ b/frontend/__tests__/adapter/watch.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 
 test('watch fetches messages and opens websocket', async () => {
   const messages = [
-    { id: 'm1', text: 'hi', user_id: 'u2', created_at: '2025-01-01T00:00:00Z' },
+    { id: 'm1', text: 'hi', user_id: 'u2', created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' },
   ];
   (global.fetch as any).mockResolvedValue({ ok: true, json: async () => messages });
 
@@ -32,6 +32,7 @@ test('watch fetches messages and opens websocket', async () => {
   });
   expect(channel.initialized).toBe(true);
   expect(channel.state.latestMessages).toEqual(messages);
+  expect(channel.state.latestMessages[0].updated_at).toBe('2025-01-01T00:00:00Z');
   expect((global as any).WebSocket).toHaveBeenCalledWith(
     'ws://localhost:8000/ws/room1/?token=jwt1'
   );

--- a/frontend/src/lib/stream-adapter/types.ts
+++ b/frontend/src/lib/stream-adapter/types.ts
@@ -14,6 +14,7 @@ export interface Message {
   text: string;
   user_id: string;
   created_at: string;
+  updated_at?: string;
   event?: Record<string, unknown>;
   deleted_at?: string;
 }


### PR DESCRIPTION
## Summary
- add `updated_at` field to `Message` model and serializer
- expose `updated_at` in the adapter's `Message` type
- return timestamps from update and watch calls
- test message update timestamps
- document completion of `updated` surface

## Testing
- `pnpm turbo build`
- `pnpm turbo test`
- `cd backend && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68521611bb24832684c8b4248a240d1b