### PR TITLE
Implement F3 ChatProvider

### DIFF
--- a/0C.md
+++ b/0C.md
@@ -6,7 +6,7 @@
 |-----|-------------------------------------------------------------------------------------------------------------------------------------|-------|--------|
 | F1  | **Env & SDK wrapper (≈ 20)** – add `.env.local`; create `lib/getStreamClient.ts` that memoises `StreamChat.getInstance(process.env.NEXT_PUBLIC_API_URL!)` |       | ✅ |
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` calls `/api/token` and returns `{ userID, userToken }`                            |       | ✅ |
-| F3  | **ChatProvider component (≈ 40)** – React Context; in `useEffect` do `client.connectUser({ id: userID }, userToken)` and expose `{ client, channel }` |       | ☐ |
+| F3  | **ChatProvider component (≈ 40)** – React Context; in `useEffect` do `client.connectUser({ id: userID }, userToken)` and expose `{ client, channel }` |       | ✅ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ☐ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                            |       | ☐ |
 | F6  | **Event logger & markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                           |       | ☐ |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 | B9  | **Backend unit tests** – `channels.testing.WebsocketCommunicator` *(implemented in PR #12)*                                                  | Codex | ✅ |
 | F1  | **Env & SDK wrapper (≈ 20)** – `.env.local`; `lib/getStreamClient.ts` memoises `StreamChat.getInstance(...)`                                | Codex | ✅ |
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` hits `/api/token` and returns `{userID,userToken}`                                       | Codex | ✅ |
-| F3  | **ChatProvider (≈ 40)** – React Context; `client.connectUser(...)`; exports `{client, channel}`                                             | Codex | ☐ |
+| F3  | **ChatProvider (≈ 40)** – React Context; `client.connectUser(...)`; exports `{client, channel}`                                             | Codex | ✅ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging","general").watch()`; save to context                                     | Codex | ☐ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                                   | Codex | ☐ |
 | F6  | **Event logger + markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                                  | Codex | ☐ |

--- a/frontend/src/lib/ChatProvider.tsx
+++ b/frontend/src/lib/ChatProvider.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import type { StreamChat, Channel } from 'stream-chat';
+import { getStreamClient } from './getStreamClient';
+import { getToken } from './getToken';
+
+interface ChatContextValue {
+  client: StreamChat | null;
+  channel: Channel | null;
+}
+
+const ChatContext = createContext<ChatContextValue>({ client: null, channel: null });
+
+export function useChat() {
+  return useContext(ChatContext);
+}
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const [client] = useState<StreamChat>(() => getStreamClient());
+  const [channel, setChannel] = useState<Channel | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    getToken()
+      .then(({ userID, userToken }) => client.connectUser({ id: userID }, userToken))
+      .then(() => {
+        if (!mounted) return;
+        // channel will be initialized in a later ticket
+        setChannel(null);
+      });
+    return () => {
+      mounted = false;
+      client.disconnectUser();
+    };
+  }, [client]);
+
+  return (
+    <ChatContext.Provider value={{ client, channel }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add React ChatProvider to manage Stream Chat client connection
- mark ChatProvider task as complete in docs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c517eab8832680863f6b871dc6b1