### PR TITLE
Fix missing channel id for local chat

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -33,6 +33,8 @@ declare module 'stream-chat' {
 
   /** Channel objects the UI works with (aliased to our LocalChannel). */
   export class LocalChannel {
+    readonly type: string;
+    readonly id: string;
     readonly cid: string;
     readonly state: {
       messages: any[];

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -2,6 +2,8 @@
 /* -------------------------------- Channel -------------------------------- */
 
 export class LocalChannel {
+  readonly type: string;
+  readonly id: string;
   private listeners = new Map<string, Set<(ev: any) => void>>();
   /** Minimal state object mimicking Stream's ChannelState */
   readonly state: {
@@ -22,6 +24,9 @@ export class LocalChannel {
   readonly stateStore: StateStore<typeof this.state>;
 
   constructor(readonly cid: string, private sock: WebSocket) {
+    const [type, id] = cid.split(':');
+    this.type = type;
+    this.id = id ?? '';
     this.state = {
       messages: [],
       messagePagination: { hasPrev: false, hasNext: false },


### PR DESCRIPTION
## Summary
- expose `type` and `id` fields on `LocalChannel`
- parse them from `cid` in constructor
- update typings

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68577426164c8326886ce7a2da6bf837