### PR TITLE
Add Supabase client helper

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@iliad/stream-ui": "file:../libs/stream-ui",
+    "@supabase/supabase-js": "2.50.0",
     "mitt": "^3.0.1",
     "mml-react": "0.4.7",
     "next": "15.3.3",
@@ -29,8 +30,8 @@
     "caniuse-lite": "^1.0.30001723",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "typescript": "^5",
     "turbo": "^1.13.0",
+    "typescript": "^5",
     "vitest": "^1.5.0"
   }
 }

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(url, key)


### PR DESCRIPTION
## Summary
- install supabase-js into the frontend workspace
- create `supabaseClient` helper for Next.js

## Testing
- `pnpm -r test`
- `pytest -q` *(fails: ImportError, 54 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68555adb6e0c8326a3d9f9d12552f993