### PR TITLE
Add useAttachmentManagerState shim

### DIFF
--- a/libs/stream-chat-shim/src/useAttachmentManagerState.ts
+++ b/libs/stream-chat-shim/src/useAttachmentManagerState.ts
@@ -1,0 +1,15 @@
+import type { AttachmentManagerState, StateStore } from 'stream-chat';
+import { useStateStore } from 'stream-chat';
+
+/**
+ * Hook to access the current attachment manager state.
+ *
+ * @param manager - State store or object containing the attachment manager state.
+ * @returns The latest attachment manager state from the provided store.
+ */
+export const useAttachmentManagerState = (
+  manager?: StateStore<AttachmentManagerState> | { state: StateStore<AttachmentManagerState> },
+) => {
+  const store = (manager as any)?.state ?? manager;
+  return useStateStore<AttachmentManagerState>(store as StateStore<AttachmentManagerState>);
+};


### PR DESCRIPTION
## Summary
- add new hook `useAttachmentManagerState` to stream-chat-shim
- mark symbol complete with status file

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685ab07a41608326bf7bd0c0a5623612