### PR TITLE
Add SearchSourceResults shim

### DIFF
--- a/libs/stream-chat-shim/src/SearchSourceResults.tsx
+++ b/libs/stream-chat-shim/src/SearchSourceResults.tsx
@@ -1,0 +1,20 @@
+// libs/stream-chat-shim/src/SearchSourceResults.tsx
+'use client'
+import React from 'react'
+
+export type SearchSourceResultsProps = {
+  /** Search source representing the query and state */
+  searchSource: any
+}
+
+/** Placeholder implementation of the SearchSourceResults component. */
+export const SearchSourceResults = (_props: SearchSourceResultsProps) => {
+  return (
+    <div data-testid="search-source-results-placeholder">
+      SearchSourceResults placeholder
+    </div>
+  )
+}
+
+export default SearchSourceResults
+


### PR DESCRIPTION
## Summary
- add SearchSourceResults placeholder shim in stream-chat-shim
- mark SearchSourceResults as done

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_685acc5e2e608326bd8f4808d8860682