### PR TITLE
Add Jest tests and demo smoke test

### DIFF
--- a/frontend/tests/e2e/demo-smoke.spec.ts
+++ b/frontend/tests/e2e/demo-smoke.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('demo shows hello world', async ({ page }) => {
+  await page.goto('/demo')
+  await expect(page.getByText('hello world')).toBeVisible()
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/libs/**/?(*.)+(test).[tj]s?(x)'],
+};

--- a/libs/chat-shim/__tests__/localClient.test.ts
+++ b/libs/chat-shim/__tests__/localClient.test.ts
@@ -1,0 +1,32 @@
+import WS from 'jest-websocket-mock';
+import { LocalChatClient } from '../index';
+
+describe('LocalChatClient', () => {
+  let server: WS;
+  beforeEach(() => {
+    server = new WS('ws://localhost:8000/ws/chat/?token=jwt', { jsonProtocol: true });
+    (global as any).location = { hostname: 'localhost' };
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  test('connect, send, echo', async () => {
+    const client = new LocalChatClient();
+    await client.connectUser({ id: 'u1' }, 'jwt');
+    const channel = client.channel('messaging', 'general');
+    await channel.watch();
+
+    const received: any[] = [];
+    channel.on('message.new', (m) => received.push(m));
+
+    channel.sendMessage({ text: 'ping' });
+    await expect(server).toReceiveMessage({ type: 'message.new', cid: 'messaging:general', text: 'ping' });
+
+    server.send({ type: 'message.new', cid: 'messaging:general', text: 'pong' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received).toEqual([{ type: 'message.new', cid: 'messaging:general', text: 'pong' }]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
     "libs/*"
   ],
   "devDependencies": {
-    "turbo": "^1.13.4"
+    "@types/jest": "29",
+    "jest": "29",
+    "jest-websocket-mock": "2",
+    "ts-jest": "29",
+    "turbo": "^1.13.4",
+    "typescript": "5"
+  },
+  "scripts": {
+    "test": "turbo run test && jest"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,6 @@
     "paths": {
       "stream-chat": ["libs/chat-shim"]
     },
-    "types": ["@types/stream-chat"]
+    "types": ["@types/stream-chat", "@types/jest"]
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and WebSocket test for `LocalChatClient`
- run Playwright smoke test that opens `/demo`
- expose jest types in `tsconfig.json`

## Testing
- `pnpm test`
- `pnpm --filter frontend exec playwright test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68562cf2cdf0832683f1d23555da92a0