### PR TITLE
Implement reminder manager

### DIFF
--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -144,9 +144,6 @@ declare module 'stream-chat' {
   export type Thread = any;
   export type ThreadManagerState = any;
   export type LocalVoiceRecordingAttachment = any;
-  export type Reminder = any;
-  export type ReminderState = any;
-  export type ReminderManagerState = any;
   export type ReactionResponse = any;
   export type ReactionSort = any;
   export type User = any;

--- a/libs/chat-shim/__tests__/localClient.test.ts
+++ b/libs/chat-shim/__tests__/localClient.test.ts
@@ -50,4 +50,13 @@ describe('LocalChatClient', () => {
     expect(typeof client.polls.registerSubscriptions).toBe('function');
     expect(typeof client.polls.unregisterSubscriptions).toBe('function');
   });
+
+  test('has reminders store and scheduler stubs', () => {
+    const client = new LocalChatClient();
+    expect(Array.isArray(client.reminders.store.getState().reminders)).toBe(true);
+    expect(typeof client.reminders.registerSubscriptions).toBe('function');
+    expect(typeof client.reminders.unregisterSubscriptions).toBe('function');
+    expect(typeof client.reminders.initTimers).toBe('function');
+    expect(typeof client.reminders.clearTimers).toBe('function');
+  });
 });

--- a/libs/chat-shim/__tests__/reminderModels.test.ts
+++ b/libs/chat-shim/__tests__/reminderModels.test.ts
@@ -1,0 +1,12 @@
+import { Reminder, ReminderState, ReminderManagerState, ReminderManager } from '../index';
+
+describe('reminder models', () => {
+  test('basic shapes', () => {
+    const rem: Reminder = { id: 'r1', text: 'hi', remind_at: '' };
+    const rs: ReminderState = { reminder: rem };
+    const manager = new ReminderManager();
+    manager.store.dispatch({ reminders: [rs] });
+    const state: ReminderManagerState = manager.store.getState();
+    expect(state.reminders[0].reminder.id).toBe('r1');
+  });
+});

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -16,6 +16,7 @@ declare module 'stream-chat' {
       registerSubscriptions(): void;
       unregisterSubscriptions(): void;
     };
+    reminders: ReminderManager;
   }
 
   /** Compatibility singleton (mimics StreamChat.getInstance) */
@@ -165,6 +166,29 @@ declare module 'stream-chat' {
     is_answer: boolean;
   };
   export function isVoteAnswer(vote: PollVote | PollAnswer): vote is PollAnswer;
+
+  export interface Reminder {
+    id: string;
+    text: string;
+    remind_at: string;
+  }
+
+  export interface ReminderState {
+    reminder: Reminder;
+    timer?: ReturnType<typeof setTimeout>;
+  }
+
+  export interface ReminderManagerState {
+    reminders: ReminderState[];
+  }
+
+  export class ReminderManager {
+    readonly store: StateStore<ReminderManagerState>;
+    registerSubscriptions(): void;
+    unregisterSubscriptions(): void;
+    initTimers(): void;
+    clearTimers(): void;
+  }
   export class FixedSizeQueueCache<T> {
     constructor(limit: number);
     enqueue(item: T): void;


### PR DESCRIPTION
## Summary
- add reminder interfaces and manager to chat-shim
- expose `reminders` helper on `LocalChatClient`
- generate typings for reminders
- test reminder types and presence on LocalChatClient
- remove `any` reminder stubs from stream-chat-shim

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68576c47b0b88326a3024692d0981c70