### PR TITLE
Fix ChatProvider to use custom ChatClient

### DIFF
--- a/frontend/src/lib/ChatProvider.tsx
+++ b/frontend/src/lib/ChatProvider.tsx
@@ -2,13 +2,14 @@
 'use client';
 
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
-import type { StreamChat, Channel } from 'stream-chat';
+import type { ChatClient } from './stream-adapter';
+import type { Channel } from './stream-adapter/Channel';
 import { getStreamClient } from './getStreamClient';
 import { getToken } from './getToken';
 import { useSession } from './SessionProvider';
 
 interface ChatContextValue {
-  client: StreamChat | null;
+  client: ChatClient | null;
   channel: Channel | null;
 }
 
@@ -20,7 +21,7 @@ export function useChat() {
 
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { session } = useSession();
-  const [client] = useState<StreamChat>(() => getStreamClient());
+  const [client] = useState<ChatClient>(() => getStreamClient());
   const [channel, setChannel] = useState<Channel | null>(null);
 
   useEffect(() => {

--- a/frontend/src/lib/getStreamClient.ts
+++ b/frontend/src/lib/getStreamClient.ts
@@ -1,14 +1,11 @@
-import { getLocalClient, StreamChat } from 'stream-chat';
+import { ChatClient } from './stream-adapter';
 
 
-let client: StreamChat | null = null;
+let client: ChatClient | null = null;
 
-export const getStreamClient = (): StreamChat => {
+export const getStreamClient = (): ChatClient => {
   if (!client) {
-    const key = process.env.NEXT_PUBLIC_STREAM_KEY;
-    client = key
-      ? StreamChat.getInstance(key)
-      : getLocalClient();
+    client = new ChatClient();
   }
   return client;
 };


### PR DESCRIPTION
## Summary
- use custom ChatClient implementation instead of stream-chat shim
- provide singleton ChatClient via `getStreamClient`

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_6857cdc0a48c832681fed4885d4784d8