### PR TITLE
Stub WS and API surfaces for chat demo

### DIFF
--- a/backend/chat/api.py
+++ b/backend/chat/api.py
@@ -1,0 +1,30 @@
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+
+@csrf_exempt
+def ws_auth(_request):
+    return JsonResponse({"auth": "ok"})
+
+@csrf_exempt
+def connection_id(_request):
+    return JsonResponse({"connection_id": "local"})
+
+@csrf_exempt
+def ok(_request):
+    return JsonResponse({})
+
+@csrf_exempt
+def ok_post(_request):
+    return JsonResponse({}, status=201)
+
+@csrf_exempt
+def channel_config(_request, cid):
+    return JsonResponse({"name": cid, "type": "messaging"})
+
+@csrf_exempt
+def members(_request, cid):
+    return JsonResponse({"members": []})
+
+@csrf_exempt
+def messages(_request, cid):
+    return JsonResponse({"messages": []})

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -1,63 +1,22 @@
-from urllib.parse import parse_qs
-
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from channels.db import database_sync_to_async
-
-from accounts.middleware import get_user as supabase_verify
-from .models import Channel, Message
-
-
-@database_sync_to_async
-def _get_or_create_channel(uuid: str):
-    return Channel.objects.get_or_create(uuid=uuid, defaults={"client": "local"})[0]
-
-
-@database_sync_to_async
-def _create_message(channel: Channel, user: str, text: str):
-    return Message.objects.create(channel=channel, sent_by=user, body=text)
 
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.rooms = set()
-        self.user = None
-
     async def connect(self):
-        query = parse_qs(self.scope.get("query_string", b"").decode())
-        token = (query.get("token") or [None])[0]
-        if not token:
-            await self.close()
-            return
-        self.user = await supabase_verify(token)
+        self.cid = self.scope["url_route"]["kwargs"].get("cid")
         await self.accept()
+        await self.channel_layer.group_add(self.cid, self.channel_name)
 
     async def receive_json(self, content, **kwargs):
         if content.get("type") == "message.new":
-            cid = content.get("cid")
-            room = cid.split(":")[1]
-            if room not in self.rooms:
-                await self.channel_layer.group_add(room, self.channel_name)
-                self.rooms.add(room)
-            channel = await _get_or_create_channel(room)
-            msg = await _create_message(channel, self.user.username, content.get("text", ""))
             await self.channel_layer.group_send(
-                room,
-                {
-                    "type": "chat.message",
-                    "payload": {
-                        "type": "message.new",
-                        "cid": cid,
-                        "text": msg.body,
-                        "user": msg.sent_by,
-                    },
-                },
+                self.cid,
+                {"type": "chat.message", "payload": content},
             )
 
     async def chat_message(self, event):
         await self.send_json(event["payload"])
 
     async def disconnect(self, code):
-        for room in self.rooms:
-            await self.channel_layer.group_discard(room, self.channel_name)
+        await self.channel_layer.group_discard(self.cid, self.channel_name)
         await super().disconnect(code)

--- a/backend/chat/routing.py
+++ b/backend/chat/routing.py
@@ -1,8 +1,8 @@
-from django.urls import path
+from django.urls import re_path
 
 from . import consumers
 
 
 websocket_urlpatterns = [
-    path("ws/chat/", consumers.ChatConsumer.as_asgi()),
+    re_path(r"ws/(?P<cid>[^/]+)/?$", consumers.ChatConsumer.as_asgi()),
 ]

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -1,6 +1,7 @@
 # backend/jatte/urls.py
 from django.contrib import admin
 from django.urls import re_path, include, path
+from chat import api
 from chat.views import TokenView  # real view
 # from chat.views import dev_token        # <- if you still need the dev stub
 
@@ -11,6 +12,17 @@ urlpatterns = [
 
     # Canonical API paths have no trailing slash; regex allows the old form.
     re_path(r'^api/token/?$', TokenView.as_view(), name='token'),
+]
+
+urlpatterns += [
+    path("api/ws-auth", api.ws_auth),
+    path("api/connection-id", api.connection_id),
+    path("api/register-subscriptions", api.ok),
+    path("api/editing-audit-state", api.ok),
+    path("api/rooms/<str:cid>/draft", api.ok_post),
+    path("rooms<str:cid>/config/", api.channel_config),
+    path("rooms<str:cid>/messages/", api.messages),
+    path("rooms<str:cid>/members/", api.members),
 ]
 
 # If you want the DEV stub only in DEBUG:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,12 @@
