### PR TITLE
Add MultipleAnswersField shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/MultipleAnswersField.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MultipleAnswersField.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MultipleAnswersField } from '../src/MultipleAnswersField';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<MultipleAnswersField />);
+  expect(getByTestId('multiple-answers-field-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/MultipleAnswersField.tsx
+++ b/libs/stream-chat-shim/src/MultipleAnswersField.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export type MultipleAnswersFieldProps = Record<string, never>;
+
+/**
+ * Placeholder implementation for Stream's MultipleAnswersField component.
+ */
+export const MultipleAnswersField = (_props: MultipleAnswersFieldProps) => (
+  <div data-testid="multiple-answers-field-placeholder" />
+);
+
+export default MultipleAnswersField;


### PR DESCRIPTION
## Summary
- add placeholder MultipleAnswersField component
- test placeholder rendering
- mark shim complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with TS errors)*
- `pnpm test` *(fails to parse turbo json)*

------
https://chatgpt.com/codex/tasks/task_e_685abd4c114c8326ab51443f12b618dd