### PR TITLE
Add demo page for hello-world smoke test

### DIFF
--- a/0C.md
+++ b/0C.md
@@ -10,7 +10,7 @@
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging", "general").watch()`; store channel in Context                    |       | ✅ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                            |       | ✅ |
 | F6  | **Event logger & markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                           |       | ✅ |
-| F7  | **Smoke-test page (≈ 10)** – Next 15 route `/demo` mounts the provider & scaffold; shows “hello world” round-trip                    |       | ☐ |
+| F7  | **Smoke-test page (≈ 10)** – Next 15 route `/demo` mounts the provider & scaffold; shows “hello world” round-trip                    |       | ✅ |
 
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 | F4  | **Default channel bootstrap (≈ 30)** – `client.channel("messaging","general").watch()`; save to context                                     | Codex | ☐ |
 | F5  | **UI scaffold (≤ 50)** – `<Chat><Channel><Window><MessageList/><MessageInput/></Window></Channel></Chat>`                                   | Codex | ✅ |
 | F6  | **Event logger + markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                                  | Codex | ✅ |
-| F7  | **Smoke-test page (≈ 10)** – Next route `/demo` mounts provider & scaffold; shows “hello world” round-trip                                  | Codex | ☐ |
+| F7  | **Smoke-test page (≈ 10)** – Next route `/demo` mounts provider & scaffold; shows “hello world” round-trip                                  | Codex | ✅ |
 | S1  | Manual smoke-test instructions (curl + WS)                                                                                                  | human | ✅ |
 | S2  | Auth-less harness – set `AllowAny`; fixture disables auth in tests                                                                          | human | ☐ |
 | S3  | Re-enable JWT auth & update tests at Phase-1 kickoff                                                                                        | human | ☐ |

--- a/frontend/src/app/demo/page.tsx
+++ b/frontend/src/app/demo/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { ChatProvider, useChat } from '@/lib/ChatProvider';
+import ChatUI from '@/lib/ChatUI';
+import { useEffect } from 'react';
+
+function HelloWorldSender() {
+  const { channel } = useChat();
+  useEffect(() => {
+    if (!channel) return;
+    channel.sendMessage({ text: 'hello world' });
+  }, [channel]);
+  return null;
+}
+
+export default function DemoPage() {
+  return (
+    <ChatProvider>
+      <HelloWorldSender />
+      <ChatUI />
+    </ChatProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add smoke-test demo page that sends 'hello world'
- mark smoke-test ticket complete in docs

## Testing
- `pnpm -r test`
- `pytest -q` *(fails: ImportError: cannot import name 'Room' from 'chat.models')*

------
https://chatgpt.com/codex/tasks/task_e_68552c2039a483268da78a632bf26685