### PR TITLE
Add shim for channelState

### DIFF
--- a/libs/stream-chat-shim/__tests__/channelState.test.tsx
+++ b/libs/stream-chat-shim/__tests__/channelState.test.tsx
@@ -1,0 +1,15 @@
+import { makeChannelReducer, initialState } from '../src/channelState';
+
+describe('channelState shim', () => {
+  test('makeChannelReducer returns a reducer function', () => {
+    const reducer = makeChannelReducer();
+    expect(typeof reducer).toBe('function');
+    const state = { v: 1 };
+    expect(reducer(state, { type: 'x' } as any)).toBe(state);
+  });
+
+  test('initialState has basic fields', () => {
+    expect(initialState).toHaveProperty('loading');
+    expect(initialState).toHaveProperty('messages');
+  });
+});

--- a/libs/stream-chat-shim/index.ts
+++ b/libs/stream-chat-shim/index.ts
@@ -1,0 +1,1 @@
+export * from './src/channelState';

--- a/libs/stream-chat-shim/src/channelState.ts
+++ b/libs/stream-chat-shim/src/channelState.ts
@@ -1,0 +1,25 @@
+export type ChannelStateReducerAction = any;
+
+export const makeChannelReducer = () =>
+  (state: any, _action: ChannelStateReducerAction) => state;
+
+export const initialState = {
+  error: null,
+  hasMore: true,
+  hasMoreNewer: false,
+  loading: true,
+  loadingMore: false,
+  members: {},
+  messages: [],
+  pinnedMessages: [],
+  read: {},
+  suppressAutoscroll: false,
+  thread: null,
+  threadHasMore: true,
+  threadLoadingMore: false,
+  threadMessages: [],
+  threadSuppressAutoscroll: false,
+  typing: {},
+  watcherCount: 0,
+  watchers: {},
+};


### PR DESCRIPTION
## Summary
- add channelState shim with minimal reducer and initial state
- expose channelState via new package barrel
- add unit test covering the shim

## Testing
- `pnpm -F frontend build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3a0f3bac832682268db6acce1cd9