### PR TITLE
Add ThreadContext shim

### DIFF
--- a/libs/stream-chat-shim/src/ThreadContext.tsx
+++ b/libs/stream-chat-shim/src/ThreadContext.tsx
@@ -1,0 +1,13 @@
+import React, { createContext, useContext, type PropsWithChildren } from 'react';
+import type { Thread } from 'stream-chat';
+
+export type ThreadContextValue = Thread | undefined;
+
+export const ThreadContext = createContext<ThreadContextValue>(undefined);
+
+export const useThreadContext = () => useContext(ThreadContext);
+
+export const ThreadProvider = ({ children, thread }: PropsWithChildren<{ thread?: Thread }>) => (
+  <ThreadContext.Provider value={thread}>{children}</ThreadContext.Provider>
+);
+


### PR DESCRIPTION
## Summary
- implement placeholder `ThreadContext` shim with provider and hook
- mark `ThreadContext` as complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685aca9332508326bc91a27418506372