### PR TITLE
Add ComponentContext shim

### DIFF
--- a/libs/stream-chat-shim/src/ComponentContext.tsx
+++ b/libs/stream-chat-shim/src/ComponentContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, PropsWithChildren } from 'react';
+
+/**
+ * Map of overridable UI components used by Stream UI.
+ * This is a minimal placeholder for the real implementation.
+ */
+export interface ComponentContextValue {
+  /** Optional emoji search index used by some inputs */
+  emojiSearchIndex?: any;
+  /** Arbitrary component mappings */
+  [key: string]: React.ComponentType<any> | undefined;
+}
+
+export const ComponentContext = createContext<ComponentContextValue>({});
+
+export const ComponentProvider: React.FC<
+  PropsWithChildren<{ value: Partial<ComponentContextValue> }>
+> = ({ value, children }) => (
+  <ComponentContext.Provider value={value as ComponentContextValue}>
+    {children}
+  </ComponentContext.Provider>
+);
+
+/** Access the current ComponentContext. */
+export const useComponentContext = () => useContext(ComponentContext);
+
+export default ComponentContext;


### PR DESCRIPTION
## Summary
- add a placeholder implementation for `ComponentContext`
- mark `ComponentContext` as migrated

## Testing
- `pnpm -r build` *(fails: next not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685acb67b5988326851137bb73ac03be