### PR TITLE
Fix missing notifications store in LocalChatClient

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -21,6 +21,11 @@ declare module 'stream-chat' {
       unregisterSubscriptions(): void;
     };
     reminders: ReminderManager;
+    notifications: {
+      store: StateStore<{ notifications: any[] }>;
+      registerSubscriptions(): void;
+      unregisterSubscriptions(): void;
+    };
   }
 
   /** Compatibility singleton (mimics StreamChat.getInstance) */

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -121,6 +121,13 @@ export class LocalChatClient {
   /** Minimal reminders helper expected by Stream UI */
   reminders = new ReminderManager();
 
+  /** Minimal notifications helper expected by Stream UI */
+  notifications = {
+    store: new StateStore<{ notifications: any[] }>({ notifications: [] }),
+    registerSubscriptions() {/* noop */},
+    unregisterSubscriptions() {/* noop */},
+  };
+
   devToken(uid: string) { return `${uid}.devtoken`; }
   getUserAgent() { return this.userAgent; }
   setUserAgent(ua: string) { this.userAgent = ua; }


### PR DESCRIPTION
## Summary
- ensure `LocalChatClient` exposes a minimal notifications store expected by stream-chat-react
- declare the new property in the TypeScript declaration file

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_685775ecf2e48326929d911d070e78b4