### PR TITLE
Add useChannelTruncatedListener shim

### DIFF
--- a/libs/stream-chat-shim/src/useChannelTruncatedListener.ts
+++ b/libs/stream-chat-shim/src/useChannelTruncatedListener.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import type { Channel, Event } from 'stream-chat';
+
+export const useChannelTruncatedListener = (
+  setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+  customHandler?: (
+    setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+    event: Event,
+  ) => void,
+  forceUpdate?: () => void,
+) => {
+  useEffect(() => {
+    // TODO: wire up real Stream Chat client events
+  }, [setChannels, customHandler, forceUpdate]);
+};


### PR DESCRIPTION
## Summary
- add placeholder for `useChannelTruncatedListener` hook
- mark `useChannelTruncatedListener` as implemented in status folder

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: `tsc` script not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa2786ad48326ad35d6852f4a2ed1