### PR TITLE
✔︎ drafts-agent: fix draft URL mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ pnpm --filter frontend dev
 The frontend automatically switches between a real Stream Chat client and the local Channels-backed shim. Set `NEXT_PUBLIC_STREAM_KEY` in `frontend/.env.local` to use your Stream Chat instance. If the variable is absent, the shim located at `libs/chat-shim` is used instead.
 
 The `stream-chat` package remains in `devDependencies` so TypeScript types are available while runtime calls go through the shim.
+
+### Terminology
+
+In this codebase a *message* is the persisted chat content. A *draft* is a per-user, unsent message for a room (the Draft model). When you see *post* in the logs, it refers to the HTTP verb POST, not a domain object.

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -39,6 +39,9 @@ urlpatterns += [
     path(
         "api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"
     ),
+    path(
+        "api/rooms/<str:room_uuid>/draft", RoomDraftView.as_view()
+    ),
     re_path(r"^api/rooms/(?P<room_uuid>[^/]+)/draft/?$", RoomDraftView.as_view()),
     path(
         "api/rooms/<path:cid>/messages/",


### PR DESCRIPTION
## Summary
- add no-slash draft route
- document message vs draft terminology in README

## Testing
- `pnpm --filter frontend test` *(fails: spy calls not matching)*
- `pytest -q` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859351e87988326b0867d84a8717947