### PR TITLE
feat(adapter): implement backend clientID endpoint

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,11 +1,12 @@
 #accounts/urls.py
 from django.urls import path
-from .views import SyncUserView, SessionView, QueryUsersView, UserAgentView, CurrentUserView
+from .views import SyncUserView, SessionView, ClientIDView, QueryUsersView, UserAgentView, CurrentUserView
 from .views import RefreshTokenView
 
 urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
     path('api/session/', SessionView.as_view(), name='session'),
+    path('api/client-id/', ClientIDView.as_view(), name='client-id'),
     path('api/users/', QueryUsersView.as_view(), name='query-users'),
     path('api/user-agent/', UserAgentView.as_view(), name='user-agent'),
     path('api/user/', CurrentUserView.as_view(), name='user'),

--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -9,6 +9,7 @@ from accounts_supabase.models import UserProfile
 from django.utils import timezone
 from django.conf import settings
 import jwt
+import uuid
 
 class SyncUserView(APIView):
     # explicitly setting here again as sanity check
@@ -29,6 +30,16 @@ class SessionView(APIView):
         # Log timestamp for debugging stale tokens
         print(f"disconnect at {timezone.now()} for {request.user}")
         return Response(status=204)
+
+
+class ClientIDView(APIView):
+    """Return a random client identifier."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({"client_id": uuid.uuid4().hex})
 
 
 class UserAgentView(APIView):

--- a/backend/chat/tests/test_client_id.py
+++ b/backend/chat/tests/test_client_id.py
@@ -1,0 +1,27 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class ClientIDAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_client_id_returns_value(self):
+        token = self.make_token()
+        url = reverse("client-id")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        cid = res.data["client_id"]
+        self.assertTrue(isinstance(cid, str) and len(cid) > 0)
+
+    def test_client_id_requires_auth(self):
+        url = reverse("client-id")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_client_id_wrong_method(self):
+        token = self.make_token()
+        url = reverse("client-id")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -11,7 +11,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **cid**                                      | ✅ | ✅ |
 | **channel**                                  | ✅ | ✅ |
 | **clear**                                    | ✅ | ✅ |
-| **clientID**                                 | ✅ | 🔲 |
+| **clientID**                                 | ✅ | ✅ |
 | **compose**                                  | ✅ | 🔲 |
 | **compositionIsEmpty**                       | ✅ | 🔲 |
 | **config**                                   | ✅ | 🔲 |

--- a/frontend/__tests__/adapter/clientID.test.ts
+++ b/frontend/__tests__/adapter/clientID.test.ts
@@ -5,8 +5,10 @@ import { API } from '../../src/lib/stream-adapter/constants';
 const originalFetch = global.fetch;
 
 beforeEach(() => {
-  // Stub out network call the adapter makes during connectUser
-  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ client_id: 'x123' }) })
+    .mockResolvedValue({ ok: true, json: async () => ({}) });
 });
 
 afterEach(() => {
@@ -21,6 +23,7 @@ test('clientID generated on connectUser includes user id', async () => {
   // clientID should now start with the user id and a separator
   expect(client.clientID).toMatch(/^u1--/);
 
-  // make sure the sync call was fired
+  expect(global.fetch).toHaveBeenCalledWith(API.CLIENT_ID, expect.anything());
   expect(global.fetch).toHaveBeenCalledWith(API.SYNC_USER, expect.anything());
+  expect(client.clientID).toBe('u1--x123');
 });

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -219,6 +219,19 @@ export class ChatClient {
         await this.tokenManager.setTokenOrProvider(token);
         (this as any).user = { id: user.id };
         this.clientID = `${user.id}--${randomId()}`;
+        try {
+            const cidRes = await fetch(API.CLIENT_ID, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            if (cidRes.ok) {
+                const cidBody = await cidRes.json().catch(() => null);
+                if (cidBody && cidBody.client_id) {
+                    this.clientID = `${user.id}--${cidBody.client_id}`;
+                }
+            }
+        } catch {
+            /* ignore network errors */
+        }
         const res = await fetch(API.SYNC_USER, {
             method: 'POST',
             headers: {

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -1,6 +1,7 @@
 export const API = {
   SYNC_USER: '/api/sync-user/',
   SESSION: '/api/session/',
+  CLIENT_ID: '/api/client-id/',
   ROOMS: '/api/rooms/',
   ACTIVE_ROOMS: '/api/rooms/active/',
   MESSAGES: '/api/messages/',


### PR DESCRIPTION
## Summary
- add API.CLIENT_ID constant and use it in ChatClient.connectUser
- implement ClientIDView and url in backend
- test adapter behavior for clientID
- test ClientIDView
- mark clientID complete in adapter-todo

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6852292a18108326aa3a82d5dc9dde29