### PR TITLE
Add useCooldownTimer shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useCooldownTimer.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useCooldownTimer.test.tsx
@@ -1,0 +1,14 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCooldownTimer } from '../src/useCooldownTimer';
+
+describe('useCooldownTimer', () => {
+  test('exposes cooldown state and updater', () => {
+    const { result } = renderHook(() => useCooldownTimer());
+    expect(result.current.cooldownInterval).toBe(0);
+    expect(result.current.cooldownRemaining).toBeUndefined();
+    act(() => {
+      result.current.setCooldownRemaining(5);
+    });
+    expect(result.current.cooldownRemaining).toBe(5);
+  });
+});

--- a/libs/stream-chat-shim/src/useCooldownTimer.tsx
+++ b/libs/stream-chat-shim/src/useCooldownTimer.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import type React from 'react';
+
+export type CooldownTimerState = {
+  cooldownInterval: number;
+  setCooldownRemaining: React.Dispatch<React.SetStateAction<number | undefined>>;
+  cooldownRemaining?: number;
+};
+
+/**
+ * Minimal placeholder for Stream's `useCooldownTimer` hook.
+ * Provides cooldown state but omits integration with Stream Chat contexts.
+ */
+export const useCooldownTimer = (): CooldownTimerState => {
+  const [cooldownRemaining, setCooldownRemaining] = useState<number>();
+
+  return {
+    cooldownInterval: 0,
+    cooldownRemaining,
+    setCooldownRemaining,
+  };
+};
+
+export default useCooldownTimer;


### PR DESCRIPTION
## Summary
- implement `useCooldownTimer` shim
- add simple test for the hook
- mark symbol as complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with type errors)*


------
https://chatgpt.com/codex/tasks/task_e_685abac3a1888326b639b37903dace21