+# Architecture Overview
+
+This project mimics basic Stream Chat features with a local shim. The table below outlines which surfaces are provided by the shim versus a real Stream backend.
+
+| Surface            | Local Shim                            | Real Stream |
+|--------------------|---------------------------------------|-------------|
+| REST endpoints     | Minimal stubs returning static JSON   | Full CRUD   |
+| WebSocket routing  | `ws/<cid>/` echo per channel          | Multiplexed |
+| Persistence        | None (in-memory only)                 | Database    |
+| Auth               | Always succeeds                       | JWT / keys  |
+
+Endpoints under `chat/api.py` are temporary shims and will evolve to store data in Redis or Django models.

--- a/frontend/tests/e2e/chat-echo.spec.ts
+++ b/frontend/tests/e2e/chat-echo.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+
+const user = { email: 'demo@example.com', password: 'password' }
+
+async function setupRoutes(page) {
+  await page.route('**/auth/v1/token?grant_type=password', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'jwt-test',
+        token_type: 'bearer',
+        user: { id: '1', email: user.email },
+        refresh_token: 'refresh',
+        expires_in: 3600
+      })
+    })
+  })
+  await page.route('**/api/token/', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ userID: '1', userToken: 'devtoken' })
+    })
+  })
+  await page.route('**/api/**', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+}
+
+test('demo echo message', async ({ page }) => {
+  await setupRoutes(page)
+  await page.goto('/demo')
+  await page.getByPlaceholder('Type your message').fill('hello')
+  await page.keyboard.press('Enter')
+  await expect(page.getByText('hello')).toBeVisible()
+})

--- a/libs/chat-shim/__tests__/localChannel.test.ts
+++ b/libs/chat-shim/__tests__/localChannel.test.ts
@@ -5,8 +5,8 @@ import { LocalChatClient } from '../index';
 describe('LocalChannel', () => {
   let server: WS;
   beforeEach(() => {
-    server = new WS('ws://localhost:8000/ws/chat/?token=jwt', { jsonProtocol: true });
-    (global as any).location = { hostname: 'localhost' };
+    server = new WS('ws://localhost/ws/messaging:general/?token=jwt', { jsonProtocol: true });
+    (global as any).location = { host: 'localhost' };
   });
   afterEach(() => {
     WS.clean();

--- a/libs/chat-shim/__tests__/localClient.test.ts
+++ b/libs/chat-shim/__tests__/localClient.test.ts
@@ -5,8 +5,8 @@ import { LocalChatClient } from '../index';
 describe('LocalChatClient', () => {
   let server: WS;
   beforeEach(() => {
-    server = new WS('ws://localhost:8000/ws/chat/?token=jwt', { jsonProtocol: true });
-    (global as any).location = { hostname: 'localhost' };
+    server = new WS('ws://localhost/ws/messaging:general/?token=jwt', { jsonProtocol: true });
+    (global as any).location = { host: 'localhost' };
   });
 
   afterEach(() => {

--- a/libs/chat-shim/__tests__/wsAuth.test.ts
+++ b/libs/chat-shim/__tests__/wsAuth.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="jest" />
+
+import { expect, test } from '@jest/globals';
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ auth: 'ok' }) });
+});
+
+afterEach(() => {
+  (global.fetch as jest.Mock).mockClear();
+});
+
+test('ws-auth returns 200', async () => {
+  const res = await fetch('/api/ws-auth');
+  expect(global.fetch).toHaveBeenCalledWith('/api/ws-auth');
+  const data = await res.json();
+  expect(data).toEqual({ auth: 'ok' });
+});


### PR DESCRIPTION
## Summary
- add minimal API stubs in `backend/chat/api.py`
- expose stub routes from `jatte/urls.py`
- update websocket routing and consumer for per-channel connections
- adjust local chat client to open per-channel sockets
- update unit tests and add `wsAuth` test
- add Playwright smoke test
- document shim vs real Stream surfaces

## Testing
- `pnpm --filter frontend test` *(fails: vitest errors)*
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_6857e9fc42508326a83f00c67e1e895a