### PR TITLE
Initialize Stream chat client in ChatInner

### DIFF
--- a/frontend/src/app/chat/ChatInner.tsx
+++ b/frontend/src/app/chat/ChatInner.tsx
@@ -3,10 +3,28 @@
 
 import { Chat, Channel, MessageList, MessageInput } from '@iliad/stream-ui';
 import { ChatClient } from '@/lib/stream-adapter';
+import { useEffect, useState } from 'react';
+
+const USER_ID = 'demo-user';
+const TOKEN = 'dummy-jwt';
+const ROOM_ID = 'demo-room';
 
 export default function ChatInner() {
-  const client  = new ChatClient('demo-user', 'dummy-jwt');
-  const channel = client.channel('messaging', 'demo-room');
+  const [client] = useState(() => new ChatClient(USER_ID, TOKEN));
+  const [channel, setChannel] = useState<any | null>(null);
+
+  useEffect(() => {
+    client.connectUser({ id: USER_ID }, TOKEN).then(() => {
+      const chan = client.channel('messaging', ROOM_ID);
+      setChannel(chan);
+    });
+
+    return () => {
+      client.disconnectUser();
+    };
+  }, [client]);
+
+  if (!channel) return null;
 
   return (
     <Chat client={client as any} theme="messaging light">


### PR DESCRIPTION
## Summary
- initialize `ChatClient` with constants
- connect/disconnect the chat client inside a `useEffect`
- create channel after connecting before rendering

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6853067623188326bf4cdbccacd6ca4d