### PR TITLE
Add FileAttachmentPreview shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/FileAttachmentPreview.test.tsx
+++ b/libs/stream-chat-shim/__tests__/FileAttachmentPreview.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FileAttachmentPreview } from '../src/FileAttachmentPreview';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(
+    <FileAttachmentPreview attachment={{ title: 'Document' } as any} />,
+  );
+  expect(getByTestId('file-attachment-preview-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/FileAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/FileAttachmentPreview.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type {
+  LocalAudioAttachment,
+  LocalFileAttachment,
+  LocalVideoAttachment,
+  LocalUploadAttachment,
+} from 'stream-chat';
+
+/**
+ * Props for {@link FileAttachmentPreview} component. Mirrors the Stream Chat
+ * implementation but with the minimal fields required for the placeholder.
+ */
+export type FileAttachmentPreviewProps<CustomLocalMetadata = unknown> = {
+  attachment:
+    | LocalFileAttachment<CustomLocalMetadata>
+    | LocalAudioAttachment<CustomLocalMetadata>
+    | LocalVideoAttachment<CustomLocalMetadata>;
+  handleRetry?: (
+    attachment: LocalUploadAttachment,
+  ) => void | Promise<LocalUploadAttachment | undefined>;
+  removeAttachments?: (ids: string[]) => void;
+};
+
+/**
+ * Placeholder FileAttachmentPreview component used while porting the real
+ * implementation from `stream-chat-react`.
+ */
+export const FileAttachmentPreview = (
+  props: FileAttachmentPreviewProps,
+) => {
+  const { attachment } = props;
+  return (
+    <div data-testid="file-attachment-preview-placeholder">
+      {attachment?.title ?? 'File Attachment'}
+    </div>
+  );
+};
+
+export default FileAttachmentPreview;


### PR DESCRIPTION
## Summary
- add `FileAttachmentPreview` placeholder component
- unit test to ensure placeholder renders
- mark shim complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf542d7883268c3c021c360ad8ff