### PR TITLE
Fix token forwarding in authentication

### DIFF
--- a/backend/accounts_supabase/authentication.py
+++ b/backend/accounts_supabase/authentication.py
@@ -77,7 +77,8 @@ class SupabaseJWTAuthentication(authentication.BaseAuthentication):
             user.supabase_uid = uid
             user.save(update_fields=["supabase_uid"])
 
-        return (user, None)
+        # Return the original JWT so views can forward it if needed
+        return (user, token)
 
 class DevTokenOrJWTAuthentication(SupabaseJWTAuthentication):
     """Legacy alias without dev-token support."""

--- a/backend/chat/tests/test_token.py
+++ b/backend/chat/tests/test_token.py
@@ -1,0 +1,26 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+import jwt
+
+class TokenAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+    def test_token_returns_passed_token(self):
+        token = self.make_token()
+        url = reverse("token-obtain")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["userToken"], token)
+
+    def test_token_requires_auth(self):
+        url = reverse("token-obtain")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_token_wrong_method(self):
+        token = self.make_token()
+        url = reverse("token-obtain")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/backend/jatte/auth/supabase.py
+++ b/backend/jatte/auth/supabase.py
@@ -57,4 +57,5 @@ class Old_Maybe_Delete_SupabaseJWTAuthentication(authentication.BaseAuthenticati
             user.supabase_uid = uid
             user.save(update_fields=["supabase_uid"])
 
-        return (user, None)
+        # Return the token so downstream views can forward it
+        return (user, token)


### PR DESCRIPTION
## Summary
- return JWT from authentication so request.auth contains a token
- add regression tests for /api/token endpoint
- update unused supabase auth class to return JWT

## Testing
- `python backend/manage.py test chat.tests.test_token.TokenAPITests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_685964c40e8c8326a39d4023088f95f4