### PR TITLE
☐ config-agent: add ChatGuard auth handling

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -2,12 +2,12 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from accounts_supabase.authentication import SupabaseJWTAuthentication
+from accounts_supabase.authentication import DevTokenOrJWTAuthentication
 from accounts.models import UserProfile
 
 class SyncUserView(APIView):
     # explicitly setting here again as sanity check
-    authentication_classes = [SupabaseJWTAuthentication]  
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request):

--- a/backend/accounts_supabase/authentication.py
+++ b/backend/accounts_supabase/authentication.py
@@ -69,3 +69,14 @@ class SupabaseJWTAuthentication(authentication.BaseAuthentication):
             user.save(update_fields=["supabase_uid"])
 
         return (user, None)
+
+class DevTokenOrJWTAuthentication(SupabaseJWTAuthentication):
+    def authenticate(self, request):
+        auth = super().authenticate(request)
+        if auth:
+            return auth
+        if settings.DEBUG:
+            if request.headers.get("Authorization") == "Bearer devtoken":
+                from django.contrib.auth.models import AnonymousUser
+                return (AnonymousUser(), None)
+        return None

--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.contrib.auth import get_user_model
 from django.conf import settings
 
-from accounts_supabase.authentication import SupabaseJWTAuthentication
+from accounts_supabase.authentication import DevTokenOrJWTAuthentication
 from django.utils import timezone
 
 from urllib.parse import urlparse
