### PR TITLE
Add optional JWT secret debug log ◔

### DIFF
--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -29,6 +29,12 @@ SECRET_KEY = 'django-insecure-%v$gh67imza=0$i%pky!jxpk*@%t+x-w$lw5lmwbvj)+#p=r#g
 
 # Secret key used by Supabase to sign JWTs
 SUPABASE_JWT_SECRET = os.environ.get('SUPABASE_JWT_SECRET', 'changeme')
+if os.environ.get("PRINT_JWT_SECRET"):
+    print(
+        "[settings] SUPABASE_JWT_SECRET:",
+        SUPABASE_JWT_SECRET[:8] + ("..." if len(SUPABASE_JWT_SECRET) > 8 else ""),
+        f"(len {len(SUPABASE_JWT_SECRET)})",
+    )
 
 # Base Supabase project URL used to fetch JWKS for verifying incoming JWTs
 SUPABASE_URL = os.environ.get('NEXT_PUBLIC_SUPABASE_URL')

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,14 @@ export async function apiFetch(path: string, opts?: RequestInit) {
     headers: { 'Content-Type': 'application/json', ...(opts?.headers || {}) },
   });
   if (res.status === 401 || res.status === 403) {
+    let body = '';
+    try {
+      body = await res.clone().text();
+    } catch {
+      /* ignore */
+    }
+    // eslint-disable-next-line no-console
+    console.warn('apiFetch auth error', { path, status: res.status, body });
     const now = Date.now();
     if (now - lastToast > 60000) {
       lastToast = now;


### PR DESCRIPTION
## Summary
- log JWT secret prefix when PRINT_JWT_SECRET is set
- warn in apiFetch on 401/403 and log response body

## Testing
- `pnpm exec jest` *(fails: Cannot find module 'react' in chat-shim tests)*

------
https://chatgpt.com/codex/tasks/task_e_685875e663648326ba51858c61e1e54b