### PR TITLE
Add useMessageNewListener shim

### DIFF
--- a/libs/stream-chat-shim/src/useMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/useMessageNewListener.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import type { Channel, Event } from 'stream-chat';
+
+/**
+ * Placeholder for Stream\'s useMessageNewListener hook.
+ * Sets up a listener for new message events.
+ */
+export const useMessageNewListener = (
+  setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+  customHandler?: (
+    setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
+    event: Event,
+  ) => void,
+  lockChannelOrder = false,
+  allowNewMessagesFromUnfilteredChannels = true,
+) => {
+  useEffect(() => {
+    // TODO: wire up real Stream Chat client events
+  }, [
+    setChannels,
+    customHandler,
+    lockChannelOrder,
+    allowNewMessagesFromUnfilteredChannels,
+  ]);
+};


### PR DESCRIPTION
## Summary
- add placeholder hook `useMessageNewListener`
- mark symbol as complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685aa2c1e3c4832691ff57fd8a133dd4