### PR TITLE
✔︎ fix login redirect

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 import { FormEvent, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import { useSession } from '@/lib/SessionProvider'
 
 export default function LoginPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { setSession } = useSession()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -20,7 +21,8 @@ export default function LoginPage() {
       return
     }
     setSession(data.session)
-    router.push('/demo')
+    const next = searchParams.get('next') || '/demo'
+    router.push(next.startsWith('/') ? next : `/${next}`)
   }
 
   return (

--- a/frontend/src/components/ChatGuard.tsx
+++ b/frontend/src/components/ChatGuard.tsx
@@ -1,12 +1,13 @@
 'use client'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode } from 'react'
 import { useSession } from '@/lib/SessionProvider'
 import Button from '@/components/ui/button'
 
 export default function ChatGuard({ children, whenUnauthed = 'inline' }: { children: ReactNode; whenUnauthed?: 'inline' | 'redirect' }) {
-  const { session } = useSession()
+  const { session, loading } = useSession()
   const loginUrl = '/login'
 
+  if (loading) return null
   if (session) return <>{children}</>
 
   if (whenUnauthed === 'redirect') {

--- a/frontend/src/lib/SessionProvider.tsx
+++ b/frontend/src/lib/SessionProvider.tsx
@@ -6,11 +6,13 @@ import { supabase } from './supabaseClient'
 interface SessionContextValue {
   session: Session | null
   setSession: (s: Session | null) => void
+  loading: boolean
 }
 
 const SessionContext = createContext<SessionContextValue>({
   session: null,
   setSession: () => {},
+  loading: true,
 })
 
 export function useSession() {
@@ -19,11 +21,16 @@ export function useSession() {
 
 export function SessionProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session))
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setLoading(false)
+    })
     const { data: listener } = supabase.auth.onAuthStateChange((_, s) => {
       setSession(s)
+      setLoading(false)
     })
     return () => {
       listener.subscription.unsubscribe()
@@ -31,7 +38,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <SessionContext.Provider value={{ session, setSession }}>
+    <SessionContext.Provider value={{ session, setSession, loading }}>
       {children}
     </SessionContext.Provider>
   )


### PR DESCRIPTION
## Summary
- keep chat guard from redirecting while session state is loading
- add optional `next` query parameter to login
- expose a `loading` flag from the `SessionProvider`

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*
- `npx jest` *(fails to run tests: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68589d8d1ba48326ad494568e262d455