### PR TITLE
☐ config-agent: fix frontend cid paths

### DIFF
--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -523,7 +523,7 @@ export class Channel {
     /** Return the parent ChatClient instance */
     getClient() { return this.client; }
     async getConfig() {
-        const res = await apiFetch(`${API.ROOMS}${this.uuid}/config/`, {
+        const res = await apiFetch(`${API.ROOMS}${this.cid}/config/`, {
             headers: { Authorization: `Bearer ${this.client['jwt']}` },
         });
         if (res.status === 403) throw new AuthError('Unauthenticated');
@@ -571,7 +571,7 @@ export class Channel {
     /** Fetch initial state without opening a websocket */
     async query() {
         try {
-            const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
+            const res = await apiFetch(`${API.ROOMS}${this.cid}/messages/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (res.ok) {
@@ -595,7 +595,7 @@ export class Channel {
                 }
             }
 
-            const memRes = await apiFetch(`${API.ROOMS}${this.uuid}/members/`, {
+            const memRes = await apiFetch(`${API.ROOMS}${this.cid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {
@@ -616,7 +616,7 @@ export class Channel {
 
         /* initial history + read row */
         try {
-            const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
+            const res = await apiFetch(`${API.ROOMS}${this.cid}/messages/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (res.ok) {
@@ -637,7 +637,7 @@ export class Channel {
                 });
             }
 
-            const memRes = await apiFetch(`${API.ROOMS}${this.uuid}/members/`, {
+            const memRes = await apiFetch(`${API.ROOMS}${this.cid}/members/`, {
                 headers: { Authorization: `Bearer ${this.client['jwt']}` },
             });
             if (memRes.ok) {
@@ -734,7 +734,7 @@ export class Channel {
         if (this.messageComposer.state.getSnapshot().showReplyInChannel) {
             payload.show_in_channel = true;
         }
-        const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
+        const res = await apiFetch(`${API.ROOMS}${this.cid}/messages/`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- use `cid` when hitting room endpoints

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pnpm --filter frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d4846aec8326bf44dec3a2663282