### PR TITLE
◔ notify-agent: throttle register-subscriptions

### DIFF
--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -48,6 +48,7 @@ export class Channel {
         /* ──────────────── messageComposer shim ──────────────── */
         messageComposer: (() => {
             const channelRef = this;                         // capture parent
+            let registered = false;
             const getRoomKey = () => `draft:${channelRef.uuid}`;
 
             /* load any previously‑saved draft */
@@ -309,7 +310,8 @@ export class Channel {
                         this.customDataManager.state.subscribe(handler),
                     ];
                     const token = channelRef.client['jwt'];
-                    if (token) {
+                    if (token && !registered) {
+                        registered = true;
                         apiFetch(API.REGISTER_SUBSCRIPTIONS, {
                             method: 'POST',
                             headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary
- prevent repeated calls to `register-subscriptions`

## Testing
- `pnpm exec jest` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68593154bb10832697d4b11aa0ae03ee