### PR TITLE
Add VoiceRecording shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Locating the original reference
 | 008 | Card                                 | libs/stream-ui/src/components/Attachment/Card.tsx                                                                    | ☐ | |
 | 009 | FileAttachment                       | libs/stream-ui/src/components/Attachment/FileAttachment.tsx                                                          | ☐ | |
 | 010 | UnsupportedAttachment                | libs/stream-ui/src/components/Attachment/UnsupportedAttachment.tsx                                                   | ☐ | |
-| 011 | VoiceRecording                       | libs/stream-ui/src/components/Attachment/VoiceRecording.tsx                                                          | ☐ | |
+| 011 | VoiceRecording                       | libs/stream-ui/src/components/Attachment/VoiceRecording.tsx                                                          | ✅ | |
 | 012 | attachment-sizing                    | libs/stream-ui/src/components/Attachment/attachment-sizing.tsx                                                       | ☐ | |
 | 013 | attachment-utils                     | libs/stream-ui/src/components/Attachment/utils.tsx                                                                   | ☐ | |
 | 014 | Avatar                               | libs/stream-ui/src/components/Avatar/Avatar.tsx                                                                      | ☐ | |

--- a/libs/stream-chat-shim/__tests__/VoiceRecording.test.tsx
+++ b/libs/stream-chat-shim/__tests__/VoiceRecording.test.tsx
@@ -1,0 +1,9 @@
+/// <reference types="jest" />
+import React from 'react';
+import { render } from '@testing-library/react';
+import { VoiceRecording } from '../src/VoiceRecording';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<VoiceRecording attachment={{}} />);
+  expect(getByTestId('voice-recording-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/VoiceRecording.tsx
+++ b/libs/stream-chat-shim/src/VoiceRecording.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export type VoiceRecordingProps = {
+  /** The attachment object from the message's attachment list. */
+  attachment: any;
+  /** If true, render a compact variant for quoted replies. */
+  isQuoted?: boolean;
+};
+
+/** Placeholder VoiceRecording component. */
+export const VoiceRecording = ({ isQuoted }: VoiceRecordingProps) => (
+  <div data-testid="voice-recording-placeholder">
+    {isQuoted ? 'Quoted Voice Recording' : 'Voice Recording'}
+  </div>
+);
+
+export default VoiceRecording;


### PR DESCRIPTION
## Summary
- stub `VoiceRecording` component in `stream-chat-shim`
- provide a simple test harness
- drop barrel re-export to avoid conflicts
- mark VoiceRecording row complete in the migration board

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685a397969248326b867bf64326317d6