### PR TITLE
Add ReminderNotification shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ReminderNotification.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ReminderNotification.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ReminderNotification } from '../src/ReminderNotification';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<ReminderNotification />);
+  expect(getByTestId('reminder-notification-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/ReminderNotification.tsx
+++ b/libs/stream-chat-shim/src/ReminderNotification.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { Reminder } from 'stream-chat';
+
+export type ReminderNotificationProps = {
+  /** Reminder object associated with the notification. */
+  reminder?: Reminder;
+};
+
+/** Placeholder ReminderNotification component. */
+export const ReminderNotification = (_props: ReminderNotificationProps) => (
+  <div data-testid="reminder-notification-placeholder">
+    ReminderNotification placeholder
+  </div>
+);
+
+export default ReminderNotification;


### PR DESCRIPTION
## Summary
- implement `ReminderNotification` placeholder in stream-chat shim
- add basic test for placeholder rendering
- mark `ReminderNotification` task as complete

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685aadc58da08326a13e5852c64fe9b1