### PR TITLE
Implement secure dev token endpoint

### DIFF
--- a/backend/chat/tests/test_supabase_auth.py
+++ b/backend/chat/tests/test_supabase_auth.py
@@ -30,3 +30,14 @@ class SupabaseAuthAPITests(APITestCase):
             res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data, {"status": "ok"})
+
+    def test_dev_token_endpoint(self):
+        priv, jwks = make_keys()
+        token = jwt.encode({"sub": "u1", "email": "u1@example.com"}, priv, algorithm="RS256", headers={"kid": "test"})
+        url = reverse("token-obtain")
+        with patch("jwt.PyJWKClient.fetch_data", return_value=jwks):
+            res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["userID"], 1)
+        self.assertTrue(res.data["userToken"].endswith("devtoken"))
+

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -1,0 +1,22 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from jatte.auth.supabase import SupabaseJWTAuthentication
+import base64
+import json
+
+class TokenView(APIView):
+    """Return a Stream Chat dev token for the authenticated user."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user_id = str(request.user.id)
+        header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"user_id": user_id}).encode()
+        ).decode().rstrip("=")
+        token = f"{header}.{payload}.devtoken"
+        return Response({"userID": user_id, "userToken": token})
+

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework_simplejwt.views import TokenObtainPairView
+from chat.views import TokenView
 
 urlpatterns = [
     path('', include('accounts_supabase.urls')),
@@ -10,5 +10,6 @@ urlpatterns = [
 
 #for dev credentials delete in prod:
 urlpatterns += [
-    path("api/token/", TokenObtainPairView.as_view(), name="token-obtain"),
+    path("api/token/", TokenView.as_view(), name="token-obtain"),
 ]
+


### PR DESCRIPTION
## Summary
- implement `/api/token/` backed by Supabase auth
- expose TokenView in URL configuration
- test Supabase JWT auth for token endpoint

## Testing
- `pytest backend/chat/tests/test_supabase_auth.py::SupabaseAuthAPITests::test_dev_token_endpoint -q` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685564767bb48326afdaf5abb8cae10c