### PR TITLE
Add PollOptionSelector shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/PollOptionSelector.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PollOptionSelector.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PollOptionSelector } from '../src/PollOptionSelector';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(
+    <PollOptionSelector option={{} as any} />,
+  );
+  expect(getByTestId('poll-option-selector-placeholder')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/PollOptionSelector.tsx
+++ b/libs/stream-chat-shim/src/PollOptionSelector.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { PollOption } from 'stream-chat';
+
+export type AmountBarProps = {
+  amount: number;
+  className?: string;
+};
+
+/** Placeholder component mimicking the real AmountBar. */
+export const AmountBar = ({ amount, className }: AmountBarProps) => (
+  <div
+    className={className}
+    data-testid="amount-bar"
+    role="progressbar"
+    style={{ width: `${amount}%` }}
+  />
+);
+
+export type CheckmarkProps = { checked?: boolean };
+
+/** Placeholder component mimicking the real Checkmark. */
+export const Checkmark = ({ checked }: CheckmarkProps) => (
+  <div data-testid="checkmark" className={checked ? 'checked' : undefined} />
+);
+
+export type PollOptionSelectorProps = {
+  option: PollOption;
+  displayAvatarCount?: number;
+  voteCountVerbose?: boolean;
+};
+
+/** Placeholder implementation of Stream's `PollOptionSelector` component. */
+export const PollOptionSelector = (_props: PollOptionSelectorProps) => (
+  <div data-testid="poll-option-selector-placeholder" />
+);
+
+export default PollOptionSelector;


### PR DESCRIPTION
## Summary
- add placeholder PollOptionSelector component
- add basic jest test for PollOptionSelector
- mark PollOptionSelector shim complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685abd9be9a48326892f90a17c28f88e