### PR TITLE
Add PollContext shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/PollContext.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PollContext.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { PollProvider, usePollContext } from '../src/PollContext'
+
+describe('PollContext shim', () => {
+  it('renders children when poll is provided', () => {
+    const html = renderToStaticMarkup(
+      <PollProvider poll={{} as any}>child</PollProvider>
+    )
+    expect(html).toContain('child')
+  })
+
+  it('usePollContext returns provided poll', () => {
+    const Test = () => {
+      const { poll } = usePollContext()
+      return <span>{poll ? 'ok' : 'no'}</span>
+    }
+    const html = renderToStaticMarkup(
+      <PollProvider poll={{ id: '1' } as any}>
+        <Test />
+      </PollProvider>
+    )
+    expect(html).toContain('ok')
+  })
+})

--- a/libs/stream-chat-shim/src/PollContext.tsx
+++ b/libs/stream-chat-shim/src/PollContext.tsx
@@ -1,0 +1,23 @@
+import React, { useContext } from 'react'
+import type { PropsWithChildren } from 'react'
+import type { Poll } from 'stream-chat'
+
+export type PollContextValue = {
+  poll: Poll
+}
+
+export const PollContext = React.createContext<PollContextValue | undefined>(undefined)
+
+export const PollProvider = ({ children, poll }: PropsWithChildren<{ poll: Poll }>) =>
+  poll ? (
+    <PollContext.Provider value={{ poll } as unknown as PollContextValue}>
+      {children}
+    </PollContext.Provider>
+  ) : null
+
+export const usePollContext = () => {
+  const contextValue = useContext(PollContext)
+  return contextValue as unknown as PollContextValue
+}
+
+export default PollContext


### PR DESCRIPTION
## Summary
- add `PollContext` React context shim
- test PollContext provider & hook
- mark implementation complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script found)*
- `pnpm tsc -p frontend --noEmit` *(fails with many type errors)*
- `pnpm test` *(fails to parse turbo config)*

------
https://chatgpt.com/codex/tasks/task_e_685acb91aabc8326871156170d24b33d