### PR TITLE
Add shim for useMessageSetKey

### DIFF
--- a/libs/stream-chat-shim/__tests__/useMessageSetKey.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useMessageSetKey.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook, act } from '@testing-library/react';
+import { useMessageSetKey } from '../src/useMessageSetKey';
+
+describe('useMessageSetKey', () => {
+  it('updates messageSetKey when first message changes', () => {
+    const { result, rerender } = renderHook(
+      ({ msgs }) => useMessageSetKey({ messages: msgs }),
+      { initialProps: { msgs: [{ id: 'a' }] as any[] } },
+    );
+    const firstKey = result.current.messageSetKey;
+    act(() => {
+      rerender({ msgs: [{ id: 'b' }] as any[] });
+    });
+    expect(result.current.messageSetKey).not.toBe(firstKey);
+  });
+
+  it('keeps messageSetKey when first message remains', () => {
+    const { result, rerender } = renderHook(
+      ({ msgs }) => useMessageSetKey({ messages: msgs }),
+      { initialProps: { msgs: [{ id: 'a' }, { id: 'b' }] as any[] } },
+    );
+    const key1 = result.current.messageSetKey;
+    act(() => {
+      rerender({ msgs: [{ id: 'a' }, { id: 'c' }] as any[] });
+    });
+    expect(result.current.messageSetKey).toBe(key1);
+  });
+});

--- a/libs/stream-chat-shim/src/useMessageSetKey.ts
+++ b/libs/stream-chat-shim/src/useMessageSetKey.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from 'react';
+import type { LocalMessage } from 'stream-chat';
+
+export type UseMessageSetKeyParams = {
+  messages?: LocalMessage[];
+};
+
+/**
+ * Logic to update the key of the virtuoso component when the list jumps to a new location.
+ */
+export const useMessageSetKey = ({ messages }: UseMessageSetKeyParams) => {
+  const [messageSetKey, setMessageSetKey] = useState(+new Date());
+  const firstMessageId = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const continuousSet = messages?.find(
+      (message) => message.id === firstMessageId.current,
+    );
+    if (!continuousSet) {
+      setMessageSetKey(+new Date());
+    }
+    firstMessageId.current = messages?.[0]?.id;
+  }, [messages]);
+
+  return {
+    messageSetKey,
+  } as const;
+};


### PR DESCRIPTION
## Summary
- implement `useMessageSetKey` hook in stream-chat shim
- add tests for `useMessageSetKey`
- mark symbol as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: none of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abbfc1dd08326a9c8506eedde8ff0