@@ -47,7 +47,7 @@ from .serializers import (
 class RoomListCreateView(generics.ListCreateAPIView):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     lookup_field = "uuid"
 
@@ -55,13 +55,13 @@ class RoomListCreateView(generics.ListCreateAPIView):
 class RoomDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     lookup_field = "uuid"
 
 
 class RoomMessageListCreateView(APIView):
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -109,7 +109,7 @@ class RoomMessageListCreateView(APIView):
 
 class RoomMarkReadView(APIView):
     """Mark all messages in a room as read for the current user."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -124,7 +124,7 @@ class RoomMarkReadView(APIView):
 
 class RoomMarkUnreadView(APIView):
     """Clear the read state for the current user in a room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -135,7 +135,7 @@ class RoomMarkUnreadView(APIView):
 
 class RoomCountUnreadView(APIView):
     """Return number of unread messages for the current user in a room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -150,7 +150,7 @@ class RoomCountUnreadView(APIView):
 
 class RoomLastReadView(APIView):
     """Return the last read timestamp for the current user in a room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -162,7 +162,7 @@ class RoomLastReadView(APIView):
 
 class RoomReadView(APIView):
     """Return read states for all users in the room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -183,7 +183,7 @@ class RoomReadView(APIView):
 
 class RoomDraftView(APIView):
     """Save and retrieve message drafts."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -227,7 +227,7 @@ class RoomDraftView(APIView):
 
 class MessageDetailView(APIView):
     """Retrieve, update or delete a single message."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, message_id):
@@ -254,7 +254,7 @@ class MessageDetailView(APIView):
 
 class MessageRestoreView(APIView):
     """Restore a previously deleted message."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, message_id):
@@ -266,7 +266,7 @@ class MessageRestoreView(APIView):
 
 class MessageRepliesView(APIView):
     """Return replies to a given message."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, message_id):
@@ -277,7 +277,7 @@ class MessageRepliesView(APIView):
 
 class MessageReactionsView(APIView):
     """List or create reactions for a message."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, message_id):
@@ -301,7 +301,7 @@ class MessageReactionsView(APIView):
 class MessageFlagView(APIView):
     """Flag a message for moderation."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, message_id):
@@ -314,7 +314,7 @@ class MessageFlagView(APIView):
 class ReactionDetailView(APIView):
     """Delete a single reaction."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
 
@@ -334,7 +334,7 @@ class ReactionDetailView(APIView):
 class MessagePinView(APIView):
     """Pin a message."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, message_id):
@@ -346,7 +346,7 @@ class MessagePinView(APIView):
 class MessageUnpinView(APIView):
     """Remove the current user's pin from a message."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def delete(self, request, message_id):
@@ -358,7 +358,7 @@ class MessageUnpinView(APIView):
 class MessageActionView(APIView):
     """Record an action on a message."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, message_id):
@@ -377,7 +377,7 @@ class MessageActionView(APIView):
 class PollOptionCreateView(APIView):
     """Create a new poll option."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, poll_id):
@@ -394,7 +394,7 @@ class PollOptionCreateView(APIView):
 class PollListCreateView(APIView):
     """List or create polls."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -419,7 +419,7 @@ class PollListCreateView(APIView):
 class PollDetailView(APIView):
     """Delete a poll."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def delete(self, request, poll_id):
@@ -430,7 +430,7 @@ class PollDetailView(APIView):
 class RoomConfigView(APIView):
     """Return basic metadata for the given room."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, cid: str):
@@ -450,7 +450,7 @@ class RoomConfigView(APIView):
 class RoomMessagesView(APIView):
     """Return paginated messages for the given room cid."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, cid: str):
@@ -486,7 +486,7 @@ class RoomMessagesView(APIView):
 
 class RoomConfigStateView(APIView):
     """Return message composer configuration for the room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     def get(self, request, room_uuid):
         get_object_or_404(Room, uuid=room_uuid)
@@ -500,7 +500,7 @@ class RoomConfigStateView(APIView):
 
 class RoomArchiveView(APIView):
     """Archive a room by setting its status to CLOSED."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -512,7 +512,7 @@ class RoomArchiveView(APIView):
 
 class RoomUnarchiveView(APIView):
     """Reopen a previously archived room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -524,7 +524,7 @@ class RoomUnarchiveView(APIView):
 
 class RoomCooldownView(APIView):
     """Return cooldown seconds for the given room."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -535,7 +535,7 @@ class RoomCooldownView(APIView):
 class RoomMembersView(APIView):
     """Return list of members for the given room."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -551,7 +551,7 @@ class RoomMembersView(APIView):
 class RoomMembersCIDView(APIView):
     """Return paginated members for the room identified by cid."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, cid: str):
@@ -588,7 +588,7 @@ class RoomMembersCIDView(APIView):
 class RoomPinnedMessagesView(APIView):
     """Return messages pinned in the given room."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -601,7 +601,7 @@ class RoomPinnedMessagesView(APIView):
 class RoomQueryView(APIView):
     """Return initial messages and members for a room."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, room_uuid):
@@ -616,7 +616,7 @@ class RoomQueryView(APIView):
 
 class ActiveRoomListView(generics.ListAPIView):
     """Return all rooms currently marked as ACTIVE."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = RoomSerializer
 
@@ -626,7 +626,7 @@ class ActiveRoomListView(generics.ListAPIView):
 
 class NotificationListView(APIView):
     """Return notifications for the current user."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -638,7 +638,7 @@ class NotificationListView(APIView):
 class ReminderListCreateView(APIView):
     """List or create reminders for the current user."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -660,7 +660,7 @@ class ReminderListCreateView(APIView):
 class ThreadListView(APIView):
     """Return parent messages that have replies."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -672,7 +672,7 @@ class ThreadListView(APIView):
 class MutedChannelListView(APIView):
     """Return channels muted by the current user."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -684,7 +684,7 @@ class MutedChannelListView(APIView):
 
 class MuteStatusView(APIView):
     """Return whether the current user muted the given user."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, target_username):
@@ -695,7 +695,7 @@ class MuteStatusView(APIView):
 
 class MutedUsersView(APIView):
     """Return list of users muted by the current user."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -707,7 +707,7 @@ class MutedUsersView(APIView):
 class MuteUserView(APIView):
     """Mute the given user for the current user."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, target_username):
@@ -719,7 +719,7 @@ class MuteUserView(APIView):
 class UnmuteUserView(APIView):
     """Remove mute record for the given user."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, target_username):
@@ -731,7 +731,7 @@ class UnmuteUserView(APIView):
 class AttachmentUploadView(APIView):
     """Create a simple attachment record."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -743,7 +743,7 @@ class AttachmentUploadView(APIView):
 class LinkPreviewView(APIView):
     """Return basic metadata for a URL."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -758,7 +758,7 @@ class LinkPreviewView(APIView):
 class RoomHideView(APIView):
     """Mark a room as hidden for the current user."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -773,7 +773,7 @@ class RoomHideView(APIView):
 class RoomShowView(APIView):
     """Unhide a room previously hidden."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -788,7 +788,7 @@ class RoomShowView(APIView):
 class RoomTruncateView(APIView):
     """Remove all messages from a room."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, room_uuid):
@@ -804,7 +804,7 @@ class RoomTruncateView(APIView):
 class RecoverStateView(APIView):
     """Return basic state for reconnect recovery."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -818,7 +818,7 @@ class RecoverStateView(APIView):
 class SubarrayView(APIView):
     """Return a slice of the given array."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -855,7 +855,7 @@ class SubarrayView(APIView):
 
 class TextComposerView(APIView):
     """Echo back posted text for tests."""
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -866,7 +866,7 @@ class TextComposerView(APIView):
 class ComposeView(APIView):
     """Echo back posted composition for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -876,7 +876,7 @@ class ComposeView(APIView):
 class CompositionIsEmptyView(APIView):
     """Return whether posted text is empty after trimming."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -888,7 +888,7 @@ class CompositionIsEmptyView(APIView):
 class HasSendableDataView(APIView):
     """Return whether posted composition includes sendable data."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -910,7 +910,7 @@ class HasSendableDataView(APIView):
 class InitStateView(APIView):
     """Return default composer state for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -926,7 +926,7 @@ class InitStateView(APIView):
 class StateView(APIView):
     """Return a minimal state object for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -936,7 +936,7 @@ class StateView(APIView):
 class DispatchEventView(APIView):
     """Echo back posted event for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -946,7 +946,7 @@ class DispatchEventView(APIView):
 class EditingAuditStateView(APIView):
     """Echo back posted editing audit state for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -958,7 +958,7 @@ class EditingAuditStateView(APIView):
 class QuotedMessageView(APIView):
     """Store and retrieve quoted message for the current user."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -973,7 +973,7 @@ class QuotedMessageView(APIView):
 class AxiosTestView(APIView):
     """Simple endpoint used by axiosInstance tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -989,7 +989,7 @@ class AxiosTestView(APIView):
 class WsAuthView(APIView):
     """Simple handshake endpoint for websocket connections."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -999,7 +999,7 @@ class WsAuthView(APIView):
 class ConnectionIDView(APIView):
     """Return a stable connection identifier for the session."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1025,7 +1025,7 @@ class ConnectionIDView(APIView):
 class ContextTypeView(APIView):
     """Return message composer context type."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1035,7 +1035,7 @@ class ContextTypeView(APIView):
 class GetClientView(APIView):
     """Return basic client information for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1046,7 +1046,7 @@ class GetClientView(APIView):
 class IntroMessageView(APIView):
     """Return an intro message structure."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1056,7 +1056,7 @@ class IntroMessageView(APIView):
 class ListenersView(APIView):
     """Return available event listeners."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1066,7 +1066,7 @@ class ListenersView(APIView):
 class OffView(APIView):
     """Echo back the event listener to remove."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -1077,7 +1077,7 @@ class OffView(APIView):
 class OnView(APIView):
     """Echo back the event listener to add."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -1088,7 +1088,7 @@ class OnView(APIView):
 class RegisterSubscriptionsView(APIView):
     """Echo back posted subscriptions for tests."""
 
-    authentication_classes = [SupabaseJWTAuthentication]
+    authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -74,7 +74,7 @@ INSTALLED_APPS = [
 # REST framework configuration
 REST_FRAMEWORK = {
      "DEFAULT_AUTHENTICATION_CLASSES": (
-         "accounts_supabase.authentication.SupabaseJWTAuthentication",
+         "accounts_supabase.authentication.DevTokenOrJWTAuthentication",
          #"jatte.auth.supabase.SupabaseJWTAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "turbo-dev": "turbo run dev --parallel",
-    "dev":       "next dev -p 3000",
+    "dev": "next dev -p 3000",
     "build": "next build",
     "test": "vitest run",
     "turbo": "turbo",
@@ -19,7 +19,8 @@
     "mml-react": "0.4.7",
     "next": "15.3.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "sonner": "2.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import ChatGuard from '@/components/ChatGuard';
 
 /**
  * Skip SSR for the heavy chat UI – it will be
@@ -9,5 +10,9 @@ import dynamic from 'next/dynamic';
 const ChatInner = dynamic(() => import('./ChatInner'), { ssr: false });
 
 export default function ChatPage() {
-  return <ChatInner />;
+  return (
+    <ChatGuard whenUnauthed="redirect">
+      <ChatInner />
+    </ChatGuard>
+  );
 }

--- a/frontend/src/app/demo/page.tsx
+++ b/frontend/src/app/demo/page.tsx
@@ -4,6 +4,7 @@
 
 import { ChatProvider, useChat } from '@/lib/ChatProvider';
 import ChatUI from '@/lib/ChatUI';
+import ChatGuard from '@/components/ChatGuard';
 import { useEffect } from 'react';
 
 function HelloWorldSender() {
@@ -19,7 +20,9 @@ export default function DemoPage() {
   return (
     <ChatProvider>
       <HelloWorldSender />
-      <ChatUI />
+      <ChatGuard>
+        <ChatUI />
+      </ChatGuard>
     </ChatProvider>
   );
 }

--- a/frontend/src/components/ChatGuard.tsx
+++ b/frontend/src/components/ChatGuard.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { ReactNode, useEffect } from 'react'
+import { useSession } from '@/lib/SessionProvider'
+import Button from '@/components/ui/button'
+
+export default function ChatGuard({ children, whenUnauthed = 'inline' }: { children: ReactNode; whenUnauthed?: 'inline' | 'redirect' }) {
+  const { session } = useSession()
+  const loginUrl = '/login'
+
+  if (session) return <>{children}</>
+
+  if (whenUnauthed === 'redirect') {
+    if (typeof window !== 'undefined') {
+      const next = encodeURIComponent(window.location.pathname)
+      window.location.href = `${loginUrl}?next=${next}`
+    }
+    return null
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-6 text-center">
+      <p className="text-lg font-medium">Sign in to start chatting</p>
+      <Button onClick={() => (window.location.href = loginUrl)}>Sign in</Button>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,10 @@
+export default function Button({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...props}
+      className={['px-4 py-2 rounded bg-blue-600 text-white', props.className].filter(Boolean).join(' ')}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/lib/ChatUI.tsx
+++ b/frontend/src/lib/ChatUI.tsx
@@ -2,18 +2,21 @@
 
 import { Chat, Channel, Window, MessageList, MessageInput } from '@iliad/stream-ui';
 import { useChat } from './ChatProvider';
+import ErrorBoundary from './ErrorBoundary';
 
 export default function ChatUI() {
   const { client, channel } = useChat();
   if (!client || !channel) return null;
   return (
     <Chat client={client as any} theme="messaging light">
-      <Channel channel={channel as any}>
-        <Window>
-          <MessageList />
-          <MessageInput />
-        </Window>
-      </Channel>
+      <ErrorBoundary>
+        <Channel channel={channel as any}>
+          <Window>
+            <MessageList />
+            <MessageInput />
+          </Window>
+        </Channel>
+      </ErrorBoundary>
     </Chat>
   );
 }

--- a/frontend/src/lib/ErrorBoundary.tsx
+++ b/frontend/src/lib/ErrorBoundary.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { Component, ReactNode } from 'react'
+import ChatGuard from '@/components/ChatGuard'
+import { AuthError } from './errors'
+
+interface Props { children: ReactNode }
+interface State { error: Error | null }
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  render() {
+    const { error } = this.state
+    if (error) {
+      if (error instanceof AuthError) {
+        return <ChatGuard>{null}</ChatGuard>
+      }
+      return <div>Something went wrong</div>
+    }
+    return this.props.children
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,20 @@
-export const apiFetch = (path: string, opts?: RequestInit) =>
-  fetch(`/api${path.startsWith('/') ? '' : '/'}${path}`, {
+import { toast } from 'sonner';
+import { AuthError } from './errors';
+
+let lastToast = 0;
+
+export async function apiFetch(path: string, opts?: RequestInit) {
+  const res = await fetch(`/api${path.startsWith('/') ? '' : '/'}${path}`, {
     ...opts,
     headers: { 'Content-Type': 'application/json', ...(opts?.headers || {}) },
   });
+  if (res.status === 401 || res.status === 403) {
+    const now = Date.now();
+    if (now - lastToast > 60000) {
+      lastToast = now;
+      toast.error('Authentication required');
+    }
+    throw new AuthError(res.statusText);
+  }
+  return res;
+}

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,0 +1,6 @@
+export class AuthError extends Error {
+  constructor(message = 'Unauthenticated') {
+    super(message);
+    this.name = 'AuthError';
+  }
+}

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -4,6 +4,7 @@ import type { Message, ChatEvents } from './types';
 import { ChatClient } from './ChatClient';
 import { API, EVENTS } from './constants';
 import { apiFetch } from '../api';
+import { AuthError } from '../errors';
 import { buildAttachmentManager } from './composer/attachments';
 
 /* ──────────────────────────────────────────────────────────────── */
@@ -525,6 +526,7 @@ export class Channel {
         const res = await apiFetch(`${API.ROOMS}${this.uuid}/config/`, {
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
+        if (res.status === 403) throw new AuthError('Unauthenticated');
         if (!res.ok) throw new Error('getConfig failed');
         return await res.json();
     }

--- a/frontend/tests/e2e/chat-guard.spec.ts
+++ b/frontend/tests/e2e/chat-guard.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+test('chat page redirects to login when unauthenticated', async ({ page }) => {
+  await page.goto('/chat')
+  await page.waitForURL('**/login')
+})
+
+test('demo page shows inline sign-in prompt when unauthenticated', async ({ page }) => {
+  await page.goto('/demo')
+  await expect(page.getByText('Sign in to start chatting')).toBeVisible()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
     dependencies:
       '@iliad/stream-ui':
         specifier: file:../libs/stream-ui
-        version: file:libs/stream-ui(@types/react@19.1.8)(jquery@3.7.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(stream-chat@9.8.0)(typescript@5.8.3)
+        version: stream-ui@file:libs/stream-ui
       '@supabase/supabase-js':
         specifier: 2.50.0
         version: 2.50.0
@@ -63,6 +63,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      sonner:
+        specifier: 2.0.5
+        version: 2.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -493,26 +496,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@iliad/stream-ui@file:libs/stream-ui':
-    resolution: {directory: libs/stream-ui, type: directory}
-    peerDependencies:
-      '@breezystack/lamejs': ^1.2.7
-      '@emoji-mart/data': ^1.1.0
-      '@emoji-mart/react': ^1.1.0
-      emoji-mart: ^5.4.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-      stream-chat: ^9.6.0
-    peerDependenciesMeta:
-      '@breezystack/lamejs':
-        optional: true
-      '@emoji-mart/data':
-        optional: true
-      '@emoji-mart/react':
-        optional: true
-      emoji-mart:
-        optional: true
 
   '@img/sharp-darwin-arm64@0.34.2':
     resolution: {integrity: sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==}
@@ -3499,11 +3482,6 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
 
-  react-image-gallery@1.4.0:
-    resolution: {integrity: sha512-m7xLq7+g6/xh+BhVMAxvRU0132sNcEFglYsVsgthrnItl9VtLE7MuVvVWD9pvzcI+WBP5+p9HvnRwIiyhPkBDg==}
-    peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -3723,6 +3701,12 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sonner@2.0.5:
+    resolution: {integrity: sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3783,6 +3767,9 @@ packages:
   stream-chat@9.8.0:
     resolution: {integrity: sha512-iKFVFOKWuW2/GTWBOps9YWZoQBlXdJ05FiOKXI/AnCMCGzOpmvEyaoCtsktvdeMaetmZojVPbw/5jomP36Qg0Q==}
     engines: {node: '>=18'}
+
+  stream-ui@file:libs/stream-ui:
+    resolution: {directory: libs/stream-ui, type: directory}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -4725,49 +4712,6 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@iliad/stream-ui@file:libs/stream-ui(@types/react@19.1.8)(jquery@3.7.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(stream-chat@9.8.0)(typescript@5.8.3)':
-    dependencies:
-      '@braintree/sanitize-url': 6.0.4
-      '@popperjs/core': 2.11.8
-      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      clsx: 2.1.1
-      dayjs: 1.11.13
-      emoji-regex: 9.2.2
-      fix-webm-duration: 1.0.6
-      hast-util-find-and-replace: 5.0.1
-      i18next: 25.2.1(typescript@5.8.3)
-      linkifyjs: 4.3.1
-      lodash.debounce: 4.0.8
-      lodash.defaultsdeep: 4.6.1
-      lodash.mergewith: 4.6.2
-      lodash.throttle: 4.1.1
-      lodash.uniqby: 4.7.0
-      nanoid: 3.3.11
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-dropzone: 14.3.8(react@18.2.0)
-      react-fast-compare: 3.2.2
-      react-image-gallery: 1.4.0(react@18.2.0)
-      react-markdown: 9.1.0(@types/react@19.1.8)(react@18.2.0)
-      react-player: 2.10.1(react@18.2.0)
-      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-textarea-autosize: 8.5.9(@types/react@19.1.8)(react@18.2.0)
-      react-virtuoso: 2.19.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      remark-gfm: 4.0.1
-      stream-chat: 9.8.0
-      tslib: 2.8.1
-      unist-builder: 4.0.0
-      unist-util-visit: 5.0.0
-      use-sync-external-store: 1.5.0(react@18.2.0)
-    optionalDependencies:
-      '@stream-io/transliterate': 1.5.5
-      mml-react: 0.4.7(@types/react@19.1.8)(jquery@3.7.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - jquery
-      - supports-color
-      - typescript
 
   '@img/sharp-darwin-arm64@0.34.2':
     optionalDependencies:
@@ -8474,10 +8418,6 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-image-gallery@1.4.0(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
@@ -8822,6 +8762,11 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sonner@2.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
@@ -8911,6 +8856,8 @@ snapshots:
       - bufferutil
       - debug
       - utf-8-validate
+
+  stream-ui@file:libs/stream-ui: {}
 
   streamsearch@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- add a ChatGuard component to gate chat access
- toast for API auth errors via Sonner
- error boundary shows ChatGuard on AuthError
- allow devtoken usage in DEBUG
- cover redirect/inline cases with e2e test

## Testing
- `pnpm --filter frontend test` *(fails: 66 failed, 38 passed)*
- `pnpm --filter frontend build`

------
https://chatgpt.com/codex/tasks/task_e_6858275697ac83268d1b9d3de3ba87e7