### PR TITLE
✅ fix useStateStore when store lacks getLatestValue

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -134,7 +134,14 @@ declare module 'stream-chat' {
     next(patch: Partial<T>): void;
   }
   export function useStateStore<T, O = T>(
-    store: StateStore<T> | undefined,
+    store:
+      | StateStore<T>
+      | {
+          subscribe?: (cb: () => void) => () => void;
+          getLatestValue?: () => T;
+          getSnapshot?: () => T;
+        }
+      | undefined,
     selector?: (v: T) => O,
   ): O | undefined;
   export function formatMessage(text: string): string;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -840,14 +840,23 @@ export class StateStore<T = any> {
 
 /** React hook that subscribes to a StateStore and returns its latest value */
 export function useStateStore<T, O = T>(
-  store: StateStore<T> | undefined,
+  store:
+    | StateStore<T>
+    | {
+        subscribe?: (cb: () => void) => () => void;
+        getLatestValue?: () => T;
+        getSnapshot?: () => T;
+      }
+    | undefined,
   selector: (v: T) => O = (v) => v as unknown as O,
 ): O | undefined {
-  if (!store) return undefined;
+  if (!store || typeof (store as any).subscribe !== 'function') return undefined;
+  const getter =
+    (store as any).getLatestValue ?? (store as any).getSnapshot ?? (() => undefined);
   return useSyncExternalStore(
-    store.subscribe.bind(store),
-    () => selector(store.getLatestValue()),
-    () => selector(store.getLatestValue()),
+    (store as any).subscribe.bind(store),
+    () => selector(getter()),
+    () => selector(getter()),
   );
 }
 


### PR DESCRIPTION
## Summary
- make useStateStore handle stores that don't implement `getLatestValue`

## Testing
- `pnpm --filter frontend test` *(fails: Failed to load url stream-chat)*
- `pnpm --filter frontend build` *(fails: invalid POST export type)*

------
https://chatgpt.com/codex/tasks/task_e_68599e4403c48326b540f0199335916a