### PR TITLE
Add Thread shim

### DIFF
--- a/libs/stream-chat-shim/src/Thread.tsx
+++ b/libs/stream-chat-shim/src/Thread.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { MessageInputProps } from './MessageInput';
+import type { MessageListProps } from './MessageList';
+import type { MessageProps, MessageUIComponentProps, MessageActionsArray } from './message-types';
+import type { VirtualizedMessageListProps } from './VirtualizedMessageList';
+
+export type ThreadProps = {
+  /** Additional props for `MessageInput` component. */
+  additionalMessageInputProps?: MessageInputProps;
+  /** Additional props for `MessageList` component. */
+  additionalMessageListProps?: MessageListProps;
+  /** Additional props for the parent `Message` component. */
+  additionalParentMessageProps?: Partial<MessageProps>;
+  /** Additional props for `VirtualizedMessageList` component. */
+  additionalVirtualizedMessageListProps?: VirtualizedMessageListProps;
+  /** If true, focuses the `MessageInput` component on opening a thread. */
+  autoFocus?: boolean;
+  /** Inject date separators into the Thread. */
+  enableDateSeparator?: boolean;
+  /** Custom thread input UI component. */
+  Input?: React.ComponentType;
+  /** Custom thread message UI component. */
+  Message?: React.ComponentType<MessageUIComponentProps>;
+  /** Allowed message actions for thread messages. */
+  messageActions?: MessageActionsArray;
+  /** Use `VirtualizedMessageList` instead of the standard list. */
+  virtualized?: boolean;
+};
+
+/** Placeholder implementation of the Stream Chat `Thread` component. */
+export const Thread = (_props: ThreadProps) => {
+  return <div data-testid="thread-placeholder">Thread placeholder</div>;
+};
+
+export default Thread;


### PR DESCRIPTION
## Summary
- add placeholder implementation for `Thread` component in `stream-chat-shim`
- mark `Thread` shim completed

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: `tsc` script missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aca79981c83269377fceb0ae167fb