### PR TITLE
Add renderText shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/renderText.test.tsx
+++ b/libs/stream-chat-shim/__tests__/renderText.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { renderText } from '../src/renderText';
+
+describe('renderText', () => {
+  it('renders markdown text', () => {
+    const html = renderToStaticMarkup(renderText('**hi**') as React.ReactElement);
+    expect(html).toContain('strong');
+  });
+});

--- a/libs/stream-chat-shim/src/renderText.tsx
+++ b/libs/stream-chat-shim/src/renderText.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactMarkdown, { Options } from 'react-markdown';
+import type { PluggableList } from 'react-markdown/lib/react-markdown';
+import type { UserResponse } from 'stream-chat';
+
+export type RenderTextPluginConfigurator = (
+  defaultPlugins: PluggableList,
+) => PluggableList;
+
+export const defaultAllowedTagNames: Array<keyof JSX.IntrinsicElements | 'emoji' | 'mention'> = [
+  'p',
+  'strong',
+  'em',
+  'a',
+  'code',
+  'pre',
+];
+
+export type RenderTextOptions<StreamChatGenerics = unknown> = {
+  allowedTagNames?: Array<
+    keyof JSX.IntrinsicElements | 'emoji' | 'mention' | (string & {})
+  >;
+  customMarkDownRenderers?: Options['components'];
+  getRehypePlugins?: RenderTextPluginConfigurator;
+  getRemarkPlugins?: RenderTextPluginConfigurator;
+};
+
+/**
+ * Minimal placeholder implementation of renderText.
+ * Renders markdown using react-markdown without advanced plugins.
+ */
+export const renderText = <StreamChatGenerics,>(
+  text?: string,
+  _mentionedUsers?: UserResponse<StreamChatGenerics>[],
+  _options: RenderTextOptions = {},
+) => {
+  if (!text) return null;
+  return <ReactMarkdown skipHtml>{text}</ReactMarkdown>;
+};
+
+export default renderText;


### PR DESCRIPTION
## Summary
- implement `renderText` placeholder shim
- add basic test
- mark symbol done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aaeec7f4c8326911399449b312960