### PR TITLE
Implement default channel bootstrap

### DIFF
--- a/0C.md
+++ b/0C.md
@@ -7,7 +7,7 @@
 | F1  | **Env & SDK wrapper (≈ 20)** – add `.env.local`; create `lib/getStreamClient.ts` that memoises `StreamChat.getInstance(process.env.NEXT_PUBLIC_API_URL!)` |       | ✅ |
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` calls `/api/token` and returns `{ userID, userToken }`                            |       | ✅ |
 | F3  | **ChatProvider component (≈ 40)** – React Context; in `useEffect` do `client.connectUser({ id: userID }, userToken)` and expose `{ client, channel }` |       | ✅ |
-| F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ☐ |
+| F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ✅ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                            |       | ☐ |
 | F6  | **Event logger & markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                           |       | ☐ |
 | F7  | **Smoke-test page (≈ 10)** – Next 15 route `/demo` mounts the provider & scaffold; shows “hello world” round-trip                    |       | ☐ |

--- a/frontend/src/lib/ChatProvider.tsx
+++ b/frontend/src/lib/ChatProvider.tsx
@@ -25,9 +25,12 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     getToken()
       .then(({ userID, userToken }) => client.connectUser({ id: userID }, userToken))
       .then(() => {
+        const chan = client.channel('messaging', 'general');
+        return chan.watch().then(() => chan);
+      })
+      .then((chan) => {
         if (!mounted) return;
-        // channel will be initialized in a later ticket
-        setChannel(null);
+        setChannel(chan);
       });
     return () => {
       mounted = false;


### PR DESCRIPTION
## Summary
- bootstrap the `general` messaging channel in `ChatProvider`
- mark F4 as complete in the backlog

## Testing
- `pnpm -r test`
- `pytest` *(fails: 54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854c98fdda883269bab51d689cab876