### PR TITLE
feat(adapter): implement visible backend

### DIFF
--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -43,6 +43,7 @@ class RoomSerializer(serializers.ModelSerializer):
     cid = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
+    visible = serializers.SerializerMethodField()
 
     def get_cid(self, obj: Room) -> str:
         return f"messaging:{obj.uuid}"
@@ -52,6 +53,10 @@ class RoomSerializer(serializers.ModelSerializer):
 
     def get_type(self, obj: Room) -> str:
         return "messaging"
+
+    def get_visible(self, obj: Room) -> bool:
+        data = obj.data or {}
+        return not data.get("hidden", False)
 
     class Meta:
         model = Room
@@ -66,6 +71,7 @@ class RoomSerializer(serializers.ModelSerializer):
             "messages",
             "url",
             "data",
+            "visible",
             "status",
             "created_at",
         ]

--- a/backend/chat/tests/test_room_visible.py
+++ b/backend/chat/tests/test_room_visible.py
@@ -1,0 +1,26 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room
+
+class RoomVisibleAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_room_list_includes_visible(self):
+        Room.objects.create(uuid="r1", client="c1", data={"hidden": True})
+        token = self.make_token()
+        url = reverse("room-list")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.data[0]["visible"])
+
+    def test_room_detail_includes_visible(self):
+        room = Room.objects.create(uuid="r1", client="c1", data={"hidden": False})
+        token = self.make_token()
+        url = reverse("room-detail", kwargs={"uuid": room.uuid})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.data["visible"])

--- a/docs/adapter-todo.md
+++ b/docs/adapter-todo.md
@@ -104,7 +104,7 @@ _Keep this file as the single source-of-truth for surface coverage._
 | **user**                                     | ✅ | ✅ |
 | **userID**                                   | ✅ | ✅ |
 | **userToken**                                | ✅ | ✅ |
-| **visible**                                  | ✅ | 🔲 |
+| **visible**                                  | ✅ | ✅ |
 | **watch**                                    | ✅ | ✅ |
 | **wsPromise**                                | ✅ | ✅ |
 


### PR DESCRIPTION
## Summary
- expose `visible` flag in `RoomSerializer`
- test channel visibility API fields
- update TODO for the surface

## Testing
- `pnpm turbo build`
- `pnpm --filter frontend test`
- `python backend/manage.py test chat core`


------
https://chatgpt.com/codex/tasks/task_e_6852faf2c4408326925de9b803651fb6