### PR TITLE
Add getUserAgent to LocalChatClient

### DIFF
--- a/libs/chat-shim/__tests__/localClient.test.ts
+++ b/libs/chat-shim/__tests__/localClient.test.ts
@@ -30,4 +30,11 @@ describe('LocalChatClient', () => {
 
     expect(received).toEqual([{ type: 'message.new', cid: 'messaging:general', text: 'pong' }]);
   });
+
+  test('getUserAgent and setUserAgent', () => {
+    const client = new LocalChatClient();
+    expect(client.getUserAgent()).toBe('local-chat-client/0.0.1 stream-chat-react-adapter');
+    client.setUserAgent('my-agent/1.0');
+    expect(client.getUserAgent()).toBe('my-agent/1.0');
+  });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -5,7 +5,8 @@ declare module 'stream-chat' {
     channel(type: string, id: string): any;
     disconnectUser(): void;
     devToken(uid: string): string;
-    setUserAgent(): void;
+    getUserAgent(): string;
+    setUserAgent(ua: string): void;
   }
 
   /** Compatibility singleton (mimics StreamChat.getInstance) */

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -93,6 +93,7 @@ export class LocalChatClient {
   private sock!: WebSocket;
   private channels = new Map<string, LocalChannel>();
   private userId = 'anonymous';
+  private userAgent = 'local-chat-client/0.0.1 stream-chat-react-adapter';
   /** properties stream-chat-react pokes at */
   clientID = '';
   activeChannels: Record<string, LocalChannel> = {};
@@ -100,7 +101,8 @@ export class LocalChatClient {
   mutedChannels: any[] = [];
 
   devToken(uid: string) { return `${uid}.devtoken`; }
-  setUserAgent() {/* no-op */}
+  getUserAgent() { return this.userAgent; }
+  setUserAgent(ua: string) { this.userAgent = ua; }
 
   /* ------------------------------------------------------------------- */
   /*  ░░ 2.   tiny event-bus so  stream-chat-react  can  .on/.off()      */


### PR DESCRIPTION
## Summary
- implement getUserAgent/setUserAgent for the chat-shim
- expose new methods in type declarations
- test LocalChatClient user agent helpers

## Testing
- `pnpm --filter ./frontend test`
- `pnpm --filter ./frontend build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68576472e2288326a8ccd9af5311fc50