### PR TITLE
Add renderMessages shim

### DIFF
--- a/libs/stream-chat-shim/src/renderMessages.tsx
+++ b/libs/stream-chat-shim/src/renderMessages.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import type { UserResponse } from 'stream-chat';
+import type { MessageProps } from './message-types';
+
+// Placeholder type definitions for Stream UI internals
+export type GroupStyle = any;
+export type RenderedMessage = any;
+export type ComponentContextValue = any;
+export type ChannelUnreadUiState = any;
+export type CustomClasses = Record<string, string>;
+
+export type MessagePropsToOmit =
+  | 'channel'
+  | 'groupStyles'
+  | 'initialMessage'
+  | 'lastReceivedId'
+  | 'message'
+  | 'readBy';
+
+export type SharedMessageProps = Omit<MessageProps, MessagePropsToOmit>;
+
+export interface RenderMessagesOptions {
+  components: ComponentContextValue;
+  lastReceivedMessageId: string | null;
+  messageGroupStyles: Record<string, GroupStyle>;
+  messages: Array<RenderedMessage>;
+  readData: Record<string, Array<UserResponse>>;
+  sharedMessageProps: SharedMessageProps;
+  channelUnreadUiState?: ChannelUnreadUiState;
+  customClasses?: CustomClasses;
+}
+
+export type MessageRenderer = (
+  options: RenderMessagesOptions,
+) => Array<ReactNode>;
+
+/**
+ * Minimal placeholder implementation of Stream's renderMessages utility.
+ * Each message is rendered as a simple list item.
+ */
+export const defaultRenderMessages: MessageRenderer = ({ messages }) =>
+  messages.map((message: any) => (
+    <li key={message.id || message.created_at}>Placeholder message</li>
+  ));
+
+export default defaultRenderMessages;


### PR DESCRIPTION
## Summary
- add placeholder for `renderMessages` in stream-chat shim
- mark `renderMessages` as done

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685abc5a1f688326aa3b5f3daba64af9