### PR TITLE
feat(adapter): implement disconnected backend

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,7 +1,7 @@
 #accounts/urls.py
 from django.urls import path
 from .views import SyncUserView, SessionView, ClientIDView, QueryUsersView, UserAgentView, CurrentUserView
-from .views import RefreshTokenView
+from .views import RefreshTokenView, DisconnectedView
 
 urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
@@ -11,4 +11,5 @@ urlpatterns = [
     path('api/user-agent/', UserAgentView.as_view(), name='user-agent'),
     path('api/user/', CurrentUserView.as_view(), name='user'),
     path('api/refresh-token/', RefreshTokenView.as_view(), name='refresh-token'),
+    path('api/disconnected/', DisconnectedView.as_view(), name='disconnected'),
 ]

--- a/backend/chat/tests/test_disconnected.py
+++ b/backend/chat/tests/test_disconnected.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class DisconnectedAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_state_toggles_via_session(self):
+        token = self.make_token()
+        # connect user -> sets disconnected False
+        self.client.post(reverse("sync-user"), HTTP_AUTHORIZATION=f"Bearer {token}")
+        url = reverse("disconnected")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.data["disconnected"])
+
+        # disconnect user -> sets disconnected True
+        self.client.delete(reverse("session"), HTTP_AUTHORIZATION=f"Bearer {token}")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.data["disconnected"])
+
+    def test_requires_auth(self):
+        url = reverse("disconnected")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        token = self.make_token()
+        url = reverse("disconnected")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -29,7 +29,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **deleteReaction**                           | ✅ | ✅ |
 | **deleted**                                  | ✅ | ✅ |
 | **disconnectUser**                           | ✅ | ✅ |
-| **disconnected**                             | ✅ | 🔲 |
+| **disconnected**                             | ✅ | ✅ |
 | **dispatchEvent**                            | ✅ | 🔲 |
 | **draft**                                    | ✅ | ✅ |
 | **editedMessage**                            | ✅ | ✅ |

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -28,6 +28,7 @@ export const API = {
   EDITING_AUDIT_STATE: '/api/editing-audit-state/',
   WS_AUTH: '/api/ws-auth/',
   ATTACHMENTS: '/api/attachments/',
+  DISCONNECTED: '/api/disconnected/',
 } as const;
 
 export const EVENTS = {


### PR DESCRIPTION
## Summary
- add `DISCONNECTED` API route constant
- track disconnect state in session and expose new `/api/disconnected/` endpoint
- include Django tests for the new endpoint
- update TODO checklist

## Testing
- `pnpm turbo run build`
- `pnpm turbo run test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685247db69288326816a830aed553079