### PR TITLE
Add SearchResultsHeader shim

### DIFF
--- a/libs/stream-chat-shim/src/SearchResultsHeader.tsx
+++ b/libs/stream-chat-shim/src/SearchResultsHeader.tsx
@@ -1,0 +1,14 @@
+// libs/stream-chat-shim/src/SearchResultsHeader.tsx
+'use client'
+import React from 'react'
+
+/** Placeholder implementation of the SearchResultsHeader component.
+ *  It accepts no props and renders a minimal placeholder element.
+ */
+export const SearchResultsHeader = () => {
+  return (
+    <div data-testid="search-results-header-placeholder">SearchResultsHeader placeholder</div>
+  )
+}
+
+export default SearchResultsHeader


### PR DESCRIPTION
## Summary
- add placeholder SearchResultsHeader shim
- mark symbol done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: none of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685acc109078832687e01b2b716b907e