### PR TITLE
Add shim for useChannelHiddenListener

### DIFF
--- a/libs/stream-chat-shim/__tests__/useChannelHiddenListener.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useChannelHiddenListener.test.tsx
@@ -1,0 +1,10 @@
+import { renderHook } from '@testing-library/react';
+import { useChannelHiddenListener } from '../src/useChannelHiddenListener';
+
+it('renders without crashing', () => {
+  const setChannels = jest.fn();
+  const { result } = renderHook(() =>
+    useChannelHiddenListener(setChannels)
+  );
+  expect(result.error).toBeUndefined();
+});

--- a/libs/stream-chat-shim/src/useChannelHiddenListener.ts
+++ b/libs/stream-chat-shim/src/useChannelHiddenListener.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import type { Channel, Event } from 'stream-chat';
+
+/**
+ * Placeholder implementation of Stream's `useChannelHiddenListener` hook.
+ */
+export const useChannelHiddenListener = (
+  setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+  customHandler?: (
+    setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+    event: Event,
+  ) => void,
+) => {
+  useEffect(() => {
+    // TODO: wire up real Stream Chat client events
+  }, [setChannels, customHandler]);
+};


### PR DESCRIPTION
## Summary
- add placeholder hook `useChannelHiddenListener`
- cover the new hook with a minimal test
- mark task as done

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*
- `pnpm -r build` *(fails: frontend build errors)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685aa1bd1ce88326816c98684c603c54