### PR TITLE
☐ GET /rooms/<cid>/messages

### DIFF
--- a/backend/chat/tests/test_get_messages_cid.py
+++ b/backend/chat/tests/test_get_messages_cid.py
@@ -1,0 +1,43 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message, Channel
+
+class GetCIDMessagesAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_paginated_messages(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        ch = Channel.objects.create(uuid="c1", client="c1")
+        m1 = Message.objects.create(body="m1", sent_by="u1", channel=ch)
+        m2 = Message.objects.create(body="m2", sent_by="u1", channel=ch)
+        m3 = Message.objects.create(body="m3", sent_by="u1", channel=ch)
+        room.messages.add(m1, m2, m3)
+
+        token = self.make_token()
+        url = reverse("room-messages-cid", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.get(f"{url}?limit=2", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data["messages"]), 2)
+        next_cursor = res.data["next"]
+        self.assertIsNotNone(next_cursor)
+
+        res2 = self.client.get(f"{url}?limit=2&before={next_cursor}", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res2.status_code, 200)
+        self.assertEqual(len(res2.data["messages"]), 1)
+
+    def test_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-messages-cid", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-messages-cid", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.urls import re_path, include, path
 from chat import api
 from chat.views import TokenView  # real view
-from chat.api_views import RoomDraftView, RoomConfigView, RoomConfigStateView
+from chat.api_views import RoomDraftView, RoomConfigView, RoomConfigStateView, RoomMessagesView
 # from chat.views import dev_token        # <- if you still need the dev stub
 
 urlpatterns = [
@@ -21,6 +21,7 @@ urlpatterns += [
     path("api/register-subscriptions/", api.register_subscriptions, name="register-subscriptions"),
     path("api/editing-audit-state", api.editing_audit_state, name="editing-audit-state"),
     path("api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"),
+    path("api/rooms/<str:cid>/messages/", RoomMessagesView.as_view(), name="room-messages-cid"),
     path("api/rooms/<str:cid>/config/", RoomConfigView.as_view(), name="room-config"),
     path("api/rooms/<str:room_uuid>/config-state/", RoomConfigStateView.as_view(), name="room-config-state"),
 ]


### PR DESCRIPTION
## Summary
- add message history API endpoint
- route `/api/rooms/<cid>/messages/` to new view
- test cursor pagination for room messages

## Testing
- `pytest backend/chat/tests/test_get_messages_cid.py -q`
- `pytest -q` *(fails: 210 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68580575a9d88326b06b51bc992d9989