### PR TITLE
Add useMarkRead shim

### DIFF
--- a/libs/stream-chat-shim/src/useMarkRead.ts
+++ b/libs/stream-chat-shim/src/useMarkRead.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+export type UseMarkReadParams = {
+  isMessageListScrolledToBottom: boolean
+  messageListIsThread: boolean
+  wasMarkedUnread?: boolean
+}
+
+/**
+ * Placeholder implementation of Stream's `useMarkRead` hook.
+ * Logs a warning whenever the provided parameters change.
+ */
+export const useMarkRead = (_params: UseMarkReadParams): void => {
+  useEffect(() => {
+    console.warn('useMarkRead not implemented')
+  }, [
+    _params.isMessageListScrolledToBottom,
+    _params.messageListIsThread,
+    _params.wasMarkedUnread,
+  ])
+}
+
+export default useMarkRead


### PR DESCRIPTION
## Summary
- create placeholder shim for `useMarkRead`
- mark symbol done

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685abc4bf35883269ce029f903a8de24