### PR TITLE
Implement initialized API surface

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,7 +1,7 @@
 #accounts/urls.py
 from django.urls import path
 from .views import SyncUserView, SessionView, ClientIDView, QueryUsersView, UserAgentView, CurrentUserView
-from .views import RefreshTokenView, DisconnectedView
+from .views import RefreshTokenView, DisconnectedView, InitializedView
 
 urlpatterns = [
     path('api/sync-user/', SyncUserView.as_view(), name='sync-user'),
@@ -12,4 +12,5 @@ urlpatterns = [
     path('api/user/', CurrentUserView.as_view(), name='user'),
     path('api/refresh-token/', RefreshTokenView.as_view(), name='refresh-token'),
     path('api/disconnected/', DisconnectedView.as_view(), name='disconnected'),
+    path('api/initialized/', InitializedView.as_view(), name='initialized'),
 ]

--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -20,6 +20,7 @@ class SyncUserView(APIView):
         user = request.user
         UserProfile.objects.get_or_create(user=user)
         request.session['disconnected'] = False
+        request.session['initialized'] = True
         return Response({"id": user.id, "username": user.username})
 
 
@@ -31,6 +32,7 @@ class SessionView(APIView):
         # Log timestamp for debugging stale tokens
         print(f"disconnect at {timezone.now()} for {request.user}")
         request.session['disconnected'] = True
+        request.session['initialized'] = False
         return Response(status=204)
 
 
@@ -104,6 +106,17 @@ class DisconnectedView(APIView):
     def get(self, request):
         val = request.session.get("disconnected", True)
         return Response({"disconnected": bool(val)})
+
+
+class InitializedView(APIView):
+    """Return whether the current user is marked as initialized."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        val = request.session.get("initialized", False)
+        return Response({"initialized": bool(val)})
 
 
 #---

--- a/backend/chat/tests/test_initialized.py
+++ b/backend/chat/tests/test_initialized.py
@@ -1,0 +1,35 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+
+class InitializedAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_state_toggles_via_session(self):
+        token = self.make_token()
+        # connect user -> sets initialized True
+        self.client.post(reverse("sync-user"), HTTP_AUTHORIZATION=f"Bearer {token}")
+        url = reverse("initialized")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.data["initialized"])
+
+        # disconnect user -> sets initialized False
+        self.client.delete(reverse("session"), HTTP_AUTHORIZATION=f"Bearer {token}")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.data["initialized"])
+
+    def test_requires_auth(self):
+        url = reverse("initialized")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        token = self.make_token()
+        url = reverse("initialized")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -47,7 +47,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **hidden**                                   | ✅ | ✅ |
 | **id**                                       | ✅ | ✅ |
 | **initState**                                | ✅ | ✅ |
-| **initialized**                              | ✅ | 🔲 |
+| **initialized**                              | ✅ | ✅ |
 | **intro**                                    | ✅ | 🔲 |
 | **lastRead**                                 | ✅ | ✅ |
 | **linkPreviewsManager**                      | ✅ | ✅ |

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -29,6 +29,7 @@ export const API = {
   WS_AUTH: '/api/ws-auth/',
   ATTACHMENTS: '/api/attachments/',
   DISCONNECTED: '/api/disconnected/',
+  INITIALIZED: '/api/initialized/',
   DISPATCH_EVENT: '/api/dispatch-event/',
 } as const;
 


### PR DESCRIPTION
## Summary
- implement backend session toggle for initialized flag
- expose `/api/initialized/` endpoint
- track initialized state on login/logout
- expose API.INITIALIZED constant
- test initialized session endpoint
- mark initialized surface as complete in docs

## Testing
- `pnpm -r build`
- `pnpm -r test`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6852a94b724c83269e799e7450905367