### PR TITLE
Add ChannelListMessenger shim

### DIFF
--- a/libs/chat-shim/RUNTIME_PATCHES.todo
+++ b/libs/chat-shim/RUNTIME_PATCHES.todo
@@ -1,0 +1,1 @@
+frontend/src/stream-chat-react-shim.ts

--- a/libs/stream-chat-shim/index.ts
+++ b/libs/stream-chat-shim/index.ts
@@ -1,0 +1,1 @@
+export * from './src/ChannelListMessenger';

--- a/libs/stream-chat-shim/src/ChannelListMessenger.tsx
+++ b/libs/stream-chat-shim/src/ChannelListMessenger.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { PropsWithChildren } from 'react';
+import type { Channel } from 'stream-chat';
+
+/** Props accepted by {@link ChannelListMessenger} */
+export type ChannelListMessengerProps = {
+  /** Whether the channel query request returned an errored response */
+  error: any | null;
+  /** The channels currently loaded in the list, only defined if `sendChannelsToList` on `ChannelList` is true */
+  loadedChannels?: Channel[];
+  /** Whether the channels are currently loading */
+  loading?: boolean;
+  /** Custom UI component to display the loading error indicator */
+  LoadingErrorIndicator?: React.ComponentType;
+  /** Custom UI component to display a loading indicator */
+  LoadingIndicator?: React.ComponentType;
+  /** Local state hook that resets the currently loaded channels */
+  setChannels?: React.Dispatch<React.SetStateAction<Channel[]>>;
+};
+
+/**
+ * Minimal placeholder implementation of the ChannelListMessenger component.
+ * It simply renders `children` wrapped in a <div>.
+ */
+export const ChannelListMessenger = (
+  props: PropsWithChildren<ChannelListMessengerProps>,
+) => {
+  const { children } = props;
+  return <div>{children}</div>;
+};
+
+export default ChannelListMessenger;


### PR DESCRIPTION
## Summary
- add ChannelListMessenger placeholder component
- export from stream-chat-shim package
- track runtime patch locations

## Testing
- `pnpm build` *(fails: command not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685a3a9e16b48326be62135e1185b11e