### PR TITLE
Add VirtualizedMessageListComponents shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/VirtualizedMessageListComponents.test.tsx
+++ b/libs/stream-chat-shim/__tests__/VirtualizedMessageListComponents.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  calculateItemIndex,
+  calculateFirstItemIndex,
+  Item,
+  Header,
+  EmptyPlaceholder,
+  messageRenderer,
+} from '../src/VirtualizedMessageListComponents';
+
+describe('VirtualizedMessageListComponents shim', () => {
+  test('index helpers use offset', () => {
+    const idx = calculateItemIndex(5, 3);
+    const first = calculateFirstItemIndex(3);
+    expect(idx).toBe(5 + 3 - 10 ** 7);
+    expect(first).toBe(10 ** 7 - 3);
+  });
+
+  test('Item renders a div', () => {
+    const { container } = render(<Item data-item-index={0} />);
+    expect(container.querySelector('div')).toBeTruthy();
+  });
+
+  test('messageRenderer returns element', () => {
+    const el = messageRenderer(0, null, {} as any);
+    const { getByTestId } = render(<>{el}</>);
+    expect(getByTestId('virtualized-message')).toBeTruthy();
+  });
+
+  test('EmptyPlaceholder renders when no messages', () => {
+    const { getByTestId } = render(<EmptyPlaceholder context={{}} />);
+    expect(getByTestId('virtualized-message-list-empty')).toBeTruthy();
+  });
+});

--- a/libs/stream-chat-shim/src/VirtualizedMessageListComponents.tsx
+++ b/libs/stream-chat-shim/src/VirtualizedMessageListComponents.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+// Placeholder type for VirtuosoContext from stream-chat-react
+export interface VirtuosoContext {
+  [key: string]: any;
+}
+
+export type CommonVirtuosoComponentProps = {
+  context?: VirtuosoContext;
+};
+
+const PREPEND_OFFSET = 10 ** 7;
+
+/**
+ * Calculates the index of a message in the original message list based on
+ * the position in the virtualized list.
+ */
+export function calculateItemIndex(
+  virtuosoIndex: number,
+  numItemsPrepended: number,
+) {
+  return virtuosoIndex + numItemsPrepended - PREPEND_OFFSET;
+}
+
+/**
+ * Calculates the first item index for the virtual list given how many items
+ * were prepended before the initial page.
+ */
+export function calculateFirstItemIndex(numItemsPrepended: number) {
+  return PREPEND_OFFSET - numItemsPrepended;
+}
+
+/**
+ * Creates a no-op handler for the `itemsRendered` callback.
+ */
+export const makeItemsRenderedHandler = (
+  _renderedItemsActions: Array<(msg: any[]) => void>,
+  _processedMessages: any[],
+) => {
+  return (_items: any[]) => {
+    // noop placeholder
+  };
+};
+
+/**
+ * Minimal item wrapper used in the virtualized message list.
+ */
+export const Item = (
+  props: React.HTMLAttributes<HTMLDivElement> & CommonVirtuosoComponentProps,
+) => {
+  return <div {...props} />;
+};
+
+/**
+ * Renders the header for the virtualized message list.
+ */
+export const Header = ({ context }: CommonVirtuosoComponentProps) => {
+  return <>{context?.head}</>;
+};
+
+/**
+ * Placeholder component shown when there are no messages.
+ */
+export const EmptyPlaceholder = ({ context }: CommonVirtuosoComponentProps) => {
+  if (context?.processedMessages?.length) return null;
+  return <div data-testid="virtualized-message-list-empty" />;
+};
+
+/**
+ * Default renderer for a message in the virtualized list.
+ */
+export const messageRenderer = (
+  _index: number,
+  _data: any,
+  _context: VirtuosoContext,
+) => <div data-testid="virtualized-message">VirtualizedMessage</div>;
+


### PR DESCRIPTION
## Summary
- add placeholder for `VirtualizedMessageListComponents`
- include basic unit tests
- mark symbol done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `npx jest` *(fails: attempted to install jest interactively)*

------
https://chatgpt.com/codex/tasks/task_e_685abb99423c832694ebabe340714031