### PR TITLE
Add LinkPreviewsManagerState interface

### DIFF
--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -158,7 +158,6 @@ declare module 'stream-chat' {
   export type LocalImageAttachment = any;
   export type AnyLocalAttachment = any;
   export type LocalUploadAttachment = any;
-  export type LinkPreviewsManagerState = any;
   export type UpdatedMessage = any;
   export type AttachmentManagerState = any;
   export type ChannelResponse = any;

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -49,6 +49,9 @@ declare module 'stream-chat' {
     constructor(limit?: number);
     fetch(url: string): Promise<LinkPreview>;
   }
+  export interface LinkPreviewsManagerState {
+    previews: Map<string, LinkPreview>;
+  }
   export type PollVote = {
     id: string;
     poll_id: string;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -106,6 +106,10 @@ export class LinkPreviewsManager {
   }
 }
 
+export interface LinkPreviewsManagerState {
+  previews: Map<string, LinkPreview>;
+}
+
 /* --------------------------- compatibility stub -------------------------- */
 /** Return the *same* LocalChatClient for any api-key – good enough for local */
 let _singleton: StreamChat | undefined;


### PR DESCRIPTION
## Summary
- define `LinkPreviewsManagerState` interface in chat-shim and declaration files
- remove `LinkPreviewsManagerState` stub from generated types

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570d9544e883268a659201856ff243