### PR TITLE
Add useMessageComposer shim

### DIFF
--- a/libs/stream-chat-shim/src/useMessageComposer.ts
+++ b/libs/stream-chat-shim/src/useMessageComposer.ts
@@ -1,0 +1,21 @@
+import { useEffect, useMemo } from 'react';
+import { MessageComposer } from 'stream-chat';
+
+/**
+ * Lightweight placeholder for Stream's `useMessageComposer` hook.
+ *
+ * Returns a new {@link MessageComposer} instance. In the real
+ * implementation this hook would integrate with chat contexts
+ * to return the composer for the current channel or thread.
+ */
+export const useMessageComposer = () => {
+  const composer = useMemo(() => new MessageComposer(), []);
+
+  useEffect(() => {
+    // TODO: register subscriptions with the Stream Chat client
+  }, [composer]);
+
+  return composer;
+};
+
+export default useMessageComposer;


### PR DESCRIPTION
## Summary
- implement `useMessageComposer` hook shim
- mark symbol as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abae0f4a8832682714f8b6e81da83