### PR TITLE
Add shim for EditMessageForm.test

### DIFF
--- a/libs/stream-chat-shim/src/EditMessageForm.test.ts
+++ b/libs/stream-chat-shim/src/EditMessageForm.test.ts
@@ -1,0 +1,4 @@
+// Placeholder shim for EditMessageForm.test
+// The original file contained Jest tests and exported nothing.
+// This shim ensures TypeScript module resolution succeeds.
+export {};


### PR DESCRIPTION
## Summary
- add placeholder shim for EditMessageForm.test
- mark symbol as done

## Testing
- `pnpm -r build` *(fails: Attempted import error, invalid POST export)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ab02e9de48326aa073548d7b3499b