### PR TITLE
Add useEditMessageHandler shim

### DIFF
--- a/libs/stream-chat-shim/src/useEditMessageHandler.ts
+++ b/libs/stream-chat-shim/src/useEditMessageHandler.ts
@@ -1,0 +1,29 @@
+import type {
+  LocalMessage,
+  MessageResponse,
+  StreamChat,
+  UpdateMessageOptions,
+  UpdateMessageAPIResponse,
+} from 'stream-chat';
+
+// Callback type matching Stream Chat React's expectation
+export type UpdateHandler = (
+  cid: string,
+  updatedMessage: LocalMessage | MessageResponse,
+  options?: UpdateMessageOptions,
+) => ReturnType<StreamChat['updateMessage']>;
+
+/**
+ * Placeholder implementation of useEditMessageHandler.
+ * Returns a function that throws to indicate unimplemented behaviour.
+ */
+export function useEditMessageHandler(
+  _doUpdateMessageRequest?: UpdateHandler,
+): (
+  updatedMessage: LocalMessage | MessageResponse,
+  options?: UpdateMessageOptions,
+) => Promise<UpdateMessageAPIResponse> {
+  return async () => {
+    throw new Error('useEditMessageHandler not implemented');
+  };
+}


### PR DESCRIPTION
## Summary
- implement `useEditMessageHandler` placeholder in `libs/stream-chat-shim`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_685a3a223f6083268e2bc1924839f03a