### PR TITLE
Add ChannelPreview shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ChannelPreview.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ChannelPreview.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ChannelPreview } from '../src/ChannelPreview';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<ChannelPreview channel={{} as any} />);
+  expect(getByTestId('channel-preview-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/ChannelPreview.tsx
@@ -1,0 +1,53 @@
+import React, { type ReactNode } from 'react';
+import type { Channel } from 'stream-chat';
+
+export type ChannelAvatarProps = Record<string, any>;
+export type GroupChannelDisplayInfo = Record<string, any>;
+export type LocalMessage = any;
+export type MessageDeliveryStatus = any;
+export type TranslationContextValue = {
+  t?: (key: string) => string;
+  userLanguage?: string;
+};
+export type ChatContextValue = {
+  setActiveChannel?: (...args: any[]) => void;
+  isMessageAIGenerated?: boolean;
+};
+
+export type ChannelPreviewProps = {
+  channel: Channel;
+  active?: boolean;
+  activeChannel?: Channel;
+  Avatar?: React.ComponentType<ChannelAvatarProps>;
+  channelUpdateCount?: number;
+  className?: string;
+  getLatestMessagePreview?: (
+    channel: Channel,
+    t: TranslationContextValue['t'],
+    userLanguage: TranslationContextValue['userLanguage'],
+    isMessageAIGenerated: ChatContextValue['isMessageAIGenerated'],
+  ) => ReactNode;
+  key?: string;
+  onSelect?: (event: React.MouseEvent) => void;
+  Preview?: React.ComponentType<ChannelPreviewUIComponentProps>;
+  setActiveChannel?: ChatContextValue['setActiveChannel'];
+  watchers?: { limit?: number; offset?: number };
+};
+
+export type ChannelPreviewUIComponentProps = ChannelPreviewProps & {
+  displayImage?: string;
+  displayTitle?: string;
+  groupChannelDisplayInfo?: GroupChannelDisplayInfo;
+  lastMessage?: LocalMessage;
+  latestMessage?: ReactNode;
+  latestMessagePreview?: ReactNode;
+  messageDeliveryStatus?: MessageDeliveryStatus;
+  unread?: number;
+};
+
+/** Placeholder implementation of ChannelPreview. */
+export const ChannelPreview = (_props: ChannelPreviewProps) => {
+  return <div data-testid="channel-preview-placeholder" />;
+};
+
+export default ChannelPreview;


### PR DESCRIPTION
## Summary
- implement `ChannelPreview` shim and placeholder test

## Testing
- `pnpm exec jest` *(fails: cannot find module 'react' and other type errors)*
- `pnpm build` *(fails: command not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685aa3588290832696e964fca649439f