### PR TITLE
Enable posting messages via cid path

### DIFF
--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -13,10 +13,16 @@ from .models import (
 
 
 class MessageSerializer(serializers.ModelSerializer):
+    text = serializers.CharField(write_only=True)
+
     class Meta:
         model = Message
-        fields = ["id", "body", "sent_by", "created_at"]
-        read_only_fields = ["id", "created_at"]
+        fields = ["id", "text", "body", "sent_by", "created_at"]
+        read_only_fields = ["id", "body", "sent_by", "created_at"]
+
+    def create(self, validated_data):
+        validated_data["body"] = validated_data.pop("text")
+        return super().create(validated_data)
 
 class RoomSerializer(serializers.ModelSerializer):
     messages = MessageSerializer(many=True, read_only=True)

--- a/backend/chat/tests/test_create_message.py
+++ b/backend/chat/tests/test_create_message.py
@@ -14,7 +14,7 @@ class CreateMessageAPITests(APITestCase):
     def test_create_message(self):
         self.client.force_authenticate(self.user)
         url = reverse("room-messages", kwargs={"room_uuid": self.room.uuid})
-        resp = self.client.post(url, {"body": "hi"}, format="json")
+        resp = self.client.post(url, {"text": "hi"}, format="json")
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["body"], "hi")
 
@@ -26,5 +26,5 @@ class CreateMessageAPITests(APITestCase):
 
     def test_unauthenticated(self):
         url = reverse("room-messages", kwargs={"room_uuid": self.room.uuid})
-        resp = self.client.post(url, {"body": "hi"}, format="json")
+        resp = self.client.post(url, {"text": "hi"}, format="json")
         self.assertEqual(resp.status_code, 403)

--- a/backend/chat/tests/test_get_messages_cid.py
+++ b/backend/chat/tests/test_get_messages_cid.py
@@ -35,9 +35,16 @@ class GetCIDMessagesAPITests(APITestCase):
         res = self.client.get(url)
         self.assertEqual(res.status_code, 403)
 
-    def test_wrong_method(self):
+    def test_create_message_via_cid(self):
         room = Room.objects.create(uuid="r1", client="c1")
         token = self.make_token()
         url = reverse("room-messages-cid", kwargs={"cid": f"messaging:{room.uuid}"})
-        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
-        self.assertEqual(res.status_code, 405)
+        res = self.client.post(
+            url,
+            {"text": "hello"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(room.messages.count(), 1)
+        self.assertEqual(room.messages.first().body, "hello")

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -7,7 +7,7 @@ from chat.api_views import (
     RoomDraftView,
     RoomConfigView,
     RoomConfigStateView,
-    RoomMessagesView,
+    RoomMessageListCreateView,
     RoomMembersCIDView,
 )
 
@@ -43,10 +43,10 @@ urlpatterns += [
     re_path(r"^api/rooms/(?P<room_uuid>[^/]+)/draft/?$", RoomDraftView.as_view()),
     path(
         "api/rooms/<path:cid>/messages/",
-        RoomMessagesView.as_view(),
+        RoomMessageListCreateView.as_view(),
         name="room-messages-cid",
     ),
-    re_path(r"^api/rooms/(?P<cid>.+)/messages/?$", RoomMessagesView.as_view()),
+    re_path(r"^api/rooms/(?P<cid>.+)/messages/?$", RoomMessageListCreateView.as_view()),
     path("api/rooms/<path:cid>/config/", RoomConfigView.as_view(), name="room-config"),
     re_path(r"^api/rooms/(?P<cid>.+)/config/?$", RoomConfigView.as_view()),
     path(


### PR DESCRIPTION
## Summary
- allow MessageSerializer to accept `text` payloads
- extend RoomMessageListCreateView to support `<cid>` routes
- route `/api/rooms/<cid>/messages/` to the list-create view
- update unit tests for `text` field and cid posting

## Testing
- `pytest backend/chat/tests/test_create_message.py backend/chat/tests/test_send_message.py backend/chat/tests/test_get_messages_cid.py -q` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859421714088326a034f97b3d6e5108