### PR TITLE
Add SuggestionList shim

### DIFF
--- a/libs/stream-chat-shim/src/SuggestionList.tsx
+++ b/libs/stream-chat-shim/src/SuggestionList.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export type SuggestionTrigger = '/' | ':' | '@' | string;
+
+export type SuggestionListItemComponentProps = {
+  entity: unknown;
+  focused: boolean;
+};
+
+export type SuggestionListProps = Partial<{
+  suggestionItemComponents: Record<
+    SuggestionTrigger,
+    React.ComponentType<SuggestionListItemComponentProps>
+  >;
+  className?: string;
+  closeOnClickOutside?: boolean;
+  containerClassName?: string;
+  focusedItemIndex: number;
+  setFocusedItemIndex: (index: number) => void;
+}>;
+
+export const defaultComponents: Record<
+  SuggestionTrigger,
+  React.ComponentType<SuggestionListItemComponentProps>
+> = {
+  '/': () => null,
+  ':': () => null,
+  '@': () => null,
+} as const;
+
+/**
+ * Placeholder SuggestionList component used while porting from stream-chat-react.
+ * It simply renders a container div and does not implement suggestion logic yet.
+ */
+export const SuggestionList = (
+  props: SuggestionListProps,
+) => {
+  const { containerClassName } = props;
+  return <div className={containerClassName} data-testid="suggestion-list" />;
+};
+
+export default SuggestionList;


### PR DESCRIPTION
## Summary
- add placeholder `SuggestionList` component in stream-chat-shim
- mark SuggestionList task done

## Testing
- `pnpm build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685aca2f02cc83269bb9fe0a0da0d5fe