### PR TITLE
codex: drop devtoken references

### DIFF
--- a/frontend/tests/e2e/chat-echo.spec.ts
+++ b/frontend/tests/e2e/chat-echo.spec.ts
@@ -20,7 +20,7 @@ async function setupRoutes(page) {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ userID: '1', userToken: 'devtoken' })
+      body: JSON.stringify({ userID: '1', userToken: 'jwt-test' })
     })
   })
   await page.route('**/api/**', async route => {

--- a/frontend/tests/e2e/login-smoke.spec.ts
+++ b/frontend/tests/e2e/login-smoke.spec.ts
@@ -21,7 +21,7 @@ async function setupRoutes(page) {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ userID: '1', userToken: 'devtoken' })
+      body: JSON.stringify({ userID: '1', userToken: 'jwt-test' })
     })
   })
 }

--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -4,7 +4,6 @@ declare module 'stream-chat' {
     connectUser(user: { id: string }, jwt: string): Promise<void>;
     channel(type: string, id: string): any;
     disconnectUser(): void;
-    devToken(uid: string): string;
     setUserAgent(): void;
   }
 

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -8,7 +8,6 @@ declare module 'stream-chat' {
     queryUsers(): Promise<{ users: { id: string }[] }>;
     channel(type: string, id?: string): any;
     disconnectUser(): void;
-    devToken(uid: string): string;
     getUserAgent(): string;
     setUserAgent(ua: string): void;
     threads: {

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -145,7 +145,6 @@ export class LocalChatClient {
     unregisterSubscriptions() {/* noop */},
   };
 
-  devToken(uid: string) { return `${uid}.devtoken`; }
   getUserAgent() { return this.userAgent; }
   setUserAgent(ua: string) { this.userAgent = ua; }
 


### PR DESCRIPTION
## Summary
- strip devToken method from chat shim
- adjust type definitions
- update e2e tests to use jwt placeholder

## Testing
- `npx jest` *(fails: Cannot find module 'react' or '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_6858acc4ac388326a41389d719759e44