### PR TITLE
☐ GET /rooms/<cid>/members

### DIFF
--- a/backend/chat/tests/test_get_members_cid.py
+++ b/backend/chat/tests/test_get_members_cid.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+from chat.models import Room, Message, Channel
+
+class GetMembersCIDAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_paginated_members(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        ch = Channel.objects.create(uuid="c1", client="c1")
+        for i in range(45):
+            msg = Message.objects.create(body=f"m{i}", sent_by=f"u{i}", channel=ch)
+            room.messages.add(msg)
+
+        token = self.make_token()
+        url = reverse("room-members-cid", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.get(f"{url}?limit=20&offset=20", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data), 20)
+
+    def test_requires_auth(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        url = reverse("room-members-cid", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        room = Room.objects.create(uuid="r1", client="c1")
+        token = self.make_token()
+        url = reverse("room-members-cid", kwargs={"cid": f"messaging:{room.uuid}"})
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -3,7 +3,13 @@ from django.contrib import admin
 from django.urls import re_path, include, path
 from chat import api
 from chat.views import TokenView  # real view
-from chat.api_views import RoomDraftView, RoomConfigView, RoomConfigStateView, RoomMessagesView
+from chat.api_views import (
+    RoomDraftView,
+    RoomConfigView,
+    RoomConfigStateView,
+    RoomMessagesView,
+    RoomMembersCIDView,
+)
 # from chat.views import dev_token        # <- if you still need the dev stub
 
 urlpatterns = [
@@ -23,6 +29,7 @@ urlpatterns += [
     path("api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"),
     path("api/rooms/<str:cid>/messages/", RoomMessagesView.as_view(), name="room-messages-cid"),
     path("api/rooms/<str:cid>/config/", RoomConfigView.as_view(), name="room-config"),
+    path("api/rooms/<str:cid>/members/", RoomMembersCIDView.as_view(), name="room-members-cid"),
     path("api/rooms/<str:room_uuid>/config-state/", RoomConfigStateView.as_view(), name="room-config-state"),
 ]
 


### PR DESCRIPTION
## Summary
- implement roster view accepting CID
- expose `/api/rooms/<cid>/members/` route
- test pagination on new members endpoint

## Testing
- `pytest backend/chat/tests/test_get_members_cid.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685808e2d5188326a4083fb585d52b55