### PR TITLE
Fix threads stub for LocalChatClient

### DIFF
--- a/libs/chat-shim/__tests__/localClient.test.ts
+++ b/libs/chat-shim/__tests__/localClient.test.ts
@@ -37,4 +37,10 @@ describe('LocalChatClient', () => {
     client.setUserAgent('my-agent/1.0');
     expect(client.getUserAgent()).toBe('my-agent/1.0');
   });
+
+  test('has threads register/unregister stubs', () => {
+    const client = new LocalChatClient();
+    expect(typeof client.threads.registerSubscriptions).toBe('function');
+    expect(typeof client.threads.unregisterSubscriptions).toBe('function');
+  });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -7,6 +7,10 @@ declare module 'stream-chat' {
     devToken(uid: string): string;
     getUserAgent(): string;
     setUserAgent(ua: string): void;
+    threads: {
+      registerSubscriptions(): void;
+      unregisterSubscriptions(): void;
+    };
   }
 
   /** Compatibility singleton (mimics StreamChat.getInstance) */

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -100,6 +100,12 @@ export class LocalChatClient {
   listeners: Record<string, Handler[]> = {};
   mutedChannels: any[] = [];
 
+  /** Minimal threads helper expected by Stream UI */
+  threads = {
+    registerSubscriptions() {/* noop */},
+    unregisterSubscriptions() {/* noop */},
+  };
+
   devToken(uid: string) { return `${uid}.devtoken`; }
   getUserAgent() { return this.userAgent; }
   setUserAgent(ua: string) { this.userAgent = ua; }


### PR DESCRIPTION
## Summary
- ensure `LocalChatClient` exposes a minimal `threads` object with `registerSubscriptions`/`unregisterSubscriptions`
- export typings for the `threads` object
- test presence of the new stubs

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68576713eda4832682eef9dcd9525a4e