### PR TITLE
Add MessageText placeholder

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageText.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageText.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { MessageText } from '../src/MessageText'
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<MessageText />)
+  expect(getByTestId('message-text-placeholder')).toBeTruthy()
+})

--- a/libs/stream-chat-shim/src/MessageText.tsx
+++ b/libs/stream-chat-shim/src/MessageText.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { LocalMessage } from 'stream-chat'
+
+export type MessageTextProps = {
+  customInnerClass?: string
+  customWrapperClass?: string
+  message?: LocalMessage
+  theme?: string
+  renderText?: (text?: string, mentioned_users?: any[]) => React.ReactNode
+}
+
+/** Placeholder implementation of the MessageText component. */
+export const MessageText = (_props: MessageTextProps) => {
+  return (
+    <div data-testid="message-text-placeholder">MessageText placeholder</div>
+  )
+}
+
+export default MessageText


### PR DESCRIPTION
## Summary
- add a shim for `MessageText`
- provide basic test for the placeholder
- mark `MessageText` as complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: tsc script missing)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aad4883308326afe584cdfe4e05f5