### PR TITLE
✔︎ fix RoomFromCIDMixin slug handling

### DIFF
--- a/backend/chat/mixins.py
+++ b/backend/chat/mixins.py
@@ -1,8 +1,16 @@
 from .models import Room
 
 class RoomFromCIDMixin:
-    """Create or retrieve a Room identified by cid/uuid."""
+    """Create or retrieve a Room identified by cid or plain uuid."""
 
     def get_room(self, cid: str) -> Room:
-        room, _ = Room.objects.get_or_create(uuid=cid, defaults={"client": "stream"})
+        """Normalise ``messaging:foo`` and ``foo`` to the same Room row."""
+        if ":" in cid:
+            _, room_uuid = cid.split(":", 1)
+        else:
+            room_uuid = cid
+        room, _ = Room.objects.get_or_create(
+            uuid=room_uuid,
+            defaults={"client": "stream"},
+        )
         return room


### PR DESCRIPTION
## Summary
- clean up RoomFromCIDMixin so both `messaging:<slug>` and `<slug>` resolve to the same Room

## Testing
- `pnpm --filter frontend test` *(fails: `vitest` not found)*
- `pnpm --filter frontend build` *(fails: `next` not found)*
- `pytest -q` *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859803e63f88326ad4bb5acfa526966