### PR TITLE
Fix message cid handling and env client select

### DIFF
--- a/frontend/src/lib/getStreamClient.ts
+++ b/frontend/src/lib/getStreamClient.ts
@@ -1,11 +1,15 @@
 import { ChatClient } from './stream-adapter';
+import { getLocalClient } from 'stream-chat';
 
+type AnyClient = ChatClient & Record<string, unknown>;
 
-let client: ChatClient | null = null;
+let client: AnyClient | null = null;
 
-export const getStreamClient = (): ChatClient => {
+export const getStreamClient = (): AnyClient => {
   if (!client) {
-    client = new ChatClient();
+    client = process.env.NEXT_PUBLIC_STREAM_KEY
+      ? new ChatClient()
+      : (getLocalClient() as AnyClient);
   }
   return client;
 };


### PR DESCRIPTION
## Summary
- normalise cid in websocket consumer
- choose local or HTTP client based on env var

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598e2e43688326a9a133178d010645