### PR TITLE
✔︎ Add optional API slashes

### DIFF
--- a/backend/accounts_supabase/urls.py
+++ b/backend/accounts_supabase/urls.py
@@ -1,16 +1,32 @@
-#accounts/urls.py
-from django.urls import re_path
-from .views import SyncUserView, SessionView, ClientIDView, QueryUsersView, UserAgentView, CurrentUserView
+# accounts/urls.py
+from django.urls import path, re_path
+from .views import (
+    SyncUserView,
+    SessionView,
+    ClientIDView,
+    QueryUsersView,
+    UserAgentView,
+    CurrentUserView,
+)
 from .views import RefreshTokenView, DisconnectedView, InitializedView
 
 urlpatterns = [
-    re_path(r'^api/sync-user/?$', SyncUserView.as_view(), name='sync-user'),
-    re_path(r'^api/session/?$', SessionView.as_view(), name='session'),
-    re_path(r'^api/client-id/?$', ClientIDView.as_view(), name='client-id'),
-    re_path(r'^api/users/?$', QueryUsersView.as_view(), name='query-users'),
-    re_path(r'^api/user-agent/?$', UserAgentView.as_view(), name='user-agent'),
-    re_path(r'^api/user/?$', CurrentUserView.as_view(), name='user'),
-    re_path(r'^api/refresh-token/?$', RefreshTokenView.as_view(), name='refresh-token'),
-    re_path(r'^api/disconnected/?$', DisconnectedView.as_view(), name='disconnected'),
-    re_path(r'^api/initialized/?$', InitializedView.as_view(), name='initialized'),
+    path("api/sync-user/", SyncUserView.as_view(), name="sync-user"),
+    re_path(r"^api/sync-user/?$", SyncUserView.as_view()),
+    path("api/session/", SessionView.as_view(), name="session"),
+    re_path(r"^api/session/?$", SessionView.as_view()),
+    path("api/client-id/", ClientIDView.as_view(), name="client-id"),
+    re_path(r"^api/client-id/?$", ClientIDView.as_view()),
+    path("api/users/", QueryUsersView.as_view(), name="query-users"),
+    re_path(r"^api/users/?$", QueryUsersView.as_view()),
+    path("api/user-agent/", UserAgentView.as_view(), name="user-agent"),
+    re_path(r"^api/user-agent/?$", UserAgentView.as_view()),
+    path("api/user/", CurrentUserView.as_view(), name="user"),
+    re_path(r"^api/user/?$", CurrentUserView.as_view()),
+    path("api/refresh-token/", RefreshTokenView.as_view(), name="refresh-token"),
+    re_path(r"^api/refresh-token/?$", RefreshTokenView.as_view()),
+    path("api/disconnected/", DisconnectedView.as_view(), name="disconnected"),
+    re_path(r"^api/disconnected/?$", DisconnectedView.as_view()),
+    path("api/initialized/", InitializedView.as_view(), name="initialized"),
+    re_path(r"^api/initialized/?$", InitializedView.as_view()),
 ]

--- a/backend/chat/tests/test_url_aliases.py
+++ b/backend/chat/tests/test_url_aliases.py
@@ -1,0 +1,7 @@
+from django.urls import resolve
+from chat import api
+
+
+def test_ws_auth_aliases():
+    assert resolve("/api/ws-auth/").func is api.ws_auth
+    assert resolve("/api/ws-auth").func is api.ws_auth

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,14 +1,17 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from . import views
 
-app_name = 'core'
+app_name = "core"
 
 
 urlpatterns = [
-    path('', views.index, name='index'),
-    path('about/', views.about, name='about'),
-    path('api/app-settings/', views.get_app_settings, name='app-settings'),
-    path('api/core-user-agent/', views.get_user_agent, name='user-agent'),
-    path('api/tag/', views.get_tag, name='tag'),
+    path("", views.index, name="index"),
+    path("about/", views.about, name="about"),
+    path("api/app-settings/", views.get_app_settings, name="app-settings"),
+    re_path(r"^api/app-settings/?$", views.get_app_settings),
+    path("api/core-user-agent/", views.get_user_agent, name="user-agent"),
+    re_path(r"^api/core-user-agent/?$", views.get_user_agent),
+    path("api/tag/", views.get_tag, name="tag"),
+    re_path(r"^api/tag/?$", views.get_tag),
 ]

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -10,27 +10,59 @@ from chat.api_views import (
     RoomMessagesView,
     RoomMembersCIDView,
 )
