### PR TITLE
Fix MessageComposer missing configState

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -224,6 +224,8 @@ declare module 'stream-chat' {
   export class MessageComposer {
     contextType: 'message';
     state: MessageComposerState;
+    /** configuration for the composer, e.g. accepted file types */
+    configState: StateStore<MessageComposerConfig>;
     attachmentManager: {
       state: StateStore<AttachmentManagerState>;
       availableUploadSlots: number;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -495,6 +495,8 @@ export interface MessageComposerConfig {
 export class MessageComposer {
   contextType: 'message' = 'message';
   state: MessageComposerState = { text: '', attachments: [] };
+  /** configuration for the composer, e.g. accepted file types */
+  configState: StateStore<MessageComposerConfig>;
   attachmentManager: {
     state: StateStore<AttachmentManagerState>;
     availableUploadSlots: number;
@@ -510,6 +512,21 @@ export class MessageComposer {
   };
 
   constructor(_config: MessageComposerConfig = {}) {
+    this.configState = new StateStore<MessageComposerConfig>({
+      attachments: {
+        acceptedFiles: [],
+        fileUploadFilter: () => true,
+        maxNumberOfFilesPerMessage: 10,
+      },
+      drafts: { enabled: false },
+      linkPreviews: {
+        debounceURLEnrichmentMs: 1500,
+        enabled: false,
+        findURLFn: (_t: string) => [],
+      },
+      text: { enabled: true, publishTypingEvents: true },
+      ..._config,
+    });
     const attState = new StateStore<AttachmentManagerState>({ attachments: [] });
     this.attachmentManager = {
       state: attState,


### PR DESCRIPTION
## Summary
- add `configState` to MessageComposer implementation
- expose the new field in TypeScript definitions

## Testing
- `pnpm test` *(fails: turbo not found)*
- `npx jest` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685994b5eccc832697c7f6405ffefc53