### PR TITLE
✔︎ GET /api/token/ returns access token

### DIFF
--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -7,8 +7,6 @@ from accounts_supabase.authentication import SupabaseJWTAuthentication # ← cha
 
 
 from rest_framework.response import Response
-from django.conf import settings
-import jwt
 
 
 class TokenView(APIView):
@@ -17,6 +15,8 @@ class TokenView(APIView):
     permission_classes     = [IsAuthenticated]          # or AllowAny while debugging
 
     def get(self, request):
-        uid = request.user.id
-        token = jwt.encode({"user_id": uid}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
-        return Response({"userID": uid, "userToken": token})
+        """Return the current user's ID and their Supabase access token."""
+        return Response({
+            "userID": request.user.id,
+            "userToken": request.auth,
+        })


### PR DESCRIPTION
## Summary
- use SupabaseJWTAuthentication token as-is in TokenView

## Testing
- `pytest backend/chat/tests/test_supabase_auth.py::SupabaseAuthAPITests::test_token_endpoint -q` *(fails: fixture 'settings' not found)*
- `npx jest` *(fails: cannot find module 'react' or '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_6858c7ae051083268de7348717a9974b