### PR TITLE
Add useDeleteHandler shim

### DIFF
--- a/libs/stream-chat-shim/src/useDeleteHandler.ts
+++ b/libs/stream-chat-shim/src/useDeleteHandler.ts
@@ -1,0 +1,24 @@
+import type { LocalMessage } from 'stream-chat';
+import type React from 'react';
+
+export type ReactEventHandler = (
+  event: React.BaseSyntheticEvent,
+) => Promise<void> | void;
+
+export type DeleteMessageNotifications = {
+  getErrorNotification?: (message: LocalMessage) => string;
+  notify?: (notificationText: string, type: 'success' | 'error') => void;
+};
+
+/**
+ * Placeholder implementation for Stream's `useDeleteHandler` hook.
+ * Returns a handler that throws to indicate the behaviour is not implemented.
+ */
+export const useDeleteHandler = (
+  _message?: LocalMessage,
+  _notifications: DeleteMessageNotifications = {},
+): ReactEventHandler => {
+  return async () => {
+    throw new Error('useDeleteHandler not implemented');
+  };
+};


### PR DESCRIPTION
## Summary
- stub `useDeleteHandler` hook in stream-chat shim
- mark migration status

## Testing
- `pnpm exec tsc --noEmit` *(fails: ',' expected in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685aae0d4a088326a88a762993e3a227