### PR TITLE
Add MessageDeleted shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageDeleted.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageDeleted.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageDeleted } from '../src/MessageDeleted';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<MessageDeleted message={{ id: '1' }} />);
+  expect(getByTestId('message-deleted-component')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/MessageDeleted.tsx
+++ b/libs/stream-chat-shim/src/MessageDeleted.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type MessageDeletedProps = {
+  /** The message object that was deleted */
+  message: any;
+};
+
+/** Placeholder implementation of MessageDeleted component */
+export const MessageDeleted = ({ message }: MessageDeletedProps) => {
+  return (
+    <div
+      className="str-chat__message str-chat__message--deleted"
+      data-testid="message-deleted-component"
+      key={message?.id}
+    >
+      <div className="str-chat__message--deleted-inner">This message was deleted...</div>
+    </div>
+  );
+};
+
+export default MessageDeleted;


### PR DESCRIPTION
## Summary
- add placeholder shim for MessageDeleted
- add unit test
- mark MessageDeleted as complete

## Testing
- `pnpm turbo run build` *(fails: turbo_json_parse_error)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685aad2cf3448326b36b14113598707f