### PR TITLE
Add QuotedMessage shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/QuotedMessage.test.tsx
+++ b/libs/stream-chat-shim/__tests__/QuotedMessage.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { QuotedMessage } from '../src/QuotedMessage';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<QuotedMessage />);
+  expect(getByTestId('quoted-message-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/QuotedMessage.tsx
+++ b/libs/stream-chat-shim/src/QuotedMessage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export type QuotedMessageProps = {
+  /**
+   * Function to render the text content of the quoted message.
+   */
+  renderText?: (...args: any[]) => React.ReactNode;
+};
+
+/**
+ * Placeholder implementation of Stream's `QuotedMessage` component.
+ */
+export const QuotedMessage = (_props: QuotedMessageProps) => {
+  return <div data-testid="quoted-message-placeholder" />;
+};
+
+export default QuotedMessage;


### PR DESCRIPTION
## Summary
- implement `QuotedMessage` placeholder component
- add simple unit test
- mark the symbol as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `npx jest` *(fails: many TS errors due to missing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685aada4c29c8326b5009125c6d4f78d