### PR TITLE
Add POST proxy for /api/rooms path

### DIFF
--- a/frontend/src/app/api/rooms/[...path]/route.ts
+++ b/frontend/src/app/api/rooms/[...path]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  const url = `${BACKEND}/api/rooms/${params.path.join('/')}/`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': req.headers.get('content-type') ?? 'application/json',
+      Authorization: req.headers.get('authorization') ?? '',
+    },
+    body: await req.text(),
+    credentials: 'include',
+  });
+
+  return new NextResponse(await resp.text(), {
+    status: resp.status,
+    headers: resp.headers,
+  });
+}


### PR DESCRIPTION
## Summary
- proxy POST calls for `/api/rooms/...` in Next.js so the request reaches Django

## Testing
- `pnpm -r test` *(fails: vitest missing, 69 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6859687853548326b6d3fce427dcd097