### PR TITLE
Implement UI scaffold

### DIFF
--- a/0C.md
+++ b/0C.md
@@ -8,7 +8,7 @@
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` calls `/api/token` and returns `{ userID, userToken }`                            |       | ✅ |
 | F3  | **ChatProvider component (≈ 40)** – React Context; in `useEffect` do `client.connectUser({ id: userID }, userToken)` and expose `{ client, channel }` |       | ✅ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ✅ |
-| F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                            |       | ☐ |
+| F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                            |       | ✅ |
 | F6  | **Event logger & markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                           |       | ☐ |
 | F7  | **Smoke-test page (≈ 10)** – Next 15 route `/demo` mounts the provider & scaffold; shows “hello world” round-trip                    |       | ☐ |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 | F2  | **Token fetch utility (≈ 30)** – `lib/getToken.ts` hits `/api/token` and returns `{userID,userToken}`                                       | Codex | ✅ |
 | F3  | **ChatProvider (≈ 40)** – React Context; `client.connectUser(...)`; exports `{client, channel}`                                             | Codex | ✅ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging","general").watch()`; save to context                                     | Codex | ☐ |
-| F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                                   | Codex | ☐ |
+| F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                                   | Codex | ✅ |
 | F6  | **Event logger + markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                                  | Codex | ☐ |
 | F7  | **Smoke-test page (≈ 10)** – Next route `/demo` mounts provider & scaffold; shows “hello world” round-trip                                  | Codex | ☐ |
 | S1  | Manual smoke-test instructions (curl + WS)                                                                                                  | human | ✅ |

--- a/frontend/src/lib/ChatUI.tsx
+++ b/frontend/src/lib/ChatUI.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Chat, Channel, Window, MessageList, MessageInput } from '@iliad/stream-ui';
+import { useChat } from './ChatProvider';
+
+export default function ChatUI() {
+  const { client, channel } = useChat();
+  if (!client || !channel) return null;
+  return (
+    <Chat client={client as any} theme="messaging light">
+      <Channel channel={channel as any}>
+        <Window>
+          <MessageList />
+          <MessageInput />
+        </Window>
+      </Channel>
+    </Chat>
+  );
+}

--- a/frontend/stubs/stream-ui/index.tsx
+++ b/frontend/stubs/stream-ui/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 export const Chat = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
 export const Channel = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+export const Window = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
 export const MessageList = () => <div>MessageList</div>;
 export const MessageInput = () => <div>MessageInput</div>;

--- a/frontend/types/stream-ui-shim.d.ts
+++ b/frontend/types/stream-ui-shim.d.ts
@@ -3,6 +3,7 @@ declare module '@iliad/stream-ui' {
 
   export const Chat: any;
   export const Channel: any;
+  export const Window: any;
   export const MessageList: any;
   export const MessageInput: any;
 


### PR DESCRIPTION
## Summary
- add `<Window>` stub for Stream-UI and types
- implement `ChatUI` that renders the basic Stream components
- mark F5 done in docs

## Testing
- `pnpm -r test`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854ca86d86483269456cc6fcbb9a426