### PR TITLE
Update docs for local Stream toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Jatte Headless
+
+This monorepo hosts a minimal chat demo built with Django Channels and Next.js. It ships with a local shim for the Stream Chat SDK so the UI can run without hitting the hosted Stream service.
+
+## Development setup
+
+1. Install Python and Node dependencies:
+
+```bash
+pnpm install
+pnpm --filter frontend install
+pip install -r backend/requirements.txt
+```
+
+2. Start the backend:
+
+```bash
+pnpm --filter backend exec python manage.py migrate --noinput
+pnpm --filter backend exec daphne -p 8000 jatte.asgi:application
+```
+
+3. In another terminal, run the frontend:
+
+```bash
+pnpm --filter frontend dev
+```
+
+### Stream Chat toggle
+
+The frontend automatically switches between a real Stream Chat client and the local Channels-backed shim. Set `NEXT_PUBLIC_STREAM_KEY` in `frontend/.env.local` to use your Stream Chat instance. If the variable is absent, the shim located at `libs/chat-shim` is used instead.
+
+The `stream-chat` package remains in `devDependencies` so TypeScript types are available while runtime calls go through the shim.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,7 @@
     "mml-react": "0.4.7",
     "next": "15.3.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "stream-chat": "^9.6.0"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -27,6 +26,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "stream-chat": "^9.6.0",
     "@types/webpack": "5.28.5",
     "browserslist": "^4.25.0",
     "caniuse-lite": "^1.0.30001723",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
-      stream-chat:
-        specifier: ^9.6.0
-        version: 9.6.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -75,6 +72,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.6(@types/react@19.1.8)
+      stream-chat:
+        specifier: ^9.6.0
+        version: 9.6.1
       '@types/webpack':
         specifier: 5.28.5
         version: 5.28.5


### PR DESCRIPTION
## Summary
- explain how to toggle between the Stream service and local shim
- keep `stream-chat` as a devDependency only

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568f0179308326b9fb433441331d04