### PR TITLE
Add attachment-utils shim

### DIFF
--- a/libs/chat-shim/RUNTIME_PATCHES.todo
+++ b/libs/chat-shim/RUNTIME_PATCHES.todo
@@ -1,0 +1,1 @@
+frontend/src/stream-chat-react-shim.ts

--- a/libs/stream-chat-shim/__tests__/attachment-utils.test.tsx
+++ b/libs/stream-chat-shim/__tests__/attachment-utils.test.tsx
@@ -1,0 +1,19 @@
+import { displayDuration, isGalleryAttachmentType, SUPPORTED_VIDEO_FORMATS } from '../src/attachment-utils';
+
+describe('attachment-utils', () => {
+  test('displayDuration formats seconds', () => {
+    expect(displayDuration(0)).toBe('00:00');
+    expect(displayDuration(70)).toBe('01:10');
+    expect(displayDuration(3661)).toBe('01:01:01');
+  });
+
+  test('isGalleryAttachmentType detects gallery', () => {
+    const gallery = { images: [], type: 'gallery' };
+    expect(isGalleryAttachmentType(gallery)).toBe(true);
+    expect(isGalleryAttachmentType({} as any)).toBe(false);
+  });
+
+  test('SUPPORTED_VIDEO_FORMATS has common formats', () => {
+    expect(SUPPORTED_VIDEO_FORMATS).toContain('video/mp4');
+  });
+});

--- a/libs/stream-chat-shim/src/attachment-utils.tsx
+++ b/libs/stream-chat-shim/src/attachment-utils.tsx
@@ -1,0 +1,68 @@
+// libs/stream-chat-shim/src/attachment-utils.tsx
+import type { ReactNode } from 'react';
+import type { Attachment } from 'stream-chat';
+
+export const SUPPORTED_VIDEO_FORMATS = [
+  'video/mp4',
+  'video/ogg',
+  'video/webm',
+  'video/quicktime',
+] as const;
+
+export type AttachmentComponentType =
+  | 'card'
+  | 'gallery'
+  | 'image'
+  | 'media'
+  | 'audio'
+  | 'voiceRecording'
+  | 'file'
+  | 'unsupported';
+
+export type GroupedRenderedAttachment = Record<AttachmentComponentType, ReactNode[]>;
+
+export type GalleryAttachment = {
+  images: Attachment[];
+  type: 'gallery';
+};
+
+// internal placeholder for props from Attachment component
+type AttachmentProps = any;
+
+export type RenderAttachmentProps = Omit<AttachmentProps, 'attachments'> & {
+  attachment: Attachment;
+};
+
+export type RenderGalleryProps = Omit<AttachmentProps, 'attachments'> & {
+  attachment: GalleryAttachment;
+};
+
+export const isGalleryAttachmentType = (
+  attachment: Attachment | GalleryAttachment,
+): attachment is GalleryAttachment =>
+  Array.isArray((attachment as GalleryAttachment).images);
+
+export const isSvgAttachment = (attachment: Attachment) => {
+  const filename = attachment.fallback || '';
+  return filename.toLowerCase().endsWith('.svg');
+};
+
+export const divMod = (num: number, divisor: number) => [
+  Math.floor(num / divisor),
+  num % divisor,
+];
+
+export const displayDuration = (totalSeconds?: number) => {
+  if (!totalSeconds || totalSeconds < 0) return '00:00';
+
+  const [hours, hoursLeftover] = divMod(totalSeconds, 3600);
+  const [minutes, seconds] = divMod(hoursLeftover, 60);
+  const roundedSeconds = Math.ceil(seconds);
+
+  const prependHrsZero = hours.toString().length === 1 ? '0' : '';
+  const prependMinZero = minutes.toString().length === 1 ? '0' : '';
+  const prependSecZero = roundedSeconds.toString().length === 1 ? '0' : '';
+  const minSec = `${prependMinZero}${minutes}:${prependSecZero}${roundedSeconds}`;
+
+  return hours ? `${prependHrsZero}${hours}:` + minSec : minSec;
+};


### PR DESCRIPTION
## Summary
- implement `attachment-utils` shim for stream chat react migration
- add basic unit tests for attachment util functions
- track runtime patch location

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: none of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a39baa7388326a2b1a13fc92bace2