### PR TITLE
☐ notify-agent – guard Channel with missing user

### DIFF
--- a/frontend/src/lib/stream-adapter/composer/index.ts
+++ b/frontend/src/lib/stream-adapter/composer/index.ts
@@ -54,12 +54,15 @@ export const buildMessageComposer = (channelRef:any) => {
     async compose(){
       if(this.compositionIsEmpty) return undefined;
 
+      const userId = channelRef.client.user?.id;
+      if(!userId) return undefined;
+
       const text=textComposer.state.getSnapshot().text.trim();
       const now=new Date().toISOString();
       const localMessage={
         id:`local-${Date.now()}`,
         text,
-        user_id:channelRef.client.user.id!,
+        user_id:userId,
         created_at:now,
       };
       return { localMessage, message: localMessage, sendOptions:{} };


### PR DESCRIPTION
## Summary
- avoid crashes when `client.user` is missing
- early return in composer helpers when user is absent

## Testing
- `pnpm --filter frontend test` *(fails: vitest tests report 69 failed)*
- `pnpm --filter frontend build`

------
https://chatgpt.com/codex/tasks/task_e_68581c03ed648326bdd8b2b831b6782e