### PR TITLE
Implement trailing slash policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ The `stream-chat` package remains in `devDependencies` so TypeScript types are a
 ### Terminology
 
 In this codebase a *message* is the persisted chat content. A *draft* is a per-user, unsent message for a room (the Draft model). When you see *post* in the logs, it refers to the HTTP verb POST, not a domain object.
+
+### API trailing slashes
+
+All API endpoints are defined with a trailing slash. The frontend must include
+this slash when making requests. Django's `APPEND_SLASH=True` only adds slashes
+to GET requests, so POST calls need to provide the trailing `/` explicitly.

--- a/backend/chat/tests/test_trailing_slash.py
+++ b/backend/chat/tests/test_trailing_slash.py
@@ -1,0 +1,10 @@
+from django.urls import get_resolver
+
+
+def test_api_routes_have_trailing_slash():
+    patterns = [p.pattern._route for p in get_resolver().url_patterns
+                if getattr(p, 'callback', None) and getattr(p.callback, 'cls', None)
+                and getattr(p.pattern, '_route', None) and p.pattern._route.startswith('api/')]
+    assert all(route.endswith('/') for route in patterns), (
+        "All API routes must end with a trailing slash")
+

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -17,8 +17,9 @@ urlpatterns = [
     path("", include("accounts_supabase.urls")),
     path("", include("core.urls")),
     path("admin/", admin.site.urls),
-    # Canonical API paths have no trailing slash; regex allows the old form.
-    re_path(r"^api/token/?$", TokenView.as_view(), name="token-obtain"),
+    # Canonical API paths keep the trailing slash. Regex entries allow the old form.
+    path("api/token/", TokenView.as_view(), name="token-obtain"),
+    re_path(r"^api/token/?$", TokenView.as_view()),
 ]
 
 urlpatterns += [
@@ -38,9 +39,6 @@ urlpatterns += [
     re_path(r"^api/editing-audit-state/?$", api.editing_audit_state),
     path(
         "api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"
-    ),
-    path(
-        "api/rooms/<str:room_uuid>/draft", RoomDraftView.as_view()
     ),
     re_path(r"^api/rooms/(?P<room_uuid>[^/]+)/draft/?$", RoomDraftView.as_view()),
     path(

--- a/frontend/__tests__/adapter/getDraft.test.ts
+++ b/frontend/__tests__/adapter/getDraft.test.ts
@@ -22,7 +22,7 @@ test('getDraft fetches saved draft and updates text', async () => {
 
   const text = await (channel.messageComposer as any).getDraft();
 
-  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/draft', {
+  expect(global.fetch).toHaveBeenCalledWith('/api/rooms/room1/draft/', {
     headers: {
       'Content-Type': 'application/json',
       Authorization: 'Bearer jwt-test',

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -324,7 +324,7 @@ export class Channel {
                     localStorage.setItem(getRoomKey(), text);
                     const token = channelRef.client['jwt'];
                     if (token) {
-                        apiFetch(`/rooms/${channelRef.uuid}/draft`, {
+                        apiFetch(`/rooms/${channelRef.uuid}/draft/`, {
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json',
@@ -350,7 +350,7 @@ export class Channel {
                 async getDraft() {
                     const token = channelRef.client['jwt'];
                     if (!token) return '';
-                    const res = await apiFetch(`/rooms/${channelRef.uuid}/draft`, {
+                    const res = await apiFetch(`/rooms/${channelRef.uuid}/draft/`, {
                         headers: { Authorization: `Bearer ${token}` },
                     });
                     if (!res.ok) throw new Error('getDraft failed');
@@ -469,7 +469,7 @@ export class Channel {
                     this.initState();
                     const token = channelRef.client['jwt'];
                     if (token) {
-                        apiFetch(`/rooms/${channelRef.uuid}/draft`, {
+                        apiFetch(`/rooms/${channelRef.uuid}/draft/`, {
                             method: 'DELETE',
                             headers: { Authorization: `Bearer ${token}` },
                         }).catch(() => { /* ignore network errors */ });


### PR DESCRIPTION
## Summary
- enforce trailing slashes in API URLs
- remove slashless draft endpoint and expose canonical token path
- update draft fetch calls and tests
- ensure README describes the trailing slash rule
- add unit test that checks API routes end with `/`

## Testing
- `pytest -q` *(fails: fixture 'settings' not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859391157bc83268fd4b1409211e37f