### PR TITLE
Add ChannelPreviewActionButtons shim

### DIFF
--- a/libs/stream-chat-shim/src/ChannelPreviewActionButtons.tsx
+++ b/libs/stream-chat-shim/src/ChannelPreviewActionButtons.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export type ChannelPreviewActionButtonsProps = {
+  channel: any;
+};
+
+/** Placeholder implementation of ChannelPreviewActionButtons. */
+export function ChannelPreviewActionButtons({ channel }: ChannelPreviewActionButtonsProps) {
+  return (
+    <div data-testid="channel-preview-action-buttons-placeholder">
+      ChannelPreviewActionButtons
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add placeholder implementation for `ChannelPreviewActionButtons`
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685aa36639e083268b3110293c856269