### PR TITLE
Implement axiosInstance backend

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -772,6 +772,22 @@ class EditingAuditStateView(APIView):
         return Response({"draft_update": draft_update, "state_update": state_update})
 
 
+class AxiosTestView(APIView):
+    """Simple endpoint used by axiosInstance tests."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        return Response({"method": "GET"})
+
+    def post(self, request):
+        return Response({"method": "POST", "data": request.data})
+
+    def delete(self, request):
+        return Response({"method": "DELETE"})
+
+
 class WsAuthView(APIView):
     """Simple handshake endpoint for websocket connections."""
 

--- a/backend/chat/tests/test_axios_instance.py
+++ b/backend/chat/tests/test_axios_instance.py
@@ -1,0 +1,47 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class AxiosInstanceAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_get_returns_method(self):
+        token = self.make_token()
+        url = reverse("axios-test")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["method"], "GET")
+
+    def test_post_echoes_data(self):
+        token = self.make_token()
+        url = reverse("axios-test")
+        res = self.client.post(
+            url,
+            {"a": 1},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["method"], "POST")
+        self.assertEqual(res.data["data"], {"a": 1})
+
+    def test_delete_ok(self):
+        token = self.make_token()
+        url = reverse("axios-test")
+        res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["method"], "DELETE")
+
+    def test_requires_auth(self):
+        url = reverse("axios-test")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        token = self.make_token()
+        url = reverse("axios-test")
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)
+

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -48,6 +48,7 @@ from .api_views import (
     TextComposerView,
     EditingAuditStateView,
     SubarrayView,
+    AxiosTestView,
     WsAuthView,
 )
 
@@ -234,5 +235,6 @@ urlpatterns = [
     path("api/text-composer/", TextComposerView.as_view(), name="text-composer"),
     path("api/editing-audit-state/", EditingAuditStateView.as_view(), name="editing-audit-state"),
     path("api/subarray/", SubarrayView.as_view(), name="subarray"),
+    path("api/test/", AxiosTestView.as_view(), name="axios-test"),
     path("api/ws-auth/", WsAuthView.as_view(), name="ws-auth"),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -7,7 +7,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **activeChannels**                           | ✅ | ✅ |
 | **archive**                                  | ✅ | ✅ |
 | **attachmentManager**                        | ✅ | ✅ |
-| **axiosInstance**                            | ✅ | 🔲 |
+| **axiosInstance**                            | ✅ | ✅ |
 | **cid**                                      | ✅ | ✅ |
 | **channel**                                  | ✅ | ✅ |
 | **clear**                                    | ✅ | ✅ |


### PR DESCRIPTION
## Summary
- add axios test endpoint in Django backend
- route axios test endpoint
- cover axios test endpoint with unit tests
- mark axiosInstance backend complete in docs

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python backend/manage.py test chat`

------
https://chatgpt.com/codex/tasks/task_e_685225e725948326b29fccb3917898e0