### PR TITLE
Add useFetchReactions shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useFetchReactions.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useFetchReactions.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react'
+import { useFetchReactions } from '../src/useFetchReactions'
+
+describe('useFetchReactions', () => {
+  test('returns default state and updates on fetch', async () => {
+    const handleFetchReactions = jest.fn().mockResolvedValue([{ id: '1' }])
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetchReactions({
+        reactionType: 'like',
+        shouldFetch: true,
+        handleFetchReactions,
+      })
+    )
+    expect(result.current.isLoading).toBe(true)
+    await waitForNextUpdate()
+    expect(handleFetchReactions).toHaveBeenCalledWith('like', undefined)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.reactions).toEqual([{ id: '1' }])
+  })
+})

--- a/libs/stream-chat-shim/src/useFetchReactions.ts
+++ b/libs/stream-chat-shim/src/useFetchReactions.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import type { ReactionResponse, ReactionSort } from 'stream-chat';
+
+// Placeholder type for reaction types from Stream Chat
+export type ReactionType = string;
+
+export interface FetchReactionsOptions {
+  reactionType: ReactionType;
+  shouldFetch: boolean;
+  handleFetchReactions?: (
+    type: ReactionType,
+    sort?: ReactionSort,
+  ) => Promise<ReactionResponse[]>;
+  sort?: ReactionSort;
+}
+
+/**
+ * Simplified shim for Stream's `useFetchReactions` hook.
+ * It mimics the public API without performing any real network calls.
+ */
+export function useFetchReactions(options: FetchReactionsOptions) {
+  const {
+    handleFetchReactions,
+    reactionType,
+    shouldFetch,
+    sort,
+  } = options;
+  const [reactions, setReactions] = useState<ReactionResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(shouldFetch);
+
+  useEffect(() => {
+    if (!shouldFetch) return;
+    let cancel = false;
+    (async () => {
+      try {
+        setIsLoading(true);
+        const fetched = await handleFetchReactions?.(reactionType, sort);
+        if (!cancel && fetched) {
+          setReactions(fetched);
+        }
+      } catch (_e) {
+        if (!cancel) {
+          setReactions([]);
+        }
+      } finally {
+        if (!cancel) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [handleFetchReactions, reactionType, shouldFetch, sort]);
+
+  return { isLoading, reactions };
+}
+
+export default useFetchReactions;


### PR DESCRIPTION
## Summary
- implement `useFetchReactions` hook in stream-chat-shim
- add basic unit test
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aca02c3d48326a98854537c00c4b1