### PR TITLE
Add useCursorPaginator shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useCursorPaginator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useCursorPaginator.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react';
+import { useCursorPaginator } from '../src/useCursorPaginator';
+
+describe('useCursorPaginator', () => {
+  test('returns placeholder store and loadMore throws', async () => {
+    const { result } = renderHook(() =>
+      useCursorPaginator(async () => ({ items: [], next: undefined }))
+    );
+
+    const state = result.current.cursorPaginatorState.getLatestValue();
+    expect(state.items).toEqual([]);
+    expect(state.hasNextPage).toBe(true);
+    expect(() => result.current.loadMore()).toThrow(
+      'useCursorPaginator not implemented'
+    );
+  });
+});

--- a/libs/stream-chat-shim/src/useCursorPaginator.ts
+++ b/libs/stream-chat-shim/src/useCursorPaginator.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type CursorPaginatorState<T> = {
+  hasNextPage: boolean;
+  items: T[];
+  latestPageItems: T[];
+  loading: boolean;
+  error?: Error;
+  next?: string | null;
+};
+
+export type CursorPaginatorStateStore<T> = {
+  getLatestValue: () => CursorPaginatorState<T>;
+};
+
+export type PaginationFn<T> = (next?: string) => Promise<{ items: T[]; next?: string }>;
+
+/**
+ * Placeholder implementation of Stream's `useCursorPaginator` hook.
+ * Maintains minimal state structure and throws when attempting to load data.
+ */
+export const useCursorPaginator = <T>(
+  _paginationFn: PaginationFn<T>,
+  loadFirstPage?: boolean,
+) => {
+  const [state] = useState<CursorPaginatorState<T>>({
+    hasNextPage: true,
+    items: [],
+    latestPageItems: [],
+    loading: false,
+  });
+
+  const getLatestValue = useCallback(() => state, [state]);
+
+  const cursorPaginatorState: CursorPaginatorStateStore<T> = {
+    getLatestValue,
+  };
+
+  const loadMore = useCallback(async () => {
+    throw new Error('useCursorPaginator not implemented');
+  }, []);
+
+  useEffect(() => {
+    // intentionally empty: placeholder does not automatically load pages
+  }, [loadFirstPage]);
+
+  return {
+    cursorPaginatorState,
+    loadMore,
+  };
+};


### PR DESCRIPTION
## Summary
- add placeholder `useCursorPaginator` hook in stream-chat-shim
- test that the hook returns default state and throws on load
- mark migration status

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No "tsc" script)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aace4fb848326ab7d1dc7bc715f28