### PR TITLE
Fix useStateStore optional

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -133,7 +133,10 @@ declare module 'stream-chat' {
     partialNext(patch: Partial<T>): void;
     next(patch: Partial<T>): void;
   }
-  export function useStateStore<T>(store: StateStore<T>): T;
+  export function useStateStore<T, O = T>(
+    store: StateStore<T> | undefined,
+    selector?: (v: T) => O,
+  ): O | undefined;
   export function formatMessage(text: string): string;
   export interface LinkPreview {
     url: string;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -784,10 +784,16 @@ export class StateStore<T = any> {
 }
 
 /** React hook that subscribes to a StateStore and returns its latest value */
-export function useStateStore<T>(store: StateStore<T>): T {
-  return useSyncExternalStore(store.subscribe.bind(store),
-    store.getLatestValue.bind(store),
-    store.getLatestValue.bind(store));
+export function useStateStore<T, O = T>(
+  store: StateStore<T> | undefined,
+  selector: (v: T) => O = (v) => v as unknown as O,
+): O | undefined {
+  if (!store) return undefined;
+  return useSyncExternalStore(
+    store.subscribe.bind(store),
+    () => selector(store.getLatestValue()),
+    () => selector(store.getLatestValue()),
+  );
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- allow `useStateStore` to accept optional stores

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_6859909c7de4832683a1de3b7a4bc494