### PR TITLE
Implement markRead and countUnread commands

### DIFF
--- a/backend/chat/migrations/0002_readstate.py
+++ b/backend/chat/migrations/0002_readstate.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('chat', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ReadState',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('user', models.CharField(max_length=255)),
+                ('last_read', models.DateTimeField()),
+                ('channel', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='read_states', to='chat.channel')),
+            ],
+            options={
+                'unique_together': {('user', 'channel')},
+            },
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -31,3 +31,16 @@ class Message(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.sent_by}"
+
+
+class ReadState(models.Model):
+    """Track the last read timestamp per user per channel."""
+
+    channel = models.ForeignKey(
+        Channel, related_name="read_states", on_delete=models.CASCADE
+    )
+    user = models.CharField(max_length=255)
+    last_read = models.DateTimeField()
+
+    class Meta:
+        unique_together = ("user", "channel")


### PR DESCRIPTION
## Summary
- track per-user last read state in `ReadState`
- add markRead and countUnread handlers in `ChatConsumer`
- test unread counting and read marking via WebSockets

## Testing
- `pytest backend/chat/tests/test_websocket.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c08c40d08326a17e766b2d7560e6