### PR TITLE
Fix missing useStateStore hook

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -134,6 +134,7 @@ declare module 'stream-chat' {
     partialNext(patch: Partial<T>): void;
     next(patch: Partial<T>): void;
   }
+  export function useStateStore<T>(store: StateStore<T>): T;
   export function formatMessage(text: string): string;
   export interface LinkPreview {
     url: string;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -1,4 +1,6 @@
 // libs/chat-shim/index.ts
+import { useSyncExternalStore } from 'react';
+
 /* -------------------------------- Channel -------------------------------- */
 
 export class ChannelState {
@@ -780,6 +782,13 @@ export class StateStore<T = any> {
 
   /** rxjs-compat alias */
   next = this.dispatch.bind(this);
+}
+
+/** React hook that subscribes to a StateStore and returns its latest value */
+export function useStateStore<T>(store: StateStore<T>): T {
+  return useSyncExternalStore(store.subscribe.bind(store),
+    store.getLatestValue.bind(store),
+    store.getLatestValue.bind(store));
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- implement `useStateStore` hook in `chat-shim`
- export the hook in `index.d.ts`

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68578908d5f083269d216be7551ae9eb