### PR TITLE
Add MessageInput.test shim

### DIFF
--- a/libs/stream-chat-shim/src/MessageInput.test.ts
+++ b/libs/stream-chat-shim/src/MessageInput.test.ts
@@ -1,0 +1,3 @@
+// Placeholder shim for MessageInput.test
+// The original file contained Jest tests and exported nothing.
+export {};


### PR DESCRIPTION
## Summary
- add placeholder shim for `MessageInput.test`
- mark shim complete

## Testing
- `pnpm -r build` *(fails: Attempted import error during Next build)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ab05afdcc8326b481d5ebf29fac27