### PR TITLE
Implement F1 env wrapper

### DIFF
--- a/0C.md
+++ b/0C.md
@@ -4,7 +4,7 @@
 
 | ID  | Description (≤ LOC)                                                                                                                 | Owner | Status |
 |-----|-------------------------------------------------------------------------------------------------------------------------------------|-------|--------|
-| F1  | **Env & SDK wrapper (≈ 20)** – add `.env.local`; create `lib/getStreamClient.ts` that memoises `StreamChat.getInstance(process.env.NEXT_PUBLIC_API_URL!)` |       | ☐ |
+| F1  | **Env & SDK wrapper (≈ 20)** – add `.env.local`; create `lib/getStreamClient.ts` that memoises `StreamChat.getInstance(process.env.NEXT_PUBLIC_API_URL!)` |       | ✅ |
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` calls `/api/token` and returns `{ userID, userToken }`                            |       | ☐ |
 | F3  | **ChatProvider component (≈ 40)** – React Context; in `useEffect` do `client.connectUser({ id: userID }, userToken)` and expose `{ client, channel }` |       | ☐ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ☐ |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 | B7  | **Command: sendMessage** – persist message, broadcast `message.new` *(implemented in PR #12)*                                               | Codex | ✅ |
 | B8  | **Command: markRead & countUnread (≈ 80)** – per-user read tracking                                                                         | Codex | ☐ |
 | B9  | **Backend unit tests** – `channels.testing.WebsocketCommunicator` *(implemented in PR #12)*                                                  | Codex | ✅ |
-| F1  | **Env & SDK wrapper (≈ 20)** – `.env.local`; `lib/getStreamClient.ts` memoises `StreamChat.getInstance(...)`                                | Codex | ☐ |
+| F1  | **Env & SDK wrapper (≈ 20)** – `.env.local`; `lib/getStreamClient.ts` memoises `StreamChat.getInstance(...)`                                | Codex | ✅ |
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` hits `/api/token` and returns `{userID,userToken}`                                       | Codex | ☐ |
 | F3  | **ChatProvider (≈ 40)** – React Context; `client.connectUser(...)`; exports `{client, channel}`                                             | Codex | ☐ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging","general").watch()`; save to context                                     | Codex | ☐ |

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/frontend/src/lib/getStreamClient.ts
+++ b/frontend/src/lib/getStreamClient.ts
@@ -1,0 +1,14 @@
+import { StreamChat } from 'stream-chat';
+
+let client: StreamChat | null = null;
+
+export function getStreamClient(): StreamChat {
+  if (!client) {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) {
+      throw new Error('NEXT_PUBLIC_API_URL is not set');
+    }
+    client = StreamChat.getInstance(apiUrl);
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary
- add `.env.local` for dev settings
- implement `getStreamClient` helper
- mark F1 complete in backlog docs

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6854c1f40bc483268fe0f8e5fc44db51