### PR TITLE
Add link preview status helpers

### DIFF
--- a/libs/chat-shim/__tests__/linkPreviewsManager.test.ts
+++ b/libs/chat-shim/__tests__/linkPreviewsManager.test.ts
@@ -1,4 +1,4 @@
-import { LinkPreviewsManager } from '../index';
+import { LinkPreviewsManager, LinkPreviewStatus } from '../index';
 
 describe('LinkPreviewsManager', () => {
   beforeEach(() => {
@@ -15,5 +15,6 @@ describe('LinkPreviewsManager', () => {
     const second = await mgr.fetch('https://example.com');
     expect(global.fetch).not.toHaveBeenCalled();
     expect(second).toBe(first);
+    expect(first.status).toBe(LinkPreviewStatus.loaded);
   });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -141,11 +141,26 @@ declare module 'stream-chat' {
   export interface LinkPreview {
     url: string;
     title: string;
+    status?: LinkPreviewStatus;
     [k: string]: any;
   }
   export class LinkPreviewsManager {
     constructor(limit?: number);
     fetch(url: string): Promise<LinkPreview>;
+    dismissPreview(url: string): void;
+    static previewIsLoading(p: LinkPreview): boolean;
+    static previewIsLoaded(p: LinkPreview): boolean;
+    static previewIsDismissed(p: LinkPreview): boolean;
+    static previewIsFailed(p: LinkPreview): boolean;
+    static previewIsPending(p: LinkPreview): boolean;
+    static getPreviewData(p: LinkPreview): Omit<LinkPreview, 'status'>;
+  }
+  export enum LinkPreviewStatus {
+    dismissed = 'dismissed',
+    failed = 'failed',
+    loaded = 'loaded',
+    loading = 'loading',
+    pending = 'pending',
   }
   export interface LinkPreviewsManagerState {
     previews: Map<string, LinkPreview>;


### PR DESCRIPTION
## Summary
- expand LinkPreview data to include status
- implement static helpers on LinkPreviewsManager
- store status on fetched previews and allow dismissing
- update corresponding type declarations
- extend link preview manager test

## Testing
- `pnpm --filter frontend test` *(fails: Error: Failed to load url stream-chat)*
- `pnpm --filter frontend build` *(fails: invalid POST route type)*

------
https://chatgpt.com/codex/tasks/task_e_68599a93b6ac8326a15879d56b83d87f