### PR TITLE
Add attachmentPreview-types shim

### DIFF
--- a/libs/stream-chat-shim/src/attachmentPreview-types.ts
+++ b/libs/stream-chat-shim/src/attachmentPreview-types.ts
@@ -1,0 +1,29 @@
+// Shim for AttachmentPreviewList/types.ts
+// Provides type definitions used by AttachmentPreviewList components.
+
+// Placeholder generic defaults used by other stream-chat-react types.
+type DefaultStreamChatGenerics = {
+  attachmentType?: unknown;
+  channelType?: unknown;
+  commandType?: unknown;
+  eventType?: unknown;
+  messageType?: unknown;
+  reactionType?: unknown;
+  userType?: unknown;
+};
+
+// Placeholder representation of a local attachment object.
+type LocalAttachment<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = Record<string, unknown>;
+
+export type AttachmentPreviewProps<
+  A extends LocalAttachment,
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = {
+  attachment: A;
+  handleRetry: (
+    attachment: LocalAttachment<StreamChatGenerics>,
+  ) => void | Promise<LocalAttachment<StreamChatGenerics> | undefined>;
+  removeAttachments: (ids: string[]) => void;
+};


### PR DESCRIPTION
## Summary
- stub out `AttachmentPreviewProps` type for attachment previews
- mark symbol complete

## Testing
- `pnpm build && pnpm -F frontend tsc --noEmit` *(fails: Command "build" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aafa163348326abf2f45819e3bb30