### PR TITLE
Add SearchResults shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchResults.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchResults.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { SearchResults } from '../src/SearchResults'
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<SearchResults />)
+  expect(getByTestId('search-results-placeholder')).toBeTruthy()
+})

--- a/libs/stream-chat-shim/src/SearchResults.tsx
+++ b/libs/stream-chat-shim/src/SearchResults.tsx
@@ -1,0 +1,15 @@
+// libs/stream-chat-shim/src/SearchResults.tsx
+'use client'
+import React from 'react'
+
+/** Placeholder implementation of the SearchResults component.
+ *  It accepts no props and renders a minimal placeholder element.
+ */
+export const SearchResults = () => {
+  return (
+    <div data-testid="search-results-placeholder">SearchResults placeholder</div>
+  )
+}
+
+export default SearchResults
+


### PR DESCRIPTION
## Summary
- provide placeholder `SearchResults` component
- add basic test for the shim
- mark the symbol as done

## Testing
- `pnpm -r run build` *(fails: spawn ENOENT)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa3c065f08326a69e7ecc6826977f