### PR TITLE
Add placeholder for useMessageComposerHasSendableData

### DIFF
--- a/libs/stream-chat-shim/src/useMessageComposerHasSendableData.ts
+++ b/libs/stream-chat-shim/src/useMessageComposerHasSendableData.ts
@@ -1,0 +1,11 @@
+/**
+ * Placeholder implementation of Stream's `useMessageComposerHasSendableData` hook.
+ *
+ * Always returns `false` until real message composer state is wired up.
+ */
+export const useMessageComposerHasSendableData = (): boolean => {
+  // TODO: connect to message composer state
+  return false;
+};
+
+export default useMessageComposerHasSendableData;


### PR DESCRIPTION
## Summary
- add shim for `useMessageComposerHasSendableData`
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abb0ecb2083269cb204b1347cf1d2