### PR TITLE
Fix Playwright browser install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,16 @@ jobs:
           python-version: '3.10'
       - run: pip install -r backend/requirements.txt
       - run: pnpm install --frozen-lockfile
+      - name: Install front-end deps
+        run: pnpm --filter frontend install --frozen-lockfile
       - run: |
           cd backend
           nohup daphne jatte.asgi:application &
       - name: A5-scan
         run: node scripts/list-stream-imports.ts | tee /dev/tty | (! grep -q ^$)
       - run: pnpm test
-      - run: pnpm --filter frontend exec playwright install --with-deps
+      - name: Install Playwright browsers
+        run: pnpm --filter frontend exec playwright install --with-deps
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
       - run: pnpm --filter frontend exec playwright test


### PR DESCRIPTION
## Summary
- install front-end deps separately in CI
- download Playwright browsers to a cache directory

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` *(fails: demo shows hello world / login → hello-world)*
- `PLAYWRIGHT_BROWSERS_PATH=~/.cache/ms-playwright pnpm --filter frontend exec playwright install --with-deps`
- `pnpm --filter frontend exec playwright test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68568aed5528832686d113521ed0fed3