### PR TITLE
Implement B1 ChatConsumer

### DIFF
--- a/backend/chat/routing.py
+++ b/backend/chat/routing.py
@@ -4,5 +4,5 @@ from . import consumers
 
 
 websocket_urlpatterns = [
-    path('ws/<str:room_name>/', consumers.ChatConsumer.as_asgi()),
+    path("ws/<str:room_uuid>/", consumers.ChatConsumer.as_asgi()),
 ]

--- a/backend/chat/tests/__init__.py
+++ b/backend/chat/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jatte.settings")
+django.setup()

--- a/backend/chat/tests/test_websocket.py
+++ b/backend/chat/tests/test_websocket.py
@@ -1,0 +1,32 @@
+import pytest
+from asgiref.sync import sync_to_async
+from channels.testing import WebsocketCommunicator
+from jatte.asgi import application
+from chat.models import Room
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_websocket_send_message():
+    room = await sync_to_async(Room.objects.create)(uuid="r1", client="c1")
+    communicator = WebsocketCommunicator(application, f"/ws/{room.uuid}/")
+    connected, _ = await communicator.connect()
+    assert connected
+
+    await communicator.send_json_to({"type": "channel.watch"})
+    data = await communicator.receive_json_from()
+    assert data["type"] == "channel.watch"
+    assert data["messages"] == []
+
+    await communicator.send_json_to({"type": "sendMessage", "text": "hello", "user": "u1"})
+    event = await communicator.receive_json_from()
+    assert event["type"] == "message.new"
+    assert event["text"] == "hello"
+    assert event["user"] == "u1"
+
+    await communicator.disconnect()
+    count = await sync_to_async(room.messages.count)()
+    assert count == 1
+    msg = await sync_to_async(room.messages.first)()
+    assert msg.body == "hello"
+    assert msg.sent_by == "u1"


### PR DESCRIPTION
## Summary
- implement WebSocket ChatConsumer for room messaging
- expose new consumer via routing
- initialize Django in test package
- add websocket test ensuring message persistence and broadcast

## Testing
- `pytest backend/chat/tests/test_websocket.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6854b0c3ead88326b829e371f8b4e4c5