### PR TITLE
Fix channel API paths ☐

### DIFF
--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -523,7 +523,7 @@ export class Channel {
     /** Return the parent ChatClient instance */
     getClient() { return this.client; }
     async getConfig() {
-        const res = await apiFetch(`${API.ROOMS}${this.cid}/config/`, {
+        const res = await apiFetch(`${API.ROOMS}${this.uuid}/config/`, {
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
         if (res.status === 403) throw new AuthError('Unauthenticated');
@@ -571,7 +571,7 @@ export class Channel {
     /** Fetch initial state without opening a websocket */
     async query() {
         try {
-            const res = await apiFetch(`${API.ROOMS}${this.cid}/messages/`, {
+            const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (res.ok) {
@@ -595,7 +595,7 @@ export class Channel {
                 }
             }
 
-            const memRes = await apiFetch(`${API.ROOMS}${this.cid}/members/`, {
+            const memRes = await apiFetch(`${API.ROOMS}${this.uuid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {
@@ -616,7 +616,7 @@ export class Channel {
 
         /* initial history + read row */
         try {
-            const res = await apiFetch(`${API.ROOMS}${this.cid}/messages/`, {
+            const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (res.ok) {
@@ -637,7 +637,7 @@ export class Channel {
                 });
             }
 
-            const memRes = await apiFetch(`${API.ROOMS}${this.cid}/members/`, {
+            const memRes = await apiFetch(`${API.ROOMS}${this.uuid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {


### PR DESCRIPTION
## Summary
- sanitize colon in Channels group names
- fix Channel to use room UUID for HTTP requests

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pytest -q` *(fails: Django settings fixture missing)*
- `pnpm --filter frontend test` *(fails: assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858d223dae08326bc670a69528e1c27