### PR TITLE
Add ChatView shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ChatView.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ChatView.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ChatView } from '../src/ChatView';
+
+describe('ChatView component', () => {
+  it('renders children', () => {
+    const html = renderToStaticMarkup(<ChatView>child</ChatView>);
+    expect(html).toContain('child');
+  });
+});

--- a/libs/stream-chat-shim/src/ChatView.tsx
+++ b/libs/stream-chat-shim/src/ChatView.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, PropsWithChildren } from 'react';
+
+export type ThreadsViewContextValue = {
+  activeThread: any | undefined;
+  setActiveThread: (cv: ThreadsViewContextValue['activeThread']) => void;
+};
+
+const ThreadsViewContext = createContext<ThreadsViewContextValue>({
+  activeThread: undefined,
+  setActiveThread: () => {},
+});
+
+export const useThreadsViewContext = () => useContext(ThreadsViewContext);
+
+export const useActiveThread = ({ activeThread }: { activeThread?: any }) => {
+  useEffect(() => {
+    // TODO: implement thread activation logic
+  }, [activeThread]);
+};
+
+export const ChatView: React.FC<PropsWithChildren> & {
+  Channels: React.FC<PropsWithChildren>;
+  Threads: React.FC<PropsWithChildren>;
+  ThreadAdapter: React.FC<PropsWithChildren>;
+  Selector: React.FC;
+} = ({ children }) => {
+  return <div data-testid="chat-view">{children}</div>;
+};
+
+ChatView.Channels = ({ children }: PropsWithChildren<{}>) => (
+  <div data-testid="chat-view-channels">{children}</div>
+);
+
+ChatView.Threads = ({ children }: PropsWithChildren<{}>) => (
+  <div data-testid="chat-view-threads">{children}</div>
+);
+
+ChatView.ThreadAdapter = ({ children }: PropsWithChildren<{}>) => (
+  <div data-testid="chat-view-thread-adapter">{children}</div>
+);
+
+ChatView.Selector = () => <div data-testid="chat-view-selector" />;
+
+export default ChatView;


### PR DESCRIPTION
## Summary
- implement placeholder `ChatView` component in stream-chat-shim
- add tests for the new shim
- mark `ChatView` as implemented

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aac658c288326967efd62752d703d