### PR TITLE
Implement MessageComposer state machine

### DIFF
--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -80,7 +80,16 @@ declare module 'stream-chat' {
   //export type isLocalVideoAttachment = any;
   //export type isLocalVoiceRecordingAttachment = any;
   //export type isLocalUploadAttachment = any;
-  export type MessageComposer = any;
+  export interface MessageComposerState {
+    text: string;
+    attachments: any[];
+  }
+  export class MessageComposer {
+    state: MessageComposerState;
+    reset(): void;
+    setText(text: string): void;
+    addAttachment(att: any): void;
+  }
   export type VotingVisibility = any;
   export type BaseSearchSource = any;
   //export type getTokenizedSuggestionDisplayName = any;
@@ -139,9 +148,7 @@ declare module 'stream-chat' {
   export type AnyLocalAttachment = any;
   export type LocalUploadAttachment = any;
   export type LinkPreviewsManagerState = any;
-  export type MessageComposerState = any;
   export type UpdatedMessage = any;
-  export type MessageComposerConfig = any;
   export type AttachmentManagerState = any;
   export type ChannelResponse = any;
   export type EditingAuditState = any;
@@ -193,7 +200,6 @@ declare module 'stream-chat' {
   export function insertItemWithTrigger<T>(s:T): T;
   export function replaceWordWithEntity<T>(s:T): T;
 
-  export class MessageComposer {}
   export class SearchController {}
 
 

--- a/libs/chat-shim/__tests__/messageComposer.test.ts
+++ b/libs/chat-shim/__tests__/messageComposer.test.ts
@@ -1,0 +1,14 @@
+import { MessageComposer } from '../index';
+
+describe('MessageComposer', () => {
+  test('set text, add attachment and reset', () => {
+    const mc = new MessageComposer();
+    mc.setText('hello');
+    mc.addAttachment({ id: 'a1' });
+    expect(mc.state.text).toBe('hello');
+    expect(mc.state.attachments).toEqual([{ id: 'a1' }]);
+    mc.reset();
+    expect(mc.state.text).toBe('');
+    expect(mc.state.attachments).toEqual([]);
+  });
+});

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -56,7 +56,16 @@ declare module 'stream-chat' {
     dequeue(): T | undefined;
     readonly size: number;
   }
-  export type MessageComposer = any;
+  export interface MessageComposerState {
+    text: string;
+    attachments: any[];
+  }
+  export class MessageComposer {
+    state: MessageComposerState;
+    reset(): void;
+    setText(text: string): void;
+    addAttachment(att: any): void;
+  }
   export type VotingVisibility = any;
   export type BaseSearchSource = any;
   export type getTokenizedSuggestionDisplayName = any;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -277,3 +277,26 @@ export class FixedSizeQueueCache<T> {
     return this.items.length;
   }
 }
+
+/* --------------------------- message composer -------------------------- */
+
+export interface MessageComposerState {
+  text: string;
+  attachments: any[];
+}
+
+export class MessageComposer {
+  state: MessageComposerState = { text: '', attachments: [] };
+
+  reset() {
+    this.state = { text: '', attachments: [] };
+  }
+
+  setText(text: string) {
+    this.state.text = text;
+  }
+
+  addAttachment(att: any) {
+    this.state.attachments.push(att);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MessageComposer` in chat-shim with reset/setText/addAttachment
- expose new class in type declarations
- remove generated stubs
- add unit test for `MessageComposer`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685702e67a4c832682ed2508c5e01f53