### PR TITLE
Add PollAnswerList shim

### DIFF
--- a/libs/stream-chat-shim/src/PollAnswerList.tsx
+++ b/libs/stream-chat-shim/src/PollAnswerList.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { PollAnswer, PollState } from 'stream-chat';
+
+export type PollAnswerListProps = {
+  /** The poll containing answers. */
+  poll?: PollState;
+  /** List of poll answers to display. */
+  answers?: PollAnswer[];
+};
+
+/** Placeholder implementation of PollAnswerList component. */
+export const PollAnswerList = (_props: PollAnswerListProps) => {
+  return <div data-testid="poll-answer-list">PollAnswerList placeholder</div>;
+};
+
+export default PollAnswerList;


### PR DESCRIPTION
## Summary
- stub `PollAnswerList` component in stream-chat-shim
- mark symbol as completed

## Testing
- `pnpm build` *(fails: command not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685abce0ee948326af71099d76ff3d39