### PR TITLE
Implement B2 Channel layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 |-----|---------------------------------------------------------------------------------------------------------------------------------------------|-------|--------|
 | 0A  | Ensure backend & frontend deps installed (pip/pnpm; Redis running)                                                                          | human | ✅ |
 | B1  | **ASGI bootstrap (≈ 20)** – `asgi.py` → `ProtocolTypeRouter`; add empty `chat/routing.py`                                                   | Codex | ☐ |
-| B2  | **Channel layer config (≈ 5)** – add `CHANNEL_LAYERS` Redis settings in `settings.py`                                                        | Codex | ☐ |
+| B2  | **Channel layer config (≈ 5)** – add `CHANNEL_LAYERS` Redis settings in `settings.py`                                                        | Codex | ✅ |
 | B3  | **Models: Channel & Message (≤ 80)** – minimal fields; migrations                                                                           | Codex | ☐ |
 | B4  | **JWT token endpoint (≈ 40)** – DRF Simple-JWT at `/api/token/`                                                                              | Codex | ☐ |
 | B5  | **WebSocket consumer skeleton** – connect / disconnect / `receive_json` dispatcher *(implemented in PR #12)*                                 | Codex | ✅ |

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -40,9 +40,11 @@ LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 CHANNEL_LAYERS = {
-    'default': {
-        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {"hosts": [(REDIS_HOST, 6379)]},
     }
 }
 


### PR DESCRIPTION
## Summary
- configure Channels to use Redis via `channels_redis`
- mark backlog item B2 complete

## Testing
- `pytest chat/tests/test_websocket.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854bc00ce848326a89e16b1f5f1d35b