### PR TITLE
Add SuggestPollOptionForm shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SuggestPollOptionForm.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SuggestPollOptionForm.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SuggestPollOptionForm } from '../src/SuggestPollOptionForm';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<SuggestPollOptionForm />);
+  expect(getByTestId('suggest-poll-option-form-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/SuggestPollOptionForm.tsx
+++ b/libs/stream-chat-shim/src/SuggestPollOptionForm.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export type SuggestPollOptionFormProps = Record<string, any>;
+
+/**
+ * Placeholder implementation of SuggestPollOptionForm.
+ */
+export const SuggestPollOptionForm = (_props: SuggestPollOptionFormProps) => (
+  <div data-testid="suggest-poll-option-form-placeholder">
+    SuggestPollOptionForm
+  </div>
+);
+
+export default SuggestPollOptionForm;


### PR DESCRIPTION
## Summary
- implement placeholder for `SuggestPollOptionForm`
- add basic test
- mark shim complete

## Testing
- `pnpm build` *(fails: command not found)*
- `pnpm -r build && pnpm -F frontend tsc --noEmit` *(fails: spawn ENOENT)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abd3117d483268484f33ec030cdad