### PR TITLE
Add useMessageListElements shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useMessageListElements.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useMessageListElements.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react';
+import { useMessageListElements } from '../src/useMessageListElements';
+
+describe('useMessageListElements', () => {
+  test('calls renderMessages with provided messages', () => {
+    const renderMessages = jest.fn().mockReturnValue(['ok']);
+    const props = {
+      enrichedMessages: [{ id: '1' }],
+      internalMessageProps: { foo: 'bar' },
+      messageGroupStyles: {},
+      renderMessages,
+      returnAllReadData: false,
+      threadList: false,
+    } as any;
+
+    const { result } = renderHook(() => useMessageListElements(props));
+
+    expect(renderMessages).toHaveBeenCalledWith({
+      messages: props.enrichedMessages,
+      sharedMessageProps: { ...props.internalMessageProps, threadList: false },
+    });
+    expect(result.current).toEqual(['ok']);
+  });
+});

--- a/libs/stream-chat-shim/src/useMessageListElements.ts
+++ b/libs/stream-chat-shim/src/useMessageListElements.ts
@@ -1,0 +1,37 @@
+import type React from 'react';
+import { useMemo } from 'react';
+
+export type UseMessageListElementsProps = {
+  enrichedMessages: any[];
+  internalMessageProps: any;
+  messageGroupStyles: Record<string, any>;
+  renderMessages: (options: any) => React.ReactNode[];
+  returnAllReadData: boolean;
+  threadList: boolean;
+  channelUnreadUiState?: any;
+  read?: any;
+};
+
+/**
+ * Placeholder implementation of Stream's `useMessageListElements` hook.
+ * It simply calls the provided `renderMessages` function with the given
+ * messages and returns its result.
+ */
+export const useMessageListElements = (
+  props: UseMessageListElementsProps,
+): React.ReactNode[] => {
+  const { enrichedMessages, internalMessageProps, renderMessages, threadList } = props;
+
+  const elements = useMemo(
+    () =>
+      renderMessages({
+        messages: enrichedMessages,
+        sharedMessageProps: { ...internalMessageProps, threadList },
+      }),
+    [enrichedMessages, renderMessages, internalMessageProps, threadList],
+  );
+
+  return elements;
+};
+
+export default useMessageListElements;


### PR DESCRIPTION
## Summary
- implement `useMessageListElements` placeholder in stream-chat shim
- add a basic unit test
- mark symbol as done

## Testing
- `pnpm -r run build` *(fails: `next build` not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*
- `pnpm exec jest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abbc926dc8326a5d2b7b63183d36b