### PR TITLE
Add ConnectionStatus shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ConnectionStatus.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ConnectionStatus.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConnectionStatus } from '../src/ConnectionStatus';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<ConnectionStatus />);
+  expect(getByTestId('connection-status-placeholder')).toBeTruthy();
+});
+

--- a/libs/stream-chat-shim/src/ConnectionStatus.tsx
+++ b/libs/stream-chat-shim/src/ConnectionStatus.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/** Placeholder generic defaults matching the Stream Chat generics. */
+export interface DefaultStreamChatGenerics {}
+
+/**
+ * Minimal placeholder for the ConnectionStatus component.
+ *
+ * @returns JSX element indicating a placeholder.
+ */
+export const ConnectionStatus = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>() => {
+  return (
+    <div data-testid="connection-status-placeholder">ConnectionStatus</div>
+  );
+};
+
+export default ConnectionStatus;
+


### PR DESCRIPTION
## Summary
- implement minimal `ConnectionStatus` component placeholder
- test placeholder rendering
- mark the shim as completed

## Testing
- `pnpm -r build` *(fails: Attempted import error and Next.js build errors)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with type errors)*
- `pnpm test` *(fails: turbo json parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685abb3f859c8326bd6206e64b9547d7