### PR TITLE
Add SearchResults shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchResults.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchResults.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SearchResults } from '../src/SearchResults';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<SearchResults />);
+  expect(getByTestId('search-results-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/SearchResults.tsx
+++ b/libs/stream-chat-shim/src/SearchResults.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+/** Placeholder component for search results. */
+export const SearchResults = () => (
+  <div data-testid="search-results-placeholder">SearchResults</div>
+);
+
+export default SearchResults;


### PR DESCRIPTION
## Summary
- implement `SearchResults` placeholder component for the Stream Chat shim
- add a simple test for `SearchResults`
- mark SearchResults task done

## Testing
- `npx -p turbo@1.13.4 turbo run build` *(fails: turbo_json_parse_error)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*
- `pnpm jest` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa3b73e4083268e7dba8a5f89ef5c