### PR TITLE
Add useMarkUnreadHandler shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useMarkUnreadHandler.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useMarkUnreadHandler.test.tsx
@@ -1,0 +1,11 @@
+import { renderHook } from '@testing-library/react';
+import { useMarkUnreadHandler } from '../src/useMarkUnreadHandler';
+
+describe('useMarkUnreadHandler', () => {
+  test('throws when invoked', () => {
+    const { result } = renderHook(() => useMarkUnreadHandler());
+    expect(() => result.current({ preventDefault() {} } as any)).toThrow(
+      'useMarkUnreadHandler not implemented'
+    );
+  });
+});

--- a/libs/stream-chat-shim/src/useMarkUnreadHandler.ts
+++ b/libs/stream-chat-shim/src/useMarkUnreadHandler.ts
@@ -1,0 +1,25 @@
+import type { BaseSyntheticEvent } from 'react';
+import type { LocalMessage } from 'stream-chat';
+
+/** Match Stream's ReactEventHandler type. */
+export type ReactEventHandler = (event: BaseSyntheticEvent) => Promise<void> | void;
+
+export type MarkUnreadHandlerNotifications = {
+  getErrorNotification?: (message: LocalMessage) => string;
+  getSuccessNotification?: (message: LocalMessage) => string;
+  notify?: (notificationText: string, type: 'success' | 'error') => void;
+};
+
+/**
+ * Placeholder implementation of Stream's `useMarkUnreadHandler` hook.
+ *
+ * Returns a callback that throws until the real behaviour is implemented.
+ */
+export function useMarkUnreadHandler(
+  _message?: LocalMessage,
+  _notifications: MarkUnreadHandlerNotifications = {},
+): ReactEventHandler {
+  return () => {
+    throw new Error('useMarkUnreadHandler not implemented');
+  };
+}


### PR DESCRIPTION
## Summary
- stub out `useMarkUnreadHandler` hook in stream-chat shim
- test that the hook throws when used
- mark symbol as completed

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*
- `npx jest` *(fails: requires installing jest)*

------
https://chatgpt.com/codex/tasks/task_e_685aae2a23048326b311f63a97c75ed6