### PR TITLE
Fix sync-user endpoint path

### DIFF
--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -243,7 +243,8 @@ export class ChatClient {
         } catch {
             /* ignore network errors */
         }
-        const res = await fetch(API.SYNC_USER, {
+        const syncUserURL = API.SYNC_USER.endsWith('/') ? API.SYNC_USER : `${API.SYNC_USER}/`;
+        const res = await fetch(syncUserURL, {
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- ensure trailing slash for SYNC_USER endpoint

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d2adcfa88326abcbbdd31cf710cb