### PR TITLE
Fix Channel getConfig missing function

### DIFF
--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -33,6 +33,11 @@ export class LocalChannel {
   markRead() {
     this.sock.send(JSON.stringify({ type: 'mark.read', cid: this.cid }));
   }
+
+  /** Return basic configuration flags expected by Stream UI */
+  getConfig() {
+    return { typing_events: true, read_events: true };
+  }
 }
 
 /* ---------------------------- Chat-client shim --------------------------- */


### PR DESCRIPTION
## Summary
- add `getConfig` method to `LocalChannel` so Stream UI can read defaults

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_685755435a3483269252514622cf9acb