### PR TITLE
Add useManagePollVotesRealtime shim

### DIFF
--- a/libs/stream-chat-shim/src/useManagePollVotesRealtime.ts
+++ b/libs/stream-chat-shim/src/useManagePollVotesRealtime.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import type { PollAnswer, PollVote } from 'stream-chat';
+import type { CursorPaginatorStateStore } from './useCursorPaginator';
+
+/**
+ * Placeholder for Stream\'s `useManagePollVotesRealtime` hook.
+ *
+ * Maintains a list of votes, but does not subscribe to real-time events yet.
+ */
+export function useManagePollVotesRealtime<T extends PollVote | PollAnswer = PollVote>(
+  _managedVoteType: 'answer' | 'vote',
+  cursorPaginatorState?: CursorPaginatorStateStore<T>,
+  _optionId?: string,
+) {
+  const [votesInRealtime, setVotesInRealtime] = useState<T[]>(
+    cursorPaginatorState?.getLatestValue().items ?? [],
+  );
+
+  useEffect(() => {
+    // TODO: connect to Stream Chat client and handle vote events
+    setVotesInRealtime(cursorPaginatorState?.getLatestValue().items ?? []);
+  }, [cursorPaginatorState]);
+
+  return votesInRealtime;
+}


### PR DESCRIPTION
## Summary
- add `useManagePollVotesRealtime` hook shim
- mark symbol as done

## Testing
- `pnpm --recursive run build` *(fails: Attempted import error from next build)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685abe3642cc832683d172e6f53d5762