### PR TITLE
Handle S2 Auth-less harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 | F6  | **Event logger + markRead (≈ 20)** – `channel.on("message.new", () => channel.markRead())`                                                  | Codex | ✅ |
 | F7  | **Smoke-test page (≈ 10)** – Next route `/demo` mounts provider & scaffold; shows “hello world” round-trip                                  | Codex | ✅ |
 | S1  | Manual smoke-test instructions (curl + WS)                                                                                                  | human | ✅ |
-| S2  | Auth-less harness – set `AllowAny`; fixture disables auth in tests                                                                          | human | ☐ |
+| S2  | Auth-less harness – set `AllowAny`; fixture disables auth in tests                                                                          | human | ✅ |
 | S3  | Re-enable JWT auth & update tests at Phase-1 kickoff                                                                                        | human | ☐ |
 
 **Phase 0 is done** (“Dave Matthews → hello world”) when every ☐ above is ✅.

--- a/backend/chat/tests/conftest.py
+++ b/backend/chat/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def disable_auth(settings):
+    settings.REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] = [
+        'rest_framework.permissions.AllowAny'
+    ]

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -71,7 +71,7 @@ REST_FRAMEWORK = {
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.AllowAny',
     ),
 }
 


### PR DESCRIPTION
## Summary
- disable default permissions to make the harness auth-less
- mark S2 done in the backlog
- add pytest fixture so tests also run without auth

## Testing
- `pytest backend/chat/tests/test_websocket.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68552f2512c48326872cecdd975c2e11