### PR TITLE
Remove dev-only constants

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000

--- a/frontend/__tests__/adapter/watch.test.ts
+++ b/frontend/__tests__/adapter/watch.test.ts
@@ -33,7 +33,8 @@ test('watch fetches messages and opens websocket', async () => {
   expect(channel.initialized).toBe(true);
   expect(channel.state.latestMessages).toEqual(messages);
   expect(channel.state.latestMessages[0].updated_at).toBe('2025-01-01T00:00:00Z');
+  const wsRoot = process.env.NEXT_PUBLIC_WS_URL as string;
   expect((global as any).WebSocket).toHaveBeenCalledWith(
-    'ws://localhost:8000/ws/room1/?token=jwt1'
+    `${wsRoot}/ws/room1/?token=jwt1`
   );
 });

--- a/frontend/src/app/chat/ChatInner.tsx
+++ b/frontend/src/app/chat/ChatInner.tsx
@@ -1,37 +1,13 @@
 // frontend/src/app/chat/ChatInner.tsx
 'use client';
 
-import { Chat, Channel, MessageList, MessageInput } from '@iliad/stream-ui';
-import { ChatClient } from '@/lib/stream-adapter';
-import { useEffect, useState } from 'react';
-
-const USER_ID = 'demo-user';
-const TOKEN = 'dummy-jwt';
-const ROOM_ID = 'demo-room';
+import { ChatProvider } from '@/lib/ChatProvider';
+import ChatUI from '@/lib/ChatUI';
 
 export default function ChatInner() {
-  const [client] = useState(() => new ChatClient(USER_ID, TOKEN));
-  const [channel, setChannel] = useState<any | null>(null);
-
-  useEffect(() => {
-    client.connectUser({ id: USER_ID }, TOKEN).then(() => {
-      const chan = client.channel('messaging', ROOM_ID);
-      setChannel(chan);
-    });
-
-    return () => {
-      client.disconnectUser();
-    };
-  }, [client]);
-
-  if (!channel) return null;
-
   return (
-    <Chat client={client as any} theme="messaging light">
-      <Channel channel={channel as any}>
-        <MessageList />
-        <MessageInput />
-      </Channel>
-    </Chat>
+    <ChatProvider>
+      <ChatUI />
+    </ChatProvider>
   );
 }

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -641,8 +641,12 @@ export class Channel {
         this.initialized = true;
 
         /* web-socket for live updates */
+        const wsRoot = process.env.NEXT_PUBLIC_WS_URL;
+        if (!wsRoot) {
+            throw new Error('NEXT_PUBLIC_WS_URL is not set');
+        }
         this.socket = new WebSocket(
-            `ws://localhost:8000/ws/${this.uuid}/?token=${this.client['jwt']}`,
+            `${wsRoot}/ws/${this.uuid}/?token=${this.client['jwt']}`,
         );
         this.socket.onmessage = (ev) => {
             try {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: './vitest.setup.ts',
+  },
+})

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+process.env.NEXT_PUBLIC_WS_URL ||= 'ws://test';


### PR DESCRIPTION
## Summary
- replace ChatInner with ChatProvider/ChatUI
- derive WebSocket URL from `NEXT_PUBLIC_WS_URL`
- use env var in watch tests and provide vitest setup
- add local WS URL env

## Testing
- `pnpm -r test`
- `pytest -q` *(fails: ImportError while collecting Django tests)*

------
https://chatgpt.com/codex/tasks/task_e_68556cd8d9bc83268684e3be60fdc07e