### PR TITLE
Fix auth token usage for local API

### DIFF
--- a/frontend/src/lib/ChatProvider.tsx
+++ b/frontend/src/lib/ChatProvider.tsx
@@ -32,7 +32,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     }
     let mounted = true;
     getToken()
-      .then(({ userID, userToken }) => client.connectUser({ id: userID }, userToken))
+      .then(({ userID, userToken }) =>
+        client.connectUser({ id: userID }, userToken, session.access_token)
+      )
       .then(() => {
         const chan = client.channel('messaging', 'general');
         return chan.watch().then(() => chan);


### PR DESCRIPTION
## Summary
- propagate Supabase auth token from `SessionProvider` to `ChatClient`
- update `ChatClient` to store `authToken` and send it in API calls

## Testing
- `pnpm --filter frontend test` *(fails: vitest expectations no longer match)*
- `pnpm --filter frontend build`

------
https://chatgpt.com/codex/tasks/task_e_6857e363f1a48326a8c16c7089af7274