### PR TITLE
Add TypingContext shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/TypingContext.test.tsx
+++ b/libs/stream-chat-shim/__tests__/TypingContext.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TypingProvider, useTypingContext } from '../src/TypingContext';
+
+describe('TypingContext', () => {
+  it('provides context value', () => {
+    const value = { typing: { user1: true } } as any;
+    let received: any;
+
+    const Consumer = () => {
+      received = useTypingContext();
+      return <span>child</span>;
+    };
+
+    const html = renderToStaticMarkup(
+      <TypingProvider value={value}>
+        <Consumer />
+      </TypingProvider>,
+    );
+
+    expect(html).toContain('child');
+    expect(received).toBe(value);
+  });
+});

--- a/libs/stream-chat-shim/src/TypingContext.tsx
+++ b/libs/stream-chat-shim/src/TypingContext.tsx
@@ -1,0 +1,55 @@
+import React, { useContext, type PropsWithChildren } from 'react';
+import type { ChannelState as StreamChannelState } from 'stream-chat';
+
+// Placeholder type matching Stream Chat React's generic utility
+export type UnknownType = any;
+
+export type TypingContextValue = {
+  typing?: StreamChannelState['typing'];
+};
+
+export const TypingContext = React.createContext<TypingContextValue | undefined>(
+  undefined,
+);
+
+export const TypingProvider = ({
+  children,
+  value,
+}: PropsWithChildren<{ value: TypingContextValue }>) => (
+  <TypingContext.Provider value={value}>{children}</TypingContext.Provider>
+);
+
+export const useTypingContext = (componentName?: string) => {
+  const contextValue = useContext(TypingContext);
+
+  if (!contextValue) {
+    console.warn(
+      `The useTypingContext hook was called outside of the TypingContext provider. Make sure this hook is called within a child of the Channel component. The errored call is located in the ${componentName} component.`,
+    );
+
+    return {} as TypingContextValue;
+  }
+
+  return contextValue;
+};
+
+/**
+ * Typescript currently does not support partial inference, so if TypingContext typing is desired while using the HOC withTypingContext,
+ * the Props for the wrapped component must be provided as the first generic.
+ */
+export const withTypingContext = <P extends UnknownType>(
+  Component: React.ComponentType<P>,
+) => {
+  const WithTypingContextComponent = (
+    props: Omit<P, keyof TypingContextValue>,
+  ) => {
+    const typingContext = useTypingContext();
+    return <Component {...(props as P)} {...typingContext} />;
+  };
+
+  WithTypingContextComponent.displayName = (
+    Component.displayName || Component.name || 'Component'
+  ).replace('Base', '');
+
+  return WithTypingContextComponent;
+};


### PR DESCRIPTION
## Summary
- implement `TypingContext` placeholder with provider, hook and HOC
- add unit test for TypingContext
- mark TypingContext as done

## Testing
- `pnpm -r build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acbae092883269e431c735bc35457