### PR TITLE
Add VoiceRecordingPreview shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/VoiceRecordingPreview.test.tsx
+++ b/libs/stream-chat-shim/__tests__/VoiceRecordingPreview.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { VoiceRecordingPreview } from '../src/VoiceRecordingPreview';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(
+    <VoiceRecordingPreview
+      attachment={{} as any}
+      handleRetry={() => {}}
+      removeAttachments={() => {}}
+    />
+  );
+  expect(getByTestId('voice-recording-preview-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/VoiceRecordingPreview.tsx
+++ b/libs/stream-chat-shim/src/VoiceRecordingPreview.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { LocalVoiceRecordingAttachment } from 'stream-chat';
+
+export type UploadAttachmentPreviewProps<A> = {
+  attachment: A;
+  handleRetry: (attachment: A) => void | Promise<A | undefined>;
+  removeAttachments: (ids: string[]) => void;
+};
+
+export type VoiceRecordingPreviewProps<CustomLocalMetadata = Record<string, unknown>> =
+  UploadAttachmentPreviewProps<LocalVoiceRecordingAttachment<CustomLocalMetadata>>;
+
+/** Placeholder implementation of VoiceRecordingPreview. */
+export const VoiceRecordingPreview = (_props: VoiceRecordingPreviewProps) => (
+  <div data-testid="voice-recording-preview-placeholder" />
+);
+
+export default VoiceRecordingPreview;


### PR DESCRIPTION
## Summary
- add `VoiceRecordingPreview` placeholder component
- add corresponding unit test
- mark `VoiceRecordingPreview` as complete

## Testing
- `pnpm install --ignore-scripts`
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf8d33c08326badc5d988765e2a4