### PR TITLE
Add SearchResultsPresearch shim

### DIFF
--- a/libs/stream-chat-shim/src/SearchResultsPresearch.tsx
+++ b/libs/stream-chat-shim/src/SearchResultsPresearch.tsx
@@ -1,0 +1,21 @@
+// libs/stream-chat-shim/src/SearchResultsPresearch.tsx
+'use client'
+import React from 'react'
+import type { SearchSource } from 'stream-chat'
+
+export type SearchResultsPresearchProps = {
+  activeSources: SearchSource[]
+}
+
+/** Placeholder implementation of the SearchResultsPresearch component. */
+export const SearchResultsPresearch = (
+  _props: SearchResultsPresearchProps
+) => {
+  return (
+    <div data-testid="search-results-presearch-placeholder">
+      Start typing to search
+    </div>
+  )
+}
+
+export default SearchResultsPresearch


### PR DESCRIPTION
## Summary
- add SearchResultsPresearch component shim
- mark SearchResultsPresearch as done

## Testing
- `pnpm -r build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685acc200b388326b9dc3468a4a72ed7