### PR TITLE
Add channelSearch-utils shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/channelSearch-utils.test.tsx
+++ b/libs/stream-chat-shim/__tests__/channelSearch-utils.test.tsx
@@ -1,0 +1,11 @@
+import { isChannel } from '../src/channelSearch-utils';
+
+describe('channelSearch-utils', () => {
+  test('isChannel detects channel objects', () => {
+    const channel = { cid: 'messaging:general' } as any;
+    const user = { id: 'alice' } as any;
+    expect(isChannel(channel)).toBe(true);
+    expect(isChannel(user)).toBe(false);
+  });
+});
+

--- a/libs/stream-chat-shim/src/channelSearch-utils.ts
+++ b/libs/stream-chat-shim/src/channelSearch-utils.ts
@@ -1,0 +1,9 @@
+// libs/stream-chat-shim/src/channelSearch-utils.ts
+import type { Channel, UserResponse } from 'stream-chat';
+
+export type ChannelOrUserResponse = Channel | UserResponse;
+
+export const isChannel = (
+  output: ChannelOrUserResponse,
+): output is Channel => (output as Channel).cid != null;
+


### PR DESCRIPTION
## Summary
- add shim for channelSearch-utils
- test `isChannel`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa3e83d588326b283b7aefe884166