### PR TITLE
Add LegacyThreadContext shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/LegacyThreadContext.test.tsx
+++ b/libs/stream-chat-shim/__tests__/LegacyThreadContext.test.tsx
@@ -1,0 +1,9 @@
+import { renderHook } from '@testing-library/react';
+import { useLegacyThreadContext } from '../src/LegacyThreadContext';
+
+describe('LegacyThreadContext', () => {
+  it('provides default value', () => {
+    const { result } = renderHook(() => useLegacyThreadContext());
+    expect(result.current).toEqual({ legacyThread: undefined });
+  });
+});

--- a/libs/stream-chat-shim/src/LegacyThreadContext.ts
+++ b/libs/stream-chat-shim/src/LegacyThreadContext.ts
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import type { LocalMessage } from 'stream-chat';
+
+/**
+ * LegacyThreadContext provides access to the currently active thread message.
+ */
+export const LegacyThreadContext = React.createContext<{
+  legacyThread: LocalMessage | undefined;
+}>({ legacyThread: undefined });
+
+/**
+ * Hook to access the LegacyThreadContext.
+ */
+export const useLegacyThreadContext = () => useContext(LegacyThreadContext);


### PR DESCRIPTION
## Summary
- implement `LegacyThreadContext` shim and simple hook
- add basic test for the context
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: turbo JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685aca6c77d88326aab392eae86bccbc