### PR TITLE
codex: refactor devtoken

### DIFF
--- a/backend/accounts_supabase/authentication.py
+++ b/backend/accounts_supabase/authentication.py
@@ -71,12 +71,7 @@ class SupabaseJWTAuthentication(authentication.BaseAuthentication):
         return (user, None)
 
 class DevTokenOrJWTAuthentication(SupabaseJWTAuthentication):
+    """Legacy alias without dev-token support."""
+
     def authenticate(self, request):
-        auth = super().authenticate(request)
-        if auth:
-            return auth
-        if settings.DEBUG:
-            if request.headers.get("Authorization") == "Bearer devtoken":
-                from django.contrib.auth.models import AnonymousUser
-                return (AnonymousUser(), None)
-        return None
+        return super().authenticate(request)

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -7,19 +7,16 @@ from accounts_supabase.authentication import SupabaseJWTAuthentication # ← cha
 
 
 from rest_framework.response import Response
-import base64, json
+from django.conf import settings
+import jwt
 
 
 class TokenView(APIView):
-    """Return a Stream Chat dev token for the authenticated Supabase user."""
+    """Return a signed chat token for the authenticated Supabase user."""
     authentication_classes = [SupabaseJWTAuthentication]
     permission_classes     = [IsAuthenticated]          # or AllowAny while debugging
 
     def get(self, request):
         uid = request.user.id
-        header   = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-        payload  = base64.urlsafe_b64encode(
-                     json.dumps({"user_id": uid}).encode()
-                   ).decode().rstrip("=")
-        devtoken = f"{header}.{payload}.devtoken"
-        return Response({"userID": uid, "userToken": devtoken})
+        token = jwt.encode({"user_id": uid}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        return Response({"userID": uid, "userToken": token})


### PR DESCRIPTION
## Summary
- remove devtoken fallback in `DevTokenOrJWTAuthentication`
- return HS256-signed token from `TokenView`
- check signed token in `test_supabase_auth`

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pytest` *(fails: 6 failed, 270 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858a2b5c9d8832688cf63623ebca80b