### PR TITLE
feat(adapter): implement toggleShowReplyInChannel backend

### DIFF
--- a/backend/chat/migrations/0015_show_in_channel.py
+++ b/backend/chat/migrations/0015_show_in_channel.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('chat', '0014_message_updated_at'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='message',
+            name='show_in_channel',
+            field=models.BooleanField(default=False),
+        ),
+    ]
+

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -12,6 +12,7 @@ class Message(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     deleted_at = models.DateTimeField(null=True, blank=True)
     custom_data = models.JSONField(default=dict, blank=True)
+    show_in_channel = models.BooleanField(default=False)
     reply_to = models.ForeignKey(
         'self', blank=True, null=True, on_delete=models.CASCADE, related_name='replies'
     )

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -27,6 +27,7 @@ class MessageSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
             "deleted_at",
+            "show_in_channel",
             "custom_data",
             "created_by",
             "reply_to",

--- a/backend/chat/tests/test_show_reply_in_channel.py
+++ b/backend/chat/tests/test_show_reply_in_channel.py
@@ -1,0 +1,32 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class ShowReplyInChannelTests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_send_message_sets_flag(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, {"text": "hello", "show_in_channel": True}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 201)
+        msg = room.messages.first()
+        self.assertTrue(msg.show_in_channel)
+
+    def test_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.post(url, {"text": "x", "show_in_channel": True}, format="json")
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-messages", kwargs={"room_uuid": room.uuid})
+        res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -90,7 +90,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **textComposer**                             | ✅ | ✅ |
 | **threadId**                                 | ✅ | ✅ |
 | **threads**                                  | ✅ | ✅ |
-| **toggleShowReplyInChannel**                 | ✅ | 🔲 |
+| **toggleShowReplyInChannel**                 | ✅ | ✅ |
 | **tokenManager**                             | ✅ | ✅ |
 | **truncate**                                 | ✅ | ✅ |
 | **truncated**                                | ✅ | ✅ |


### PR DESCRIPTION
## Summary
- support `show_in_channel` on messages
- add migration and serializer field for `show_in_channel`
- test message creation with `show_in_channel`
- document backend completion for `toggleShowReplyInChannel`

## Testing
- `python manage.py test`
- `pnpm turbo run build test`


------
https://chatgpt.com/codex/tasks/task_e_6852e3b9beac8326b1bfed8618a60ebb