### PR TITLE
Add WithDragAndDropUpload shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/WithDragAndDropUpload.test.tsx
+++ b/libs/stream-chat-shim/__tests__/WithDragAndDropUpload.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { WithDragAndDropUpload } from '../src/WithDragAndDropUpload';
+
+test('renders children', () => {
+  const { getByTestId } = render(
+    <WithDragAndDropUpload>child</WithDragAndDropUpload>,
+  );
+  const el = getByTestId('with-drag-and-drop-upload-placeholder');
+  expect(el).toHaveTextContent('child');
+});

--- a/libs/stream-chat-shim/src/WithDragAndDropUpload.tsx
+++ b/libs/stream-chat-shim/src/WithDragAndDropUpload.tsx
@@ -1,0 +1,28 @@
+import React, { PropsWithChildren } from 'react';
+import type { MessageComposerConfig } from 'stream-chat';
+
+/**
+ * Props for the {@link WithDragAndDropUpload} component.
+ * This shim only renders its children and does not provide
+ * any actual drag and drop functionality yet.
+ */
+export type WithDragAndDropUploadProps = PropsWithChildren<{
+  /** Optional callback when files are dropped. */
+  onDrop?: (files: File[]) => void;
+  /** Optional composer configuration. */
+  messageComposerConfig?: MessageComposerConfig;
+}>;
+
+/**
+ * Placeholder implementation of Stream Chat's WithDragAndDropUpload component.
+ */
+export const WithDragAndDropUpload = (
+  props: WithDragAndDropUploadProps,
+) => {
+  const { children } = props;
+  return (
+    <div data-testid="with-drag-and-drop-upload-placeholder">{children}</div>
+  );
+};
+
+export default WithDragAndDropUpload;


### PR DESCRIPTION
## Summary
- stub `WithDragAndDropUpload` component in stream-chat-shim
- add a basic test for the placeholder
- mark task as done

## Testing
- `pnpm -r run build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab01d81688326bb99e558b32c3df3