### PR TITLE
Add UploadButton shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/UploadButton.test.tsx
+++ b/libs/stream-chat-shim/__tests__/UploadButton.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { UploadButton } from '../src/UploadButton';
+
+test('calls onFileChange when files selected', () => {
+  const handler = jest.fn();
+  const { getByTestId } = render(
+    <UploadButton data-testid="upload" onFileChange={handler} />,
+  );
+  const input = getByTestId('upload') as HTMLInputElement;
+  const file = new File(['x'], 'test.txt');
+  Object.defineProperty(input, 'files', { value: [file] });
+  fireEvent.change(input);
+  expect(handler).toHaveBeenCalledWith([file]);
+});

--- a/libs/stream-chat-shim/src/UploadButton.tsx
+++ b/libs/stream-chat-shim/src/UploadButton.tsx
@@ -1,0 +1,28 @@
+import React, { ComponentProps } from 'react';
+
+export type UploadButtonProps = {
+  onFileChange: (files: File[]) => void;
+  resetOnChange?: boolean;
+} & Omit<ComponentProps<'input'>, 'type' | 'onChange'>;
+
+/**
+ * Placeholder implementation of Stream Chat's UploadButton component.
+ * It forwards selected files via the onFileChange callback.
+ */
+export const UploadButton = ({
+  onFileChange,
+  resetOnChange = true,
+  ...rest
+}: UploadButtonProps) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    onFileChange(files);
+    if (resetOnChange) {
+      event.target.value = '';
+    }
+  };
+
+  return <input type="file" onChange={handleChange} {...rest} />;
+};
+
+export default UploadButton;


### PR DESCRIPTION
## Summary
- add placeholder `UploadButton` component for stream chat shim
- test that `UploadButton` invokes handler
- mark `UploadButton` done

## Testing
- `pnpm -r build` *(fails: Attempted import error: 'components' is not exported from 'stream-chat-react')*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685abe5d6c7c832695771ef28bcb1650