### PR TITLE
Implement Supabase JWT authentication via JWKS

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -2,7 +2,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from accounts.authentication import SupabaseJWTAuthentication
+from jatte.auth.supabase import SupabaseJWTAuthentication
 from accounts.models import UserProfile
 
 class SyncUserView(APIView):

--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import generics, serializers
 from django.contrib.auth import get_user_model
-from accounts.authentication import SupabaseJWTAuthentication
+from jatte.auth.supabase import SupabaseJWTAuthentication
 from accounts_supabase.models import UserProfile
 from django.utils import timezone
 from django.conf import settings

--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -5,7 +5,7 @@ from rest_framework.views import APIView
 from django.shortcuts import get_object_or_404
 from django.contrib.auth import get_user_model
 
-from accounts.authentication import SupabaseJWTAuthentication
+from jatte.auth.supabase import SupabaseJWTAuthentication
 from django.utils import timezone
 
 from urllib.parse import urlparse

--- a/backend/chat/tests/test_supabase_auth.py
+++ b/backend/chat/tests/test_supabase_auth.py
@@ -1,0 +1,32 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from unittest.mock import patch
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from jwt.utils import base64url_encode
+import jwt
+
+
+def make_keys():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub = priv.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA",
+        "kid": "test",
+        "use": "sig",
+        "alg": "RS256",
+        "n": base64url_encode(pub.n.to_bytes((pub.n.bit_length() + 7) // 8, "big")),
+        "e": base64url_encode(pub.e.to_bytes((pub.e.bit_length() + 7) // 8, "big")),
+    }
+    return priv, {"keys": [jwk]}
+
+
+class SupabaseAuthAPITests(APITestCase):
+    def test_rs256_jwt_via_jwks(self):
+        priv, jwks = make_keys()
+        token = jwt.encode({"sub": "u1", "email": "u1@example.com"}, priv, algorithm="RS256", headers={"kid": "test"})
+        url = reverse("ws-auth")
+        with patch("jwt.PyJWKClient.fetch_data", return_value=jwks):
+            res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, {"status": "ok"})

--- a/backend/jatte/auth/supabase.py
+++ b/backend/jatte/auth/supabase.py
@@ -1,0 +1,59 @@
+import jwt
+from jwt import PyJWKClient
+from jwt.exceptions import PyJWTError
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from rest_framework import authentication, exceptions
+
+
+class SupabaseJWTAuthentication(authentication.BaseAuthentication):
+    """Authenticate requests using Supabase-issued JWT tokens."""
+
+    def __init__(self):
+        jwks_url = settings.SUPABASE_JWKS_URL
+        if not jwks_url:
+            raise exceptions.AuthenticationFailed("Supabase JWKS URL not configured")
+        self.jwks_client = PyJWKClient(jwks_url)
+
+    def authenticate(self, request):
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            return None
+
+        try:
+            token_type, token = auth_header.split()
+            if token_type.lower() != "bearer":
+                return None
+        except ValueError:
+            return None
+
+        try:
+            signing_key = self.jwks_client.get_signing_key_from_jwt(token)
+            decoded = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                options={"verify_aud": False},
+            )
+        except PyJWTError as e:
+            raise exceptions.AuthenticationFailed(f"Invalid token: {e}")
+
+        uid = decoded.get("sub")
+        if not uid:
+            raise exceptions.AuthenticationFailed("No 'sub' claim found")
+
+        email = decoded.get("email")
+        if not email:
+            raise exceptions.AuthenticationFailed("No 'email' claim found")
+
+        User = get_user_model()
+        user, created = User.objects.get_or_create(
+            username=uid,
+            defaults={"email": email, "supabase_uid": uid},
+        )
+        if not created and not getattr(user, "supabase_uid", None):
+            user.supabase_uid = uid
+            user.save(update_fields=["supabase_uid"])
+
+        return (user, None)

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -30,6 +30,12 @@ SECRET_KEY = 'django-insecure-%v$gh67imza=0$i%pky!jxpk*@%t+x-w$lw5lmwbvj)+#p=r#g
 # Secret key used by Supabase to sign JWTs
 SUPABASE_JWT_SECRET = os.environ.get('SUPABASE_JWT_SECRET', 'changeme')
 
+# Base Supabase project URL used to fetch JWKS for verifying incoming JWTs
+SUPABASE_URL = os.environ.get('NEXT_PUBLIC_SUPABASE_URL')
+SUPABASE_JWKS_URL = (
+    f"{SUPABASE_URL.rstrip('/')}/auth/v1/keys" if SUPABASE_URL else None
+)
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 


### PR DESCRIPTION
## Summary
- configure Supabase JWKS URL in Django settings
- add DRF `SupabaseJWTAuthentication` using JWKS validation
- swap imports in API and account views
- test JWT authentication against mocked JWKS

## Testing
- `pip install -q -r requirements.txt`
- `pytest chat/tests/test_supabase_auth.py -q` *(fails: fixture 'settings' not found)*
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68555fe645648326b5078b869ab125b6