### PR TITLE
Add Attachment shim

### DIFF
--- a/libs/chat-shim/RUNTIME_PATCHES.todo
+++ b/libs/chat-shim/RUNTIME_PATCHES.todo
@@ -1,0 +1,1 @@
+libs/stream-chat-shim/src/Attachment.tsx

--- a/libs/stream-chat-shim/__tests__/Attachment.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Attachment.test.tsx
@@ -1,0 +1,7 @@
+import { Attachment } from '../src/Attachment';
+
+describe('Attachment shim', () => {
+  it('throws when used', () => {
+    expect(() => Attachment({ attachments: [] })).toThrow('Attachment shim not implemented');
+  });
+});

--- a/libs/stream-chat-shim/src/Attachment.tsx
+++ b/libs/stream-chat-shim/src/Attachment.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export const ATTACHMENT_GROUPS_ORDER = [
+  'card',
+  'gallery',
+  'image',
+  'media',
+  'audio',
+  'voiceRecording',
+  'file',
+  'unsupported',
+] as const;
+
+export type AttachmentProps = {
+  attachments: any[];
+  actionHandler?: (...args: any[]) => any;
+  AttachmentActions?: React.ComponentType<any>;
+  Audio?: React.ComponentType<any>;
+  Card?: React.ComponentType<any>;
+  File?: React.ComponentType<any>;
+  Gallery?: React.ComponentType<any>;
+  Image?: React.ComponentType<any>;
+  isQuoted?: boolean;
+  Media?: React.ComponentType<any>;
+  UnsupportedAttachment?: React.ComponentType<any>;
+  VoiceRecording?: React.ComponentType<any>;
+};
+
+export const Attachment = (_props: AttachmentProps) => {
+  throw new Error('Attachment shim not implemented');
+};


### PR DESCRIPTION
## Summary
- add placeholder Attachment component under stream-chat-shim
- note runtime patch path for Attachment
- provide minimal unit test for shim

## Testing
- `npm test` *(fails: `turbo` not found)*
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: `tsc` script missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a38ee4acc8326a119cc5f5959abe0