### PR TITLE
Add useFlagHandler shim

### DIFF
--- a/libs/stream-chat-shim/src/useFlagHandler.ts
+++ b/libs/stream-chat-shim/src/useFlagHandler.ts
@@ -1,0 +1,24 @@
+import type { LocalMessage } from 'stream-chat';
+
+export type FlagMessageNotifications = {
+  getErrorNotification?: (message: LocalMessage) => string;
+  getSuccessNotification?: (message: LocalMessage) => string;
+  notify?: (notificationText: string, type: 'success' | 'error') => void;
+};
+
+export type ReactEventHandler = (
+  event: React.SyntheticEvent,
+) => void | Promise<void>;
+
+/**
+ * Placeholder implementation for Stream's `useFlagHandler` hook.
+ */
+export const useFlagHandler = (
+  _message?: LocalMessage,
+  _notifications: FlagMessageNotifications = {},
+): ReactEventHandler => {
+  return async (event) => {
+    event.preventDefault();
+    throw new Error('useFlagHandler not implemented');
+  };
+};


### PR DESCRIPTION
## Summary
- add placeholder implementation for `useFlagHandler`
- mark `useFlagHandler` shim as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685aae1aaa748326a827ff7fddc813a4