### PR TITLE
Add GiphyPreviewMessage shim

### DIFF
--- a/libs/stream-chat-shim/src/GiphyPreviewMessage.tsx
+++ b/libs/stream-chat-shim/src/GiphyPreviewMessage.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import type { LocalMessage } from 'stream-chat'
+
+export type GiphyPreviewMessageProps = {
+  message: LocalMessage
+}
+
+/** Placeholder implementation of GiphyPreviewMessage component. */
+export const GiphyPreviewMessage = ({ message }: GiphyPreviewMessageProps) => {
+  return (
+    <div className="giphy-preview-message" data-testid="giphy-preview-message">
+      {message?.text || 'Giphy preview'}
+    </div>
+  )
+}
+
+export default GiphyPreviewMessage


### PR DESCRIPTION
## Summary
- add placeholder implementation for `GiphyPreviewMessage`
- mark the symbol as implemented

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685abb4ca78c8326907ae33f2afe1e15