### PR TITLE
✅ config endpoints accept trailing slashes

### DIFF
--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -109,9 +109,9 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-# Disable Django's automatic slash-appending behavior. The optional
-# trailing-slash patterns in `urls.py` will handle old bookmarks.
-APPEND_SLASH = False
+# Keep Django's automatic slash-appending behaviour so the React kit
+# can consistently call API endpoints with trailing slashes.
+APPEND_SLASH = True
 
 ROOT_URLCONF = 'jatte.urls'
 

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -22,10 +22,10 @@ urlpatterns = [
 ]
 
 urlpatterns += [
-    path("api/ws-auth", api.ws_auth, name="ws-auth"),
-    path("api/connection-id", api.connection_id, name="connection-id"),
+    path("api/ws-auth/", api.ws_auth, name="ws-auth"),
+    path("api/connection-id/", api.connection_id, name="connection-id"),
     path("api/register-subscriptions/", api.register_subscriptions, name="register-subscriptions"),
-    path("api/editing-audit-state", api.editing_audit_state, name="editing-audit-state"),
+    path("api/editing-audit-state/", api.editing_audit_state, name="editing-audit-state"),
     path("api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"),
     path("api/rooms/<str:cid>/messages/", RoomMessagesView.as_view(), name="room-messages-cid"),
     path("api/rooms/<str:cid>/config/", RoomConfigView.as_view(), name="room-config"),


### PR DESCRIPTION
## Summary
- preserve Django's APPEND_SLASH behaviour
- expose ws-auth/ and other API URLs with trailing slashes so calls succeed

## Testing
- `pnpm install`
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_68581e655bcc8326a03ac055262d1b87