### PR TITLE
Add shim for ImageAttachmentPreview

### DIFF
--- a/libs/stream-chat-shim/__tests__/ImageAttachmentPreview.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ImageAttachmentPreview.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ImageAttachmentPreview } from '../src/ImageAttachmentPreview';
+
+describe('ImageAttachmentPreview', () => {
+  it('renders placeholder', () => {
+    const { getByTestId } = render(
+      <ImageAttachmentPreview attachment={{}} as any />
+    );
+    expect(getByTestId('image-attachment-preview-placeholder')).toBeTruthy();
+  });
+});

--- a/libs/stream-chat-shim/src/ImageAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/ImageAttachmentPreview.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { Attachment } from 'stream-chat';
+
+export type ImageAttachmentPreviewProps = {
+  attachment: Attachment;
+  onRemove?: (attachment: Attachment) => void;
+};
+
+/**
+ * Placeholder component for image attachments in the message input preview list.
+ * TODO: replace with real implementation.
+ */
+export const ImageAttachmentPreview = ({ attachment }: ImageAttachmentPreviewProps) => (
+  <div data-testid="image-attachment-preview-placeholder">
+    {attachment?.title || attachment?.name || 'Image'}
+  </div>
+);
+
+export default ImageAttachmentPreview;


### PR DESCRIPTION
## Summary
- add `ImageAttachmentPreview` placeholder component
- add basic test for the shim
- mark symbol as done

## Testing
- `pnpm -r build` *(fails: Attempted import error: 'components' is not exported from 'stream-chat-react')*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf6c22208326bae3c723f40a6879