### PR TITLE
Add SearchSourceResultListFooter shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchSourceResultListFooter.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchSourceResultListFooter.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { SearchSourceResultListFooter } from '../src/SearchSourceResultListFooter'
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<SearchSourceResultListFooter />)
+  expect(
+    getByTestId('search-source-result-list-footer-placeholder'),
+  ).toBeTruthy()
+})

--- a/libs/stream-chat-shim/src/SearchSourceResultListFooter.tsx
+++ b/libs/stream-chat-shim/src/SearchSourceResultListFooter.tsx
@@ -1,0 +1,14 @@
+// libs/stream-chat-shim/src/SearchSourceResultListFooter.tsx
+'use client'
+import React from 'react'
+
+/** Placeholder implementation of the SearchSourceResultListFooter component. */
+export const SearchSourceResultListFooter = () => {
+  return (
+    <div data-testid="search-source-result-list-footer-placeholder">
+      SearchSourceResultListFooter
+    </div>
+  )
+}
+
+export default SearchSourceResultListFooter


### PR DESCRIPTION
## Summary
- add stub SearchSourceResultListFooter component
- test the placeholder render
- mark SearchSourceResultListFooter as complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: "tsc" script not found)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685acc3df3f88326bd5a728625c723d2