### PR TITLE
Add NameField shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/NameField.test.tsx
+++ b/libs/stream-chat-shim/__tests__/NameField.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { NameField } from '../src/NameField';
+
+describe('NameField component', () => {
+  it('renders placeholder', () => {
+    const { getByTestId } = render(<NameField />);
+    expect(getByTestId('name-field-placeholder')).toBeTruthy();
+  });
+});

--- a/libs/stream-chat-shim/src/NameField.tsx
+++ b/libs/stream-chat-shim/src/NameField.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export interface NameFieldProps {
+  /** Current composer state */
+  state?: any;
+  /** Change handler for the poll name input */
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+/** Placeholder implementation for Stream's NameField component. */
+export const NameField = (_props: NameFieldProps) => {
+  return <div data-testid="name-field-placeholder">NameField</div>;
+};
+
+export default NameField;


### PR DESCRIPTION
## Summary
- add stub NameField component and tests

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abd580e788326bc3bb3f8d7eca569