### PR TITLE
✔︎ fix(ChatProvider): export client handle

### DIFF
--- a/frontend/src/lib/ChatProvider.tsx
+++ b/frontend/src/lib/ChatProvider.tsx
@@ -8,6 +8,8 @@ import { getStreamClient } from './getStreamClient';
 import { getChatCreds } from './getChatCreds';
 import { useSession } from './SessionProvider';
 
+export const chatClient: ChatClient = getStreamClient();
+
 interface ChatContextValue {
   client: ChatClient | null;
   channel: Channel | null;
@@ -21,7 +23,7 @@ export function useChat() {
 
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { session } = useSession();
-  const [client] = useState<ChatClient>(() => getStreamClient());
+  const [client] = useState<ChatClient>(() => chatClient);
   const [channel, setChannel] = useState<Channel | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- expose `chatClient` constant from `ChatProvider`
- reuse this instance inside the provider

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685930e700108326a2d7a8be1538dc6c