### PR TITLE
Add UnsupportedAttachmentPreview shim

### DIFF
--- a/libs/stream-chat-shim/src/UnsupportedAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/UnsupportedAttachmentPreview.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { AnyLocalAttachment, LocalUploadAttachment } from 'stream-chat';
+
+export type UnsupportedAttachmentPreviewProps<
+  CustomLocalMetadata = Record<string, unknown>,
+> = {
+  attachment: AnyLocalAttachment<CustomLocalMetadata>;
+  handleRetry: (
+    attachment: LocalUploadAttachment,
+  ) => void | Promise<LocalUploadAttachment | undefined>;
+  removeAttachments: (ids: string[]) => void;
+};
+
+/** Placeholder implementation of the UnsupportedAttachmentPreview component. */
+export const UnsupportedAttachmentPreview = (
+  { attachment }: UnsupportedAttachmentPreviewProps,
+): React.JSX.Element => (
+  <div
+    className="str-chat__attachment-preview-unsupported"
+    data-testid="attachment-preview-unsupported"
+  >
+    {attachment.title ?? 'Unsupported attachment'}
+  </div>
+);
+
+export default UnsupportedAttachmentPreview;


### PR DESCRIPTION
## Summary
- add placeholder UnsupportedAttachmentPreview component in stream-chat shim
- mark UnsupportedAttachmentPreview complete

## Testing
- `pnpm -r build` *(fails: Attempted import error in frontend build)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf7abd048326be745ad7c7425b78