+
 # from chat.views import dev_token        # <- if you still need the dev stub
 
 urlpatterns = [
-    path('', include('accounts_supabase.urls')),
-    path('', include('core.urls')),
-    path('admin/', admin.site.urls),
-
+    path("", include("accounts_supabase.urls")),
+    path("", include("core.urls")),
+    path("admin/", admin.site.urls),
     # Canonical API paths have no trailing slash; regex allows the old form.
-    re_path(r'^api/token/?$', TokenView.as_view(), name='token-obtain'),
+    re_path(r"^api/token/?$", TokenView.as_view(), name="token-obtain"),
 ]
 
 urlpatterns += [
     path("api/ws-auth/", api.ws_auth, name="ws-auth"),
+    re_path(r"^api/ws-auth/?$", api.ws_auth),
     path("api/connection-id/", api.connection_id, name="connection-id"),
-    path("api/register-subscriptions/", api.register_subscriptions, name="register-subscriptions"),
-    path("api/editing-audit-state/", api.editing_audit_state, name="editing-audit-state"),
-    path("api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"),
-    path("api/rooms/<str:cid>/messages/", RoomMessagesView.as_view(), name="room-messages-cid"),
+    re_path(r"^api/connection-id/?$", api.connection_id),
+    path(
+        "api/register-subscriptions/",
+        api.register_subscriptions,
+        name="register-subscriptions",
+    ),
+    re_path(r"^api/register-subscriptions/?$", api.register_subscriptions),
+    path(
+        "api/editing-audit-state/", api.editing_audit_state, name="editing-audit-state"
+    ),
+    re_path(r"^api/editing-audit-state/?$", api.editing_audit_state),
+    path(
+        "api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"
+    ),
+    re_path(r"^api/rooms/(?P<room_uuid>[^/]+)/draft/?$", RoomDraftView.as_view()),
+    path(
+        "api/rooms/<str:cid>/messages/",
+        RoomMessagesView.as_view(),
+        name="room-messages-cid",
+    ),
+    re_path(r"^api/rooms/(?P<cid>[^/]+)/messages/?$", RoomMessagesView.as_view()),
     path("api/rooms/<str:cid>/config/", RoomConfigView.as_view(), name="room-config"),
-    path("api/rooms/<str:cid>/members/", RoomMembersCIDView.as_view(), name="room-members-cid"),
-    path("api/rooms/<str:room_uuid>/config-state/", RoomConfigStateView.as_view(), name="room-config-state"),
+    re_path(r"^api/rooms/(?P<cid>[^/]+)/config/?$", RoomConfigView.as_view()),
+    path(
+        "api/rooms/<str:cid>/members/",
+        RoomMembersCIDView.as_view(),
+        name="room-members-cid",
+    ),
+    re_path(r"^api/rooms/(?P<cid>[^/]+)/members/?$", RoomMembersCIDView.as_view()),
+    path(
+        "api/rooms/<str:room_uuid>/config-state/",
+        RoomConfigStateView.as_view(),
+        name="room-config-state",
+    ),
+    re_path(
+        r"^api/rooms/(?P<room_uuid>[^/]+)/config-state/?$",
+        RoomConfigStateView.as_view(),
+    ),
 ]
 
 # If you want the DEV stub only in DEBUG:


### PR DESCRIPTION
## Summary
- accept optional trailing slash for API endpoints
- prove ws-auth resolves with and without the slash

## Testing
- `pytest backend/chat/tests/test_url_aliases.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685820eee2e88326ba283b73803bc6ac