### PR TITLE
Add useChannelUpdatedListener shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useChannelUpdatedListener.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useChannelUpdatedListener.test.tsx
@@ -1,0 +1,11 @@
+import { renderHook } from '@testing-library/react';
+import { useChannelUpdatedListener } from '../src/useChannelUpdatedListener';
+import type { Channel } from 'stream-chat';
+
+describe('useChannelUpdatedListener', () => {
+  test('can be invoked without errors', () => {
+    const setChannels = (() => {}) as React.Dispatch<React.SetStateAction<Array<Channel>>>;
+    const { result } = renderHook(() => useChannelUpdatedListener(setChannels));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/useChannelUpdatedListener.ts
+++ b/libs/stream-chat-shim/src/useChannelUpdatedListener.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import type { Channel, Event } from 'stream-chat';
+
+/**
+ * Placeholder implementation for useChannelUpdatedListener.
+ * Hooks into channel update events when wired to a Stream Chat client.
+ *
+ * @param setChannels - State setter for the channel list.
+ * @param customHandler - Optional callback for custom handling of the event.
+ */
+export const useChannelUpdatedListener = (
+  setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+  customHandler?: (
+    setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+    event: Event,
+  ) => void,
+) => {
+  useEffect(() => {
+    // TODO: wire up real Stream Chat client events
+  }, [setChannels, customHandler]);
+};


### PR DESCRIPTION
## Summary
- add `useChannelUpdatedListener` shim
- provide a simple unit test
- mark task complete

## Testing
- `pnpm -r build` *(fails: `next build` not found)*
- `pnpm --filter frontend exec tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685aa2894d64832683a19c744b5db277