### PR TITLE
Add ChannelHeader shim

### DIFF
--- a/libs/chat-shim/RUNTIME_PATCHES.todo
+++ b/libs/chat-shim/RUNTIME_PATCHES.todo
@@ -1,0 +1,1 @@
+frontend/src/stream-chat-react-shim.ts

--- a/libs/stream-chat-shim/src/ChannelHeader.tsx
+++ b/libs/stream-chat-shim/src/ChannelHeader.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export type ChannelAvatarProps = Record<string, any>;
+
+export type ChannelHeaderProps = {
+  Avatar?: React.ComponentType<ChannelAvatarProps>;
+  image?: string;
+  live?: boolean;
+  MenuIcon?: React.ComponentType;
+  title?: string;
+};
+
+/** Placeholder implementation of ChannelHeader. */
+export const ChannelHeader = (_props: ChannelHeaderProps) => {
+  return <div data-placeholder='ChannelHeader' />;
+};


### PR DESCRIPTION
## Summary
- add placeholder `ChannelHeader` component to stream-chat-shim
- begin runtime patch tracking file

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: script missing)*
- `pnpm exec tsc --noEmit` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_685a3a7b95e083268050ca9780fd23f0