### PR TITLE
Add useEnrichedMessages shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useEnrichedMessages.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useEnrichedMessages.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react';
+import { useEnrichedMessages } from '../src/useEnrichedMessages';
+
+describe('useEnrichedMessages', () => {
+  test('returns messages unchanged and empty group styles', () => {
+    const messages = [{ id: '1' } as any, { id: '2' } as any];
+    const { result } = renderHook(() =>
+      useEnrichedMessages({
+        channel: {} as any,
+        disableDateSeparator: false,
+        hideDeletedMessages: false,
+        hideNewMessageSeparator: false,
+        messages,
+        noGroupByUser: false,
+      })
+    );
+    expect(result.current.messages).toBe(messages);
+    expect(result.current.messageGroupStyles).toEqual({});
+  });
+});

--- a/libs/stream-chat-shim/src/useEnrichedMessages.ts
+++ b/libs/stream-chat-shim/src/useEnrichedMessages.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import type { Channel, LocalMessage } from 'stream-chat';
+
+// Placeholder type definitions for yet-to-be-implemented utilities
+export type GroupStyle = any;
+export type RenderedMessage = any;
+export type ProcessMessagesParams = { reviewProcessedMessage?: (msgs: LocalMessage[]) => LocalMessage[] };
+
+export const useEnrichedMessages = (args: {
+  channel: Channel;
+  disableDateSeparator: boolean;
+  hideDeletedMessages: boolean;
+  hideNewMessageSeparator: boolean;
+  messages: LocalMessage[];
+  noGroupByUser: boolean;
+  groupStyles?: (
+    message: RenderedMessage,
+    previousMessage: RenderedMessage,
+    nextMessage: RenderedMessage,
+    noGroupByUser: boolean,
+    maxTimeBetweenGroupedMessages?: number,
+  ) => GroupStyle;
+  headerPosition?: number;
+  maxTimeBetweenGroupedMessages?: number;
+  reviewProcessedMessage?: ProcessMessagesParams['reviewProcessedMessage'];
+}) => {
+  const { messages } = args;
+  const messageGroupStyles = useMemo(() => ({} as Record<string, GroupStyle>), [messages]);
+  return { messageGroupStyles, messages } as const;
+};


### PR DESCRIPTION
## Summary
- implement placeholder useEnrichedMessages hook
- add basic unit test
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo json parse error)*
- `npx jest libs/stream-chat-shim/__tests__/useEnrichedMessages.test.tsx` *(fails: cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_685abbb96f2483269afdeef4a1190d40