### PR TITLE
Add FixedHeightMessage shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/FixedHeightMessage.test.tsx
+++ b/libs/stream-chat-shim/__tests__/FixedHeightMessage.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FixedHeightMessage } from '../src/FixedHeightMessage';
+
+describe('FixedHeightMessage component', () => {
+  it('renders message text when provided', () => {
+    const { getByTestId } = render(
+      <FixedHeightMessage message={{ id: '1', text: 'hello' } as any} />,
+    );
+    expect(getByTestId('fixed-height-message').textContent).toContain('hello');
+  });
+});

--- a/libs/stream-chat-shim/src/FixedHeightMessage.tsx
+++ b/libs/stream-chat-shim/src/FixedHeightMessage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { LocalMessage } from 'stream-chat';
+
+export type FixedHeightMessageProps = {
+  /** Whether to group messages from the same user */
+  groupedByUser?: boolean;
+  /** Message data to display */
+  message?: LocalMessage;
+};
+
+/** Minimal placeholder for Stream's FixedHeightMessage component. */
+export const FixedHeightMessage = ({ message }: FixedHeightMessageProps) => {
+  return (
+    <div data-testid="fixed-height-message">{message?.text}</div>
+  );
+};
+
+export default FixedHeightMessage;


### PR DESCRIPTION
## Summary
- add placeholder implementation for `FixedHeightMessage`
- add unit test covering the placeholder
- mark symbol as completed

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685aad1cc81c8326acd9f5b74db5af38