### PR TITLE
Enable text field for message creation

### DIFF
--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -13,10 +13,20 @@ from .models import (
 
 
 class MessageSerializer(serializers.ModelSerializer):
+    """Expose `body` as read-only and accept `text` on input."""
+
+    text = serializers.CharField(write_only=True, required=False)
+
     class Meta:
         model = Message
-        fields = ["id", "body", "sent_by", "created_at"]
-        read_only_fields = ["id", "created_at"]
+        fields = ["id", "text", "body", "sent_by", "created_at"]
+        read_only_fields = ["id", "body", "sent_by", "created_at"]
+
+    def create(self, validated_data):
+        # Map the incoming text field to the body column
+        if "text" in validated_data:
+            validated_data["body"] = validated_data.pop("text")
+        return super().create(validated_data)
 
 class RoomSerializer(serializers.ModelSerializer):
     messages = MessageSerializer(many=True, read_only=True)

--- a/backend/chat/tests/test_create_message.py
+++ b/backend/chat/tests/test_create_message.py
@@ -14,7 +14,7 @@ class CreateMessageAPITests(APITestCase):
     def test_create_message(self):
         self.client.force_authenticate(self.user)
         url = reverse("room-messages", kwargs={"room_uuid": self.room.uuid})
-        resp = self.client.post(url, {"body": "hi"}, format="json")
+        resp = self.client.post(url, {"text": "hi"}, format="json")
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["body"], "hi")
 
@@ -26,5 +26,5 @@ class CreateMessageAPITests(APITestCase):
 
     def test_unauthenticated(self):
         url = reverse("room-messages", kwargs={"room_uuid": self.room.uuid})
-        resp = self.client.post(url, {"body": "hi"}, format="json")
+        resp = self.client.post(url, {"text": "hi"}, format="json")
         self.assertEqual(resp.status_code, 403)


### PR DESCRIPTION
## Summary
- map `text` to `body` when creating a message
- adjust create_message test to post `text`

## Testing
- `DJANGO_SETTINGS_MODULE=jatte.settings pytest -q chat/tests/test_create_message.py::CreateMessageAPITests::test_create_message --maxfail=1` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595084d230832699f6f5bd309b0cf0