### PR TITLE
Implement login page with session context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 
 | ID  | Description (≤ LOC)                                                                                                               | Owner | Status |
 |-----|----------------------------------------------------------------------------------------------------------------------------------|-------|--------|
-| A1  | **Install supabase-js & helper (≈20)** – `pnpm add @supabase/supabase-js`; add `src/lib/supabaseClient.ts`                        | Codex | ☐ |
-| A2  | **Login page (≈50)** – email+password `/login`; stores `session` in context                                                       | Codex | ☐ |
+| A1  | **Install supabase-js & helper (≈20)** – `pnpm add @supabase/supabase-js`; add `src/lib/supabaseClient.ts`                        | Codex | ✅ |
+| A2  | **Login page (≈50)** – email+password `/login`; stores `session` in context                                                       | Codex | ✅ |
 | A3  | **DRF SupabaseJWTAuthentication (≈80)** – validate Bearer JWT via Supabase JWKS                                                   | Codex | ☐ |
 | A4  | **Secure /api/token/ (≈40)** – requires Supabase auth; returns `StreamChat.devToken(user.id)`                                     | Codex | ☐ |
 | A5  | **Token fetch hook (≈30)** – uses `supabase.auth.getSession()`; fetches `/api/token/` with auth header                            | Codex | ☐ |

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { SessionProvider } from "@/lib/SessionProvider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -14,7 +15,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        {children}
+        <SessionProvider>
+          {children}
+        </SessionProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+import { useSession } from '@/lib/SessionProvider'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const { setSession } = useSession()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error || !data.session) {
+      setError(error?.message || 'Login failed')
+      return
+    }
+    setSession(data.session)
+    router.push('/demo')
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type='email'
+        placeholder='Email'
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type='password'
+        placeholder='Password'
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type='submit'>Login</button>
+      {error && <p>{error}</p>}
+    </form>
+  )
+}

--- a/frontend/src/lib/SessionProvider.tsx
+++ b/frontend/src/lib/SessionProvider.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react'
+import type { Session } from '@supabase/supabase-js'
+import { supabase } from './supabaseClient'
+
+interface SessionContextValue {
+  session: Session | null
+  setSession: (s: Session | null) => void
+}
+
+const SessionContext = createContext<SessionContextValue>({
+  session: null,
+  setSession: () => {},
+})
+
+export function useSession() {
+  return useContext(SessionContext)
+}
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session))
+    const { data: listener } = supabase.auth.onAuthStateChange((_, s) => {
+      setSession(s)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <SessionContext.Provider value={{ session, setSession }}>
+      {children}
+    </SessionContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- mark A1 and A2 tasks complete in `AGENTS.md`
- add `SessionProvider` for managing supabase auth state
- wrap app layout with the new session provider
- create `/login` page that signs in with email and password

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68555ceb8ed48326a781d5ac1f9b2d10