### PR TITLE
Fix message composer features

### DIFF
--- a/libs/chat-shim/__tests__/messageComposer.test.ts
+++ b/libs/chat-shim/__tests__/messageComposer.test.ts
@@ -11,4 +11,22 @@ describe('MessageComposer', () => {
     expect(mc.state.text).toBe('');
     expect(mc.state.attachments).toEqual([]);
   });
+
+  test('attachment manager adds files', async () => {
+    const mc = new MessageComposer();
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' });
+    await mc.attachmentManager.addFiles([file]);
+    const list = mc.attachmentManager.state.getLatestValue().attachments;
+    expect(list.length).toBe(1);
+  });
+
+  test('link previews manager stores fetched previews', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ url: 'http://x', title: 'X' }),
+    }) as any;
+    const mc = new MessageComposer();
+    await mc.linkPreviewsManager.add('http://x');
+    const map = mc.linkPreviewsManager.state.getLatestValue().previews;
+    expect(map.get('http://x')).toEqual({ url: 'http://x', title: 'X' });
+  });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -221,6 +221,19 @@ declare module 'stream-chat' {
   export class MessageComposer {
     contextType: 'message';
     state: MessageComposerState;
+    attachmentManager: {
+      state: StateStore<AttachmentManagerState>;
+      availableUploadSlots: number;
+      addFiles(files: File[]): Promise<void>;
+      removeAttachment(id: string): void;
+      replaceAttachment(oldAtt: any, newAtt: any): void;
+    };
+    linkPreviewsManager: {
+      state: StateStore<LinkPreviewsManagerState>;
+      add(url: string): Promise<LinkPreview>;
+      remove(url: string): void;
+      clear(): void;
+    };
     reset(): void;
     setText(text: string): void;
     addAttachment(att: any): void;


### PR DESCRIPTION
## Summary
- add attachment manager and link previews manager to `MessageComposer`
- update type definitions
- extend tests for message composer

## Testing
- `pnpm --filter frontend test`
- `npx jest`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_685784c1270083269a2293c0b8e94f12