### PR TITLE
☐ notify-agent: fix(redis) parse host

### DIFF
--- a/backend/chat/api.py
+++ b/backend/chat/api.py
@@ -77,7 +77,11 @@ def connection_id(request):
     try:
         import redis
 
-        r = redis.Redis(host=settings.REDIS_HOST, decode_responses=True)
+        r = redis.Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            decode_responses=True,
+        )
         r.set(f"cid:{cid}", request.user.username, ex=60)
     except Exception:
         pass

--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -97,7 +97,11 @@ class RoomMessageListCreateView(APIView):
         room.messages.add(message)
         Draft.objects.filter(user=request.user, room=room).delete()
         try:
-            r = redis.Redis(host=settings.REDIS_HOST, decode_responses=True)
+            r = redis.Redis(
+                host=settings.REDIS_HOST,
+                port=settings.REDIS_PORT,
+                decode_responses=True,
+            )
             r.delete(f"draft:{request.user.username}:{room.uuid}")
         except Exception:
             pass
@@ -195,7 +199,11 @@ class RoomDraftView(APIView):
             defaults={"text": text},
         )
         try:
-            r = redis.Redis(host=settings.REDIS_HOST, decode_responses=True)
+            r = redis.Redis(
+                host=settings.REDIS_HOST,
+                port=settings.REDIS_PORT,
+                decode_responses=True,
+            )
             r.set(f"draft:{request.user.username}:{room.uuid}", text, ex=86400)
         except Exception:
             pass
@@ -205,7 +213,11 @@ class RoomDraftView(APIView):
         room = get_object_or_404(Room, uuid=room_uuid)
         text = None
         try:
-            r = redis.Redis(host=settings.REDIS_HOST, decode_responses=True)
+            r = redis.Redis(
+                host=settings.REDIS_HOST,
+                port=settings.REDIS_PORT,
+                decode_responses=True,
+            )
             text = r.get(f"draft:{request.user.username}:{room.uuid}")
         except Exception:
             pass
@@ -218,7 +230,11 @@ class RoomDraftView(APIView):
         room = get_object_or_404(Room, uuid=room_uuid)
         Draft.objects.filter(user=request.user, room=room).delete()
         try:
-            r = redis.Redis(host=settings.REDIS_HOST, decode_responses=True)
+            r = redis.Redis(
+                host=settings.REDIS_HOST,
+                port=settings.REDIS_PORT,
+                decode_responses=True,
+            )
             r.delete(f"draft:{request.user.username}:{room.uuid}")
         except Exception:
             pass
@@ -1014,7 +1030,11 @@ class ConnectionIDView(APIView):
             import redis
             from django.conf import settings
 
-            r = redis.Redis(host=settings.REDIS_HOST, decode_responses=True)
+            r = redis.Redis(
+                host=settings.REDIS_HOST,
+                port=settings.REDIS_PORT,
+                decode_responses=True,
+            )
             r.set(f"cid:{cid}", request.user.username, ex=60)
         except Exception:
             pass

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -48,10 +48,22 @@ LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
+# Allow REDIS_HOST to include a port via "host:port" or use a separate
+# REDIS_PORT environment variable. This mirrors common Redis configuration
+# strings and avoids connection errors like "localhost:6379:6379" when the
+# host variable already includes the port.
+REDIS_PORT = 6379
+if ":" in REDIS_HOST:
+    host, port = REDIS_HOST.rsplit(":", 1)
+    REDIS_HOST = host
+    REDIS_PORT = int(port)
+else:
+    REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
+
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {"hosts": [(REDIS_HOST, 6379)]},
+        "CONFIG": {"hosts": [(REDIS_HOST, REDIS_PORT)]},
     }
 }
 


### PR DESCRIPTION
## Summary
- handle REDIS_HOST values that include a port
- pass settings.REDIS_PORT to redis.Redis

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*
- `pnpm -F frontend test` *(fails: 66 failed, 38 passed)*
- `pytest -q` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587193583083268c19db801e8c56a7