### PR TITLE
Implement event logger and markRead

### DIFF
--- a/0C.md
+++ b/0C.md
@@ -9,7 +9,7 @@
 | F3  | **ChatProvider component (≈ 40)** – React Context; in `useEffect` do `client.connectUser({ id: userID }, userToken)` and expose `{ client, channel }` |       | ✅ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ✅ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                            |       | ✅ |
-| F6  | **Event logger & markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                           |       | ☐ |
+| F6  | **Event logger & markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                           |       | ✅ |
 | F7  | **Smoke-test page (≈ 10)** – Next 15 route `/demo` mounts the provider & scaffold; shows “hello world” round-trip                    |       | ☐ |
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 | F3  | **ChatProvider (≈ 40)** – React Context; `client.connectUser(...)`; exports `{client, channel}`                                             | Codex | ✅ |
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging","general").watch()`; save to context                                     | Codex | ☐ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                                   | Codex | ✅ |
-| F6  | **Event logger + markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                                  | Codex | ☐ |
+| F6  | **Event logger + markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                                  | Codex | ✅ |
 | F7  | **Smoke-test page (≈ 10)** – Next route `/demo` mounts provider & scaffold; shows “hello world” round-trip                                  | Codex | ☐ |
 | S1  | Manual smoke-test instructions (curl + WS)                                                                                                  | human | ✅ |
 | S2  | Auth-less harness – set `AllowAny`; fixture disables auth in tests                                                                          | human | ☐ |

--- a/frontend/src/lib/ChatProvider.tsx
+++ b/frontend/src/lib/ChatProvider.tsx
@@ -38,6 +38,18 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     };
   }, [client]);
 
+  useEffect(() => {
+    if (!channel) return;
+    const logEvent = (e: any) => console.log('channel event', e);
+    const handleNew = () => channel.markRead();
+    channel.on('*', logEvent);
+    channel.on('message.new', handleNew);
+    return () => {
+      channel.off('*', logEvent);
+      channel.off('message.new', handleNew);
+    };
+  }, [channel]);
+
   return (
     <ChatContext.Provider value={{ client, channel }}>
       {children}


### PR DESCRIPTION
## Summary
- add channel event logger and markRead hook
- mark F6 done in progress docs

## Testing
- `pnpm -r test`
- `pytest -q` *(fails: ImportError: cannot import name 'Room' from 'chat.models')*

------
https://chatgpt.com/codex/tasks/task_e_6854cc58075c8326ae2b3d01b2ca05f3