### PR TITLE
Add reactions-types shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/reactions-types.test.ts
+++ b/libs/stream-chat-shim/__tests__/reactions-types.test.ts
@@ -1,0 +1,29 @@
+import type {
+  ReactionSummary,
+  ReactionType,
+  ReactionDetailsComparator,
+  ReactionsComparator,
+} from '../src/reactions-types';
+
+describe('reactions-types', () => {
+  test('allows creating and using basic typed objects', () => {
+    const summary: ReactionSummary = {
+      EmojiComponent: null,
+      firstReactionAt: null,
+      isOwnReaction: false,
+      lastReactionAt: null,
+      latestReactedUserNames: [],
+      reactionCount: 0,
+      reactionType: 'like',
+      unlistedReactedUserCount: 0,
+    };
+    const cmp: ReactionsComparator = (a, b) => a.reactionCount - b.reactionCount;
+    const detailsCmp: ReactionDetailsComparator = () => 0;
+    const type: ReactionType = 'love' as ReactionType;
+
+    expect(summary.reactionType).toBe('like');
+    expect(cmp(summary, summary)).toBe(0);
+    expect(detailsCmp({} as any, {} as any)).toBe(0);
+    expect(typeof type).toBe('string');
+  });
+});

--- a/libs/stream-chat-shim/src/reactions-types.ts
+++ b/libs/stream-chat-shim/src/reactions-types.ts
@@ -1,0 +1,29 @@
+import type { ComponentType } from 'react';
+import type { ReactionResponse } from 'stream-chat';
+
+/** Summary information about a specific reaction type. */
+export interface ReactionSummary {
+  EmojiComponent: ComponentType | null;
+  firstReactionAt: Date | null;
+  isOwnReaction: boolean;
+  lastReactionAt: Date | null;
+  latestReactedUserNames: string[];
+  reactionCount: number;
+  reactionType: string;
+  unlistedReactedUserCount: number;
+}
+
+/** Comparator used to sort reaction summaries. */
+export type ReactionsComparator = (
+  a: ReactionSummary,
+  b: ReactionSummary
+) => number;
+
+/** Comparator used to sort detailed reaction objects. */
+export type ReactionDetailsComparator = (
+  a: ReactionResponse,
+  b: ReactionResponse
+) => number;
+
+/** Convenience alias for the reaction type string. */
+export type ReactionType = ReactionResponse['type'];


### PR DESCRIPTION
## Summary
- add placeholder typings for reactions
- add minimal unit test
- mark reactions-types as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aca14cd90832686633bdc4c4c8e1b