### PR TITLE
◔ GET /rooms/<cid>/config

### DIFF
--- a/backend/chat/tests/test_get_config.py
+++ b/backend/chat/tests/test_get_config.py
@@ -3,34 +3,44 @@ from rest_framework.test import APITestCase
 from django.conf import settings
 import jwt
 
-from chat.models import Room
+from chat.models import Room, RoomMute
+from accounts_supabase.models import CustomUser
 
 class GetConfigAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
         return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
 
-    def test_get_config_returns_defaults(self):
-        room = Room.objects.create(uuid="r1", client="c1")
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            username="u1", email="u1@example.com", password="x", supabase_uid="u1"
+        )
+
+    def test_get_config_returns_metadata(self):
+        room = Room.objects.create(uuid="r1", client="u1", data={"name": "Chat"})
         token = self.make_token()
-        url = reverse("room-config", kwargs={"room_uuid": room.uuid})
+        url = reverse("room-config", kwargs={"cid": f"messaging:{room.uuid}"})
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data, {
-            "typing_events": True,
-            "read_events": True,
-            "reactions": True,
-            "uploads": True,
-        })
+        self.assertEqual(res.data, {"name": "Chat", "type": "messaging", "muted": False})
+
+    def test_get_config_returns_muted_true(self):
+        room = Room.objects.create(uuid="r1", client="u1")
+        RoomMute.objects.create(user=self.user, room=room)
+        token = self.make_token()
+        url = reverse("room-config", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.data["muted"])
 
     def test_get_config_requires_auth(self):
-        room = Room.objects.create(uuid="r1", client="c1")
-        url = reverse("room-config", kwargs={"room_uuid": room.uuid})
+        room = Room.objects.create(uuid="r1", client="u1")
+        url = reverse("room-config", kwargs={"cid": f"messaging:{room.uuid}"})
         res = self.client.get(url)
         self.assertEqual(res.status_code, 403)
 
     def test_get_config_wrong_method(self):
-        room = Room.objects.create(uuid="r1", client="c1")
+        room = Room.objects.create(uuid="r1", client="u1")
         token = self.make_token()
-        url = reverse("room-config", kwargs={"room_uuid": room.uuid})
+        url = reverse("room-config", kwargs={"cid": f"messaging:{room.uuid}"})
         res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -110,7 +110,7 @@ urlpatterns = [
         name="room-draft",
     ),
     path(
-        "api/rooms/<str:room_uuid>/config/",
+        "api/rooms/<str:cid>/config/",
         RoomConfigView.as_view(),
         name="room-config",
     ),

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.urls import re_path, include, path
 from chat import api
 from chat.views import TokenView  # real view
-from chat.api_views import RoomDraftView
+from chat.api_views import RoomDraftView, RoomConfigView, RoomConfigStateView
 # from chat.views import dev_token        # <- if you still need the dev stub
 
 urlpatterns = [
@@ -21,6 +21,8 @@ urlpatterns += [
     path("api/register-subscriptions/", api.register_subscriptions, name="register-subscriptions"),
     path("api/editing-audit-state", api.editing_audit_state, name="editing-audit-state"),
     path("api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"),
+    path("api/rooms/<str:cid>/config/", RoomConfigView.as_view(), name="room-config"),
+    path("api/rooms/<str:room_uuid>/config-state/", RoomConfigStateView.as_view(), name="room-config-state"),
 ]
 
 # If you want the DEV stub only in DEBUG:


### PR DESCRIPTION
## Summary
- implement `/rooms/<cid>/config` metadata endpoint
- wire route through Django URL configuration
- adapt unit test to expect `{name,type,muted}` output

## Testing
- `pytest backend/chat/tests/test_get_config.py -q`
- `pytest backend/chat/tests/test_config_state.py backend/chat/tests/test_get_config.py -q`
- `pytest backend/chat/tests -q` *(fails: NoReverseMatch and IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_685802eda52c8326811eb2a20a2f34b7