### PR TITLE
Add ReactionsList shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ReactionsList.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ReactionsList.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ReactionsList } from '../src/ReactionsList';
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<ReactionsList />);
+  expect(getByTestId('reactions-list')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/ReactionsList.tsx
+++ b/libs/stream-chat-shim/src/ReactionsList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { ReactionGroupResponse, ReactionResponse } from 'stream-chat';
+
+// Placeholder type definitions mirroring Stream's UI library
+export type ReactionOptions = Array<{
+  Component: React.ComponentType;
+  type: string;
+  name?: string;
+}>;
+
+export type ReactionDetailsComparator = (
+  a: ReactionResponse,
+  b: ReactionResponse,
+) => number;
+export type ReactionsComparator = (a: any, b: any) => number;
+export type ReactionType = ReactionResponse['type'];
+export type MessageContextValue = {
+  handleFetchReactions?: () => void;
+  reactionDetailsSort?: ReactionDetailsComparator;
+};
+
+export type ReactionsListProps = Partial<
+  Pick<MessageContextValue, 'handleFetchReactions' | 'reactionDetailsSort'>
+> & {
+  own_reactions?: ReactionResponse[];
+  reaction_counts?: Record<string, number>;
+  reaction_groups?: Record<string, ReactionGroupResponse>;
+  reactionOptions?: ReactionOptions;
+  reactions?: ReactionResponse[];
+  reverse?: boolean;
+  sortReactionDetails?: ReactionDetailsComparator;
+  sortReactions?: ReactionsComparator;
+};
+
+/** Minimal placeholder for Stream's ReactionsList component. */
+export const ReactionsList = (_props: ReactionsListProps) => (
+  <div data-testid="reactions-list">ReactionsList placeholder</div>
+);
+
+export default ReactionsList;


### PR DESCRIPTION
## Summary
- add placeholder ReactionsList component
- add simple test for ReactionsList
- mark ReactionsList shim completed

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `npm test` *(fails: turbo not found)*
- `npx jest` *(prompts to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_685abeaf434c832697ad6b193e8ca354