### PR TITLE
Add useCreateChatClient shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useCreateChatClient.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useCreateChatClient.test.tsx
@@ -1,0 +1,16 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCreateChatClient } from '../src/useCreateChatClient';
+
+it('creates and connects a chat client', async () => {
+  const { result } = renderHook(() =>
+    useCreateChatClient({
+      apiKey: 'test',
+      tokenOrProvider: 'token',
+      userData: { id: 'u1' },
+    })
+  );
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(result.current).not.toBeNull();
+});

--- a/libs/stream-chat-shim/src/useCreateChatClient.ts
+++ b/libs/stream-chat-shim/src/useCreateChatClient.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { StreamChat } from 'stream-chat';
+import type {
+  OwnUserResponse,
+  StreamChatOptions,
+  TokenOrProvider,
+  UserResponse,
+} from 'stream-chat';
+
+/**
+ * React hook to create, connect and return `StreamChat` client.
+ */
+export const useCreateChatClient = ({
+  apiKey,
+  options,
+  tokenOrProvider,
+  userData,
+}: {
+  apiKey: string;
+  tokenOrProvider: TokenOrProvider;
+  userData: OwnUserResponse | UserResponse;
+  options?: StreamChatOptions;
+}) => {
+  const [chatClient, setChatClient] = useState<StreamChat | null>(null);
+  const [cachedUserData, setCachedUserData] = useState(userData);
+
+  if (userData.id !== cachedUserData.id) {
+    setCachedUserData(userData);
+  }
+
+  const [cachedOptions] = useState(options);
+
+  useEffect(() => {
+    const client = new StreamChat(apiKey, undefined, cachedOptions);
+    let didUserConnectInterrupt = false;
+
+    const connectionPromise = client
+      .connectUser(cachedUserData, tokenOrProvider)
+      .then(() => {
+        if (!didUserConnectInterrupt) setChatClient(client);
+      });
+
+    return () => {
+      didUserConnectInterrupt = true;
+      setChatClient(null);
+      connectionPromise
+        .then(() => client.disconnectUser())
+        .then(() => {
+          console.log(`Connection for user "${cachedUserData.id}" has been closed`);
+        });
+    };
+  }, [apiKey, cachedUserData, cachedOptions, tokenOrProvider]);
+
+  return chatClient;
+};


### PR DESCRIPTION
## Summary
- implement `useCreateChatClient` hook in the shim package
- add a simple unit test
- mark the symbol as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No `tsc` script defined)*
- `pnpm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aab03a3e8832690413391e1e99369