### PR TITLE
Add ThreadMessageInput.test shim

### DIFF
--- a/libs/stream-chat-shim/src/ThreadMessageInput.test.ts
+++ b/libs/stream-chat-shim/src/ThreadMessageInput.test.ts
@@ -1,0 +1,3 @@
+// Placeholder shim for ThreadMessageInput.test
+// The original file contained Jest tests and exported nothing.
+export {};


### PR DESCRIPTION
## Summary
- add placeholder shim for `ThreadMessageInput.test`
- mark `ThreadMessageInput.test` as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab06c46608326881a44ed2237245f