### PR TITLE
Add PollOptionWithVotesHeader shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/PollOptionWithVotesHeader.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PollOptionWithVotesHeader.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { PollOptionWithVotesHeader } from '../src/PollOptionWithVotesHeader'
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(
+    <PollOptionWithVotesHeader option={{ id: '1', text: 'Opt' } as any} />
+  )
+  expect(getByTestId('poll-option-with-votes-header')).toBeTruthy()
+})

--- a/libs/stream-chat-shim/src/PollOptionWithVotesHeader.tsx
+++ b/libs/stream-chat-shim/src/PollOptionWithVotesHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import type { PollOption } from 'stream-chat'
+
+export type PollResultOptionVoteCounterProps = {
+  optionId: string
+}
+
+/** Placeholder vote counter for poll options. */
+export const PollResultOptionVoteCounter = (
+  { optionId }: PollResultOptionVoteCounterProps,
+) => {
+  return (
+    <span data-testid="poll-result-option-vote-counter" />
+  )
+}
+
+export type PollOptionWithVotesHeaderProps = {
+  option: PollOption
+}
+
+/** Minimal placeholder for Stream's PollOptionWithVotesHeader component. */
+export const PollOptionWithVotesHeader = ({ option }: PollOptionWithVotesHeaderProps) => (
+  <div className='str-chat__poll-option__header' data-testid='poll-option-with-votes-header'>
+    <div className='str-chat__poll-option__option-text'>{option.text}</div>
+    <PollResultOptionVoteCounter optionId={option.id} />
+  </div>
+)
+
+export default PollOptionWithVotesHeader


### PR DESCRIPTION
## Summary
- implement PollOptionWithVotesHeader placeholder shim
- add basic test for placeholder
- mark symbol as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abd17f8108326bf40c6d5cd40fb8b