### PR TITLE
Add ChatContext shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ChatContext.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ChatContext.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import type { StreamChat } from 'stream-chat';
+import { ChatProvider, useChatContext } from '../src/ChatContext';
+
+const createQueryState = () => ({
+  error: null,
+  queryInProgress: null,
+  setError: jest.fn(),
+  setQueryInProgress: jest.fn(),
+});
+
+describe('ChatContext', () => {
+  it('provides context value', () => {
+    const value = {
+      channel: undefined,
+      channelsQueryState: createQueryState(),
+      client: {} as StreamChat,
+      closeMobileNav: jest.fn(),
+      customClasses: undefined,
+      getAppSettings: () => null,
+      latestMessageDatesByChannels: {},
+      mutes: [],
+      navOpen: false,
+      openMobileNav: jest.fn(),
+      setActiveChannel: jest.fn(),
+      theme: 'messaging light',
+      themeVersion: '1' as const,
+      useImageFlagEmojisOnWindows: false,
+      isMessageAIGenerated: false,
+    };
+    const wrapper = ({ children }: any) => (
+      <ChatProvider value={value}>{children}</ChatProvider>
+    );
+    const { result } = renderHook(() => useChatContext(), { wrapper });
+    expect(result.current).toBe(value);
+  });
+});

--- a/libs/stream-chat-shim/src/ChatContext.tsx
+++ b/libs/stream-chat-shim/src/ChatContext.tsx
@@ -1,0 +1,80 @@
+import React, { PropsWithChildren, useContext } from 'react';
+import type {
+  AppSettingsAPIResponse,
+  Channel,
+  Mute,
+  StreamChat,
+} from 'stream-chat';
+import type { Theme } from './Chat';
+import type { ChannelsQueryState } from './useChannelsQueryState';
+
+/** Placeholder generic defaults matching the Stream Chat generics. */
+export interface DefaultStreamChatGenerics {}
+
+export type CustomClasses = Partial<Record<string, string>>;
+
+export type ChatContextValue<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = {
+  channel?: Channel<StreamChatGenerics>;
+  channelsQueryState: ChannelsQueryState;
+  client: StreamChat<StreamChatGenerics>;
+  closeMobileNav: () => void;
+  customClasses?: CustomClasses;
+  getAppSettings: () => Promise<AppSettingsAPIResponse<StreamChatGenerics>> | null;
+  latestMessageDatesByChannels: Record<string, Date>;
+  mutes: Array<Mute<StreamChatGenerics>>;
+  navOpen?: boolean;
+  openMobileNav: () => void;
+  setActiveChannel: (
+    newChannel?: Channel<StreamChatGenerics>,
+    watchers?: { limit?: number; offset?: number },
+    event?: React.BaseSyntheticEvent,
+  ) => void;
+  theme: Theme;
+  themeVersion: '1' | '2';
+  useImageFlagEmojisOnWindows: boolean;
+  isMessageAIGenerated?: boolean;
+};
+
+const ChatContext = React.createContext<ChatContextValue | undefined>(undefined);
+
+export const ChatProvider = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>({ children, value }: PropsWithChildren<{ value: ChatContextValue<StreamChatGenerics> }>) => (
+  <ChatContext.Provider value={value as unknown as ChatContextValue}>{children}</ChatContext.Provider>
+);
+
+export const useChatContext = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>(componentName?: string) => {
+  const contextValue = useContext(ChatContext);
+  if (!contextValue) {
+    console.warn(
+      `The useChatContext hook was called outside of the ChatContext provider. Make sure this hook is called within a child of the Chat component. The errored call is located in the ${componentName} component.`,
+    );
+    return {} as ChatContextValue<StreamChatGenerics>;
+  }
+  return contextValue as unknown as ChatContextValue<StreamChatGenerics>;
+};
+
+const getDisplayName = (Component: React.ComponentType<any>) =>
+  Component.displayName || Component.name || 'Component';
+
+export const withChatContext = <
+  P extends Record<string, any>,
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>(Component: React.ComponentType<P>) => {
+  const WithChatContextComponent = (
+    props: Omit<P, keyof ChatContextValue<StreamChatGenerics>>,
+  ) => {
+    const chatContext = useChatContext<StreamChatGenerics>();
+    return <Component {...(props as P)} {...chatContext} />;
+  };
+  WithChatContextComponent.displayName = `WithChatContext${getDisplayName(Component)}`;
+  return WithChatContextComponent;
+};
+
+export { ChatContext };
+export type { ChatContextValue };
+export default ChatContext;


### PR DESCRIPTION
## Summary
- add placeholder `ChatContext` with provider, hook, and HOC
- test `ChatContext` hook behavior
- mark symbol done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685acb5aae048326a3cf14a536f6dcb3