### PR TITLE
Implement token fetch hook

### DIFF
--- a/frontend/src/lib/getToken.ts
+++ b/frontend/src/lib/getToken.ts
@@ -1,16 +1,24 @@
+import { supabase } from './supabaseClient'
+
 export interface TokenData {
-  userID: string;
-  userToken: string;
+  userID: string
+  userToken: string
 }
 
 export async function getToken(): Promise<TokenData> {
-  const res = await fetch('/api/token/');
+  const { data } = await supabase.auth.getSession()
+  const session = data.session
+  if (!session) throw new Error('not authenticated')
+
+  const res = await fetch('/api/token/', {
+    headers: { Authorization: `Bearer ${session.access_token}` },
+  })
   if (!res.ok) {
-    throw new Error('failed to fetch token');
+    throw new Error('failed to fetch token')
   }
-  const data = await res.json();
+  const dataRes = await res.json()
   return {
-    userID: data.user_id ?? data.userID ?? data.id,
-    userToken: data.token ?? data.access ?? data.userToken,
-  } as TokenData;
+    userID: dataRes.user_id ?? dataRes.userID ?? dataRes.id,
+    userToken: dataRes.token ?? dataRes.access ?? dataRes.userToken,
+  } as TokenData
 }


### PR DESCRIPTION
## Summary
- fetch Stream Chat token with bearer credentials

## Testing
- `pnpm -r test`
- `pytest backend/chat/tests/test_supabase_auth.py::SupabaseAuthAPITests::test_dev_token_endpoint -q` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855679201bc832689fb88294d6df7a5