### PR TITLE
Fix missing stateStore in LocalChannel

### DIFF
--- a/libs/chat-shim/__tests__/localChannel.test.ts
+++ b/libs/chat-shim/__tests__/localChannel.test.ts
@@ -1,0 +1,24 @@
+import WS from 'jest-websocket-mock';
+import { LocalChatClient } from '../index';
+
+/** Ensure LocalChannel exposes a stateStore compatible with StateStore */
+describe('LocalChannel', () => {
+  let server: WS;
+  beforeEach(() => {
+    server = new WS('ws://localhost:8000/ws/chat/?token=jwt', { jsonProtocol: true });
+    (global as any).location = { hostname: 'localhost' };
+  });
+  afterEach(() => {
+    WS.clean();
+  });
+
+  test('channel has stateStore with basic api', async () => {
+    const client = new LocalChatClient();
+    await client.connectUser({ id: 'u1' }, 'jwt');
+    const channel = client.channel('messaging', 'general');
+    await channel.watch();
+    expect(channel.stateStore).toBeDefined();
+    expect(typeof channel.stateStore.getState).toBe('function');
+    expect(channel.stateStore.getState().messages).toEqual([]);
+  });
+});

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -17,7 +17,31 @@ declare module 'stream-chat' {
   export function getLocalClient(): LocalChatClient;
 
   /** Channel objects the UI works with (aliased to our LocalChannel). */
-  export type Channel = import('../../libs/chat-shim').LocalChannel; 
+  export class LocalChannel {
+    readonly cid: string;
+    readonly state: {
+      messages: any[];
+      messagePagination: { hasPrev: boolean; hasNext: boolean };
+      read: Record<string, any>;
+      watchers: Record<string, any>;
+      members: Record<string, any>;
+      pinnedMessages: any[];
+      typing: Record<string, any>;
+      threads: Record<string, any[]>;
+      addMessageSorted(msg: any): void;
+      filterErrorMessages(): void;
+      removeMessage(msg: any): void;
+    };
+    readonly stateStore: StateStore<typeof this.state>;
+    watch(): Promise<LocalChannel>;
+    sendMessage(msg: { text: string }): Promise<void>;
+    on(evt: string, cb: (ev: any) => void): { unsubscribe(): void };
+    off(evt: string, cb: (ev: any) => void): void;
+    markRead(): void;
+    getConfig(): { typing_events: boolean; read_events: boolean };
+  }
+
+  export type Channel = LocalChannel;
   
   export type AIState = any;
   export type Event    = any;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -18,6 +18,9 @@ export class LocalChannel {
     removeMessage(msg: any): void;
   };
 
+  /** Store wrapper used by Stream UI hooks */
+  readonly stateStore: StateStore<typeof this.state>;
+
   constructor(readonly cid: string, private sock: WebSocket) {
     this.state = {
       messages: [],
@@ -28,14 +31,20 @@ export class LocalChannel {
       pinnedMessages: [],
       typing: {},
       threads: {},
-      addMessageSorted: (msg: any) => { this.state.messages.push(msg); },
+      addMessageSorted: (msg: any) => {
+        this.state.messages.push(msg);
+        this.stateStore.dispatch({ messages: this.state.messages });
+      },
       filterErrorMessages: () => {
         this.state.messages = this.state.messages.filter(m => m.type !== 'error');
+        this.stateStore.dispatch({ messages: this.state.messages });
       },
       removeMessage: (msg: any) => {
         this.state.messages = this.state.messages.filter(m => m.id !== msg.id);
+        this.stateStore.dispatch({ messages: this.state.messages });
       },
     };
+    this.stateStore = new StateStore(this.state);
   }
 
   async watch() {


### PR DESCRIPTION
## Summary
- provide `stateStore` on `LocalChannel`
- update type declarations for `LocalChannel`
- add regression test for channel `stateStore`

## Testing
- `npx jest libs/chat-shim/__tests__/localChannel.test.ts`
- `corepack pnpm --filter frontend test`
- `corepack pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68575de618008326af73ce6aa26260e8