### PR TITLE
Add CommandItem shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/CommandItem.test.tsx
+++ b/libs/stream-chat-shim/__tests__/CommandItem.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CommandItem } from '../src/CommandItem';
+
+test('renders command info', () => {
+  const entity = {
+    name: '/giphy',
+    args: 'cat',
+    description: 'Giphy command',
+  } as any;
+  const { container } = render(<CommandItem entity={entity} />);
+  expect(container.textContent).toContain('/giphy');
+  expect(container.textContent).toContain('Giphy command');
+});

--- a/libs/stream-chat-shim/src/CommandItem.tsx
+++ b/libs/stream-chat-shim/src/CommandItem.tsx
@@ -1,0 +1,30 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import type { CommandResponse } from 'stream-chat';
+
+export type CommandItemProps = {
+  entity: CommandResponse;
+};
+
+/**
+ * Placeholder implementation of the CommandItem component.
+ */
+export const CommandItem = (
+  props: PropsWithChildren<CommandItemProps>
+) => {
+  const { entity } = props;
+
+  return (
+    <div className='str-chat__slash-command'>
+      <span className='str-chat__slash-command-header'>
+        <strong>{entity.name}</strong> {entity.args}
+      </span>
+      <br />
+      <span className='str-chat__slash-command-description'>
+        {entity.description}
+      </span>
+    </div>
+  );
+};
+
+export default CommandItem;


### PR DESCRIPTION
## Summary
- implement `CommandItem` in stream chat shim
- add unit test for `CommandItem`
- mark `CommandItem` as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aca22a2388326afc99dc768d9802e