### PR TITLE
Add AttachmentManagerState interface

### DIFF
--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -159,7 +159,6 @@ declare module 'stream-chat' {
   export type AnyLocalAttachment = any;
   export type LocalUploadAttachment = any;
   export type UpdatedMessage = any;
-  export type AttachmentManagerState = any;
   export type ChannelResponse = any;
   export type EditingAuditState = any;
   export type EventHandler = any;

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -52,6 +52,10 @@ declare module 'stream-chat' {
   export interface LinkPreviewsManagerState {
     previews: Map<string, LinkPreview>;
   }
+
+  export interface AttachmentManagerState {
+    attachments: any[];
+  }
   export type PollVote = {
     id: string;
     poll_id: string;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -189,6 +189,10 @@ export type UserResponse = any;
 
 /* ----------------------------- attachments ------------------------------ */
 
+export interface AttachmentManagerState {
+  attachments: any[];
+}
+
 const IMG_RX = /\.(?:jpe?g|png|gif)$/i;
 const VID_RX = /\.(?:mp4|webm)$/i;
 const AUD_RX = /\.(?:mp3|wav)$/i;


### PR DESCRIPTION
## Summary
- implement `AttachmentManagerState` in chat shim
- remove any-type stub from generated types

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857100d2ff88326a8cd5d1484b610c9