### PR TITLE
Add MessageErrorText shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageErrorText.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageErrorText.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageErrorText } from '../src/MessageErrorText';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<MessageErrorText />);
+  expect(getByTestId('message-error-text-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/MessageErrorText.tsx
+++ b/libs/stream-chat-shim/src/MessageErrorText.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import type { LocalMessage } from 'stream-chat';
+
+export type MessageErrorTextProps = {
+  /** The message that failed to send */
+  message?: LocalMessage;
+};
+
+/** Placeholder component displayed when a message fails to send. */
+export const MessageErrorText = (_props: MessageErrorTextProps) => (
+  <span data-testid="message-error-text-placeholder">Message failed</span>
+);
+
+export default MessageErrorText;


### PR DESCRIPTION
## Summary
- stub `MessageErrorText` component in stream-chat-shim
- add corresponding unit test
- mark `MessageErrorText` as complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aad381bb08326ad4eb24214bdfafc