### PR TITLE
feat(adapter): implement connectionId endpoint (task)

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -818,3 +818,13 @@ class WsAuthView(APIView):
 
     def get(self, request):
         return Response({"status": "ok"})
+
+
+class ConnectionIDView(APIView):
+    """Return a random connection identifier."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        return Response({"connection_id": uuid.uuid4().hex})

--- a/backend/chat/tests/test_connection_id.py
+++ b/backend/chat/tests/test_connection_id.py
@@ -1,0 +1,28 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class ConnectionIDAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_connection_id_returns_value(self):
+        token = self.make_token()
+        url = reverse("connection-id")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        cid = res.data["connection_id"]
+        self.assertTrue(isinstance(cid, str) and len(cid) > 0)
+
+    def test_connection_id_requires_auth(self):
+        url = reverse("connection-id")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_connection_id_wrong_method(self):
+        token = self.make_token()
+        url = reverse("connection-id")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)
+

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -51,6 +51,7 @@ from .api_views import (
     CompositionIsEmptyView,
     SubarrayView,
     AxiosTestView,
+    ConnectionIDView,
     WsAuthView,
 )
 
@@ -240,5 +241,6 @@ urlpatterns = [
     path("api/editing-audit-state/", EditingAuditStateView.as_view(), name="editing-audit-state"),
     path("api/subarray/", SubarrayView.as_view(), name="subarray"),
     path("api/test/", AxiosTestView.as_view(), name="axios-test"),
+    path("api/connection-id/", ConnectionIDView.as_view(), name="connection-id"),
     path("api/ws-auth/", WsAuthView.as_view(), name="ws-auth"),
 ]

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -17,7 +17,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **config**                                   | ✅ | ✅ |
 | **configState**                              | ✅ | ✅ |
 | **connectUser**                              | ✅ | ✅ |
-| **connectionId**                             | ✅ | 🔲 |
+| **connectionId**                             | ✅ | ✅ |
 | **contextType**                              | ✅ | 🔲 |
 | **cooldown**                                 | ✅ | ✅ |
 | **countUnread**                              | ✅ | ✅ |

--- a/frontend/__tests__/adapter/connectionId.test.ts
+++ b/frontend/__tests__/adapter/connectionId.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
+import { API } from '../../src/lib/stream-adapter/constants';
 
 const originalFetch = global.fetch;
 
 beforeEach(() => {
-  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    .mockResolvedValue({ ok: true, json: async () => ({ connection_id: 'c123' }) });
 });
 
 afterEach(() => {
@@ -15,7 +19,8 @@ afterEach(() => {
 test('connectUser sets connectionId', async () => {
   const client = new ChatClient('u1', 'jwt1');
   await client.connectUser({ id: 'u1' }, 'jwt1');
-  expect(client.connectionId).not.toBeNull();
+  expect(global.fetch).toHaveBeenCalledWith(API.CONNECTION_ID, expect.anything());
+  expect(client.connectionId).toBe('c123');
 });
 
 test('disconnectUser clears connectionId', () => {

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -249,7 +249,22 @@ export class ChatClient {
             headers: { Authorization: `Bearer ${token}` },
         }).then(() => undefined);
         await this.wsPromise;
-        this.connectionId = crypto.randomUUID();
+        try {
+            const cidRes = await fetch(API.CONNECTION_ID, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            if (cidRes.ok) {
+                const cidBody = await cidRes.json().catch(() => null);
+                if (cidBody && cidBody.connection_id) {
+                    this.connectionId = cidBody.connection_id;
+                }
+            }
+        } catch {
+            /* ignore network errors */
+        }
+        if (!this.connectionId) {
+            this.connectionId = crypto.randomUUID();
+        }
         this.initialized = true;
         this.disconnected = false;
         this.emit('connection.changed', { online: true });

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -2,6 +2,7 @@ export const API = {
   SYNC_USER: '/api/sync-user/',
   SESSION: '/api/session/',
   CLIENT_ID: '/api/client-id/',
+  CONNECTION_ID: '/api/connection-id/',
   ROOMS: '/api/rooms/',
   ACTIVE_ROOMS: '/api/rooms/active/',
   MESSAGES: '/api/messages/',


### PR DESCRIPTION
## Summary
- add API.CONNECTION_ID constant
- fetch connection ID in ChatClient
- expose `ConnectionIDView` in backend
- test connectionId API and adapter behaviour
- update TODO

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python backend/manage.py test chat.tests.test_connection_id`


------
https://chatgpt.com/codex/tasks/task_e_6852365836308326990b5cc6306daf34