### PR TITLE
Add placeholder useOpenThreadHandler hook

### DIFF
--- a/libs/stream-chat-shim/src/useOpenThreadHandler.ts
+++ b/libs/stream-chat-shim/src/useOpenThreadHandler.ts
@@ -1,0 +1,16 @@
+import type { LocalMessage } from 'stream-chat';
+
+export type ReactEventHandler = (event: React.BaseSyntheticEvent) => void;
+
+/**
+ * Placeholder implementation of Stream's `useOpenThreadHandler` hook.
+ * Returns a handler that throws to indicate missing implementation.
+ */
+export const useOpenThreadHandler = (
+  _message?: LocalMessage,
+  _customOpenThread?: (message: LocalMessage, event: React.BaseSyntheticEvent) => void,
+): ReactEventHandler => {
+  return () => {
+    throw new Error('useOpenThreadHandler not implemented');
+  };
+};


### PR DESCRIPTION
## Summary
- stub out `useOpenThreadHandler` in stream-chat-shim
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685aae6be6fc8326ae8b0f5858ca3786