### PR TITLE
Add usePinHandler shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/usePinHandler.test.tsx
+++ b/libs/stream-chat-shim/__tests__/usePinHandler.test.tsx
@@ -1,0 +1,10 @@
+import { renderHook } from '@testing-library/react';
+import { usePinHandler } from '../src/usePinHandler';
+
+describe('usePinHandler', () => {
+  test('returns placeholder handler', () => {
+    const { result } = renderHook(() => usePinHandler({} as any));
+    expect(result.current.canPin).toBe(false);
+    expect(() => result.current.handlePin({} as any)).toThrow('usePinHandler not implemented');
+  });
+});

--- a/libs/stream-chat-shim/src/usePinHandler.ts
+++ b/libs/stream-chat-shim/src/usePinHandler.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+
+/**
+ * @deprecated in favor of `channelCapabilities` - TODO: remove in next major release
+ */
+export type PinEnabledUserRoles<T extends string = string> = Partial<Record<T, boolean>> & {
+  admin?: boolean;
+  anonymous?: boolean;
+  channel_member?: boolean;
+  channel_moderator?: boolean;
+  guest?: boolean;
+  member?: boolean;
+  moderator?: boolean;
+  owner?: boolean;
+  user?: boolean;
+};
+
+/**
+ * @deprecated in favor of `channelCapabilities` - TODO: remove in next major release
+ */
+export type PinPermissions<T extends string = string, U extends string = string> =
+  Partial<Record<T, PinEnabledUserRoles<U>>> & {
+    commerce?: PinEnabledUserRoles<U>;
+    gaming?: PinEnabledUserRoles<U>;
+    livestream?: PinEnabledUserRoles<U>;
+    messaging?: PinEnabledUserRoles<U>;
+    team?: PinEnabledUserRoles<U>;
+  };
+
+export type PinMessageNotifications<StreamChatGenerics extends unknown = unknown> = {
+  getErrorNotification?: (message: any) => string;
+  notify?: (notificationText: string, type: 'success' | 'error') => void;
+};
+
+/**
+ * Placeholder implementation of Stream's `usePinHandler` hook.
+ * Returns a handler that throws to indicate unimplemented behaviour.
+ */
+export const usePinHandler = <StreamChatGenerics extends unknown = unknown>(
+  _message: any,
+  _permissions: PinPermissions = {},
+  _notifications: PinMessageNotifications<StreamChatGenerics> = {},
+) => {
+  const handlePin = useCallback(() => {
+    throw new Error('usePinHandler not implemented');
+  }, []);
+
+  const canPin = false;
+
+  return { canPin, handlePin } as const;
+};


### PR DESCRIPTION
## Summary
- add placeholder for `usePinHandler`
- test placeholder behaviour
- mark symbol done

## Testing
- `pnpm -r --if-present build` *(fails: next build errors)*
- `npx tsc -p frontend --noEmit` *(fails: multiple type errors)*
- `npx jest libs/stream-chat-shim/__tests__/usePinHandler.test.tsx` *(fails: cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_685aae7a85d08326a5c497fca6d09d75