### PR TITLE
Add CustomMessageActionsList shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/CustomMessageActionsList.test.tsx
+++ b/libs/stream-chat-shim/__tests__/CustomMessageActionsList.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { CustomMessageActionsList } from '../src/CustomMessageActionsList'
+
+test('renders custom actions and handles click', () => {
+  const handler = jest.fn()
+  const { getByText } = render(
+    <CustomMessageActionsList message={{}} customMessageActions={{ Test: handler }} />
+  )
+  const button = getByText('Test')
+  fireEvent.click(button)
+  expect(handler).toHaveBeenCalled()
+})

--- a/libs/stream-chat-shim/src/CustomMessageActionsList.tsx
+++ b/libs/stream-chat-shim/src/CustomMessageActionsList.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+export type CustomMessageActionsListProps = {
+  message: any
+  customMessageActions?: Record<string, (message: any, event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void>
+}
+
+/** Placeholder implementation mimicking the Stream Chat component. */
+export const CustomMessageActionsList = (props: CustomMessageActionsListProps) => {
+  const { customMessageActions, message } = props
+  if (!customMessageActions) return null
+
+  const customActionsArray = Object.keys(customMessageActions)
+
+  return (
+    <>
+      {customActionsArray.map((customAction) => {
+        const customHandler = customMessageActions[customAction]
+        return (
+          <button
+            aria-selected="false"
+            className="str-chat__message-actions-list-item str-chat__message-actions-list-item-button"
+            key={customAction}
+            onClick={(event) => customHandler(message, event)}
+            role="option"
+          >
+            {customAction}
+          </button>
+        )
+      })}
+    </>
+  )
+}
+
+export default CustomMessageActionsList


### PR DESCRIPTION
## Summary
- add placeholder CustomMessageActionsList component
- add corresponding unit test
- mark CustomMessageActionsList as done

## Testing
- `pnpm -F frontend exec tsc --noEmit` *(fails: Cannot find type definition file for 'jest', 'node', 'react')*
- `npx jest` *(fails: needs to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf2b95dc832689503c0ff473f006