### PR TITLE
Implement MessageComposer

### DIFF
--- a/frontend/stubs/stream-ui/index.ts
+++ b/frontend/stubs/stream-ui/index.ts
@@ -1,7 +1,0 @@
-// Ultra-minimal stub for MVP build
-export { Chat }         from '../../../libs/stream-ui/src/components/Chat';
-export { Channel }      from '../../../libs/stream-ui/src/components/Channel';
-export { Window }       from '../../../libs/stream-ui/src/components/Window';
-export { MessageList }  from '../../../libs/stream-ui/src/components/MessageList';
-export { MessageInput } from '../../../libs/stream-ui/src/components/MessageInput';
-export default {};

--- a/frontend/stubs/stream-ui/index.tsx
+++ b/frontend/stubs/stream-ui/index.tsx
@@ -4,3 +4,4 @@ export const Channel = ({ children }: { children: React.ReactNode }) => <div>{ch
 export const Window = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
 export const MessageList = () => <div>MessageList</div>;
 export const MessageInput = () => <div>MessageInput</div>;
+export default {};

--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -73,7 +73,13 @@ declare module 'stream-chat' {
   //export type isLocalVoiceRecordingAttachment = any;
   //export type isLocalUploadAttachment = any;
   export type FixedSizeQueueCache = any;
-  export type MessageComposer = any;
+export interface MessageComposerState { text: string; attachments: any[]; }
+  export class MessageComposer {
+    state: MessageComposerState;
+    reset(): void;
+    setText(text: string): void;
+    addAttachment(att: any): void;
+  }
   export type VotingVisibility = any;
   export type BaseSearchSource = any;
   //export type getTokenizedSuggestionDisplayName = any;
@@ -133,7 +139,6 @@ declare module 'stream-chat' {
   export type LocalUploadAttachment = any;
   export type LinkPreview = any;
   export type LinkPreviewsManagerState = any;
-  export type MessageComposerState = any;
   export type UpdatedMessage = any;
   export type MessageComposerConfig = any;
   export type AttachmentManagerState = any;
@@ -188,7 +193,6 @@ declare module 'stream-chat' {
   export function replaceWordWithEntity<T>(s:T): T;
 
   export class LinkPreviewsManager {}
-  export class MessageComposer {}
   export class FixedSizeQueueCache {}
   export class SearchController {}
 

--- a/libs/chat-shim/__tests__/messageComposer.test.ts
+++ b/libs/chat-shim/__tests__/messageComposer.test.ts
@@ -1,0 +1,17 @@
+import { MessageComposer } from '../index';
+
+describe('MessageComposer', () => {
+  test('basic state transitions', () => {
+    const comp = new MessageComposer();
+    expect(comp.state).toEqual({ text: '', attachments: [] });
+
+    comp.setText('hello');
+    expect(comp.state.text).toBe('hello');
+
+    comp.addAttachment({ id: 1 });
+    expect(comp.state.attachments).toEqual([{ id: 1 }]);
+
+    comp.reset();
+    expect(comp.state).toEqual({ text: '', attachments: [] });
+  });
+});

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -47,7 +47,13 @@ declare module 'stream-chat' {
   export type isLocalVoiceRecordingAttachment = any;
   export type isLocalUploadAttachment = any;
   export type FixedSizeQueueCache = any;
-  export type MessageComposer = any;
+export interface MessageComposerState { text: string; attachments: any[]; }
+  export class MessageComposer {
+    state: MessageComposerState;
+    reset(): void;
+    setText(text: string): void;
+    addAttachment(att: any): void;
+  }
   export type VotingVisibility = any;
   export type BaseSearchSource = any;
   export type getTokenizedSuggestionDisplayName = any;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -96,3 +96,24 @@ export const getLocalClient = () => StreamChat.getInstance();
 /* ------------------------------------------------------------------------ */
 /*  Make  import { Channel } from 'stream‑chat'  resolve successfully       */
 export type Channel = LocalChannel;
+
+export interface MessageComposerState {
+  text: string;
+  attachments: any[];
+}
+
+export class MessageComposer {
+  state: MessageComposerState;
+  constructor() {
+    this.state = { text: "", attachments: [] };
+  }
+  reset() {
+    this.state = { text: "", attachments: [] };
+  }
+  setText(text: string) {
+    this.state.text = text;
+  }
+  addAttachment(att: any) {
+    this.state.attachments.push(att);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
       "@/*": ["frontend/lib/*", "frontend/src/*"],
       "stream-chat": ["libs/chat-shim"],
     },
-    "types": ["node", "react"]
+    "types": ["node", "react", "jest"]
   }
 }


### PR DESCRIPTION
## Summary
- add `MessageComposer` state machine with basic methods
- update TypeScript declarations
- stub Stream UI locally
- add unit tests for MessageComposer
- include jest typings in tsconfig

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`
- `pnpm exec jest`


------
https://chatgpt.com/codex/tasks/task_e_6856f231ecc48326af24d951c4bc4750