### PR TITLE
Add SearchSourceResultsContext shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchSourceResultsContext.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchSourceResultsContext.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  SearchSourceResultsContextProvider,
+  useSearchSourceResultsContext,
+  SearchSourceResultsContextValue,
+} from '../src/SearchSourceResultsContext';
+import type { SearchSource } from 'stream-chat';
+
+test('SearchSourceResultsContextProvider provides context', () => {
+  const testSource = {} as SearchSource;
+  let received: SearchSourceResultsContextValue | undefined;
+
+  const Consumer = () => {
+    received = useSearchSourceResultsContext();
+    return <div />;
+  };
+
+  renderToStaticMarkup(
+    <SearchSourceResultsContextProvider value={{ searchSource: testSource }}>
+      <Consumer />
+    </SearchSourceResultsContextProvider>
+  );
+
+  expect(received?.searchSource).toBe(testSource);
+});

--- a/libs/stream-chat-shim/src/SearchSourceResultsContext.tsx
+++ b/libs/stream-chat-shim/src/SearchSourceResultsContext.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithChildren } from 'react';
+import React, { createContext, useContext } from 'react';
+import type { SearchSource } from 'stream-chat';
+
+export type SearchSourceResultsContextValue = {
+  searchSource: SearchSource;
+};
+
+export const SearchSourceResultsContext = createContext<
+  SearchSourceResultsContextValue | undefined
+>(undefined);
+
+/**
+ * Context provider for components rendered within the `SearchSourceResults`.
+ */
+export const SearchSourceResultsContextProvider = ({
+  children,
+  value,
+}: PropsWithChildren<{
+  value: SearchSourceResultsContextValue;
+}>) => (
+  <SearchSourceResultsContext.Provider
+    value={value as unknown as SearchSourceResultsContextValue}
+  >
+    {children}
+  </SearchSourceResultsContext.Provider>
+);
+
+export const useSearchSourceResultsContext = () => {
+  const contextValue = useContext(SearchSourceResultsContext);
+  return contextValue as unknown as SearchSourceResultsContextValue;
+};


### PR DESCRIPTION
## Summary
- implement `SearchSourceResultsContext` shim with context provider and hook
- add unit test for the shim
- mark `SearchSourceResultsContext` as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acc6be3448326a160c14fee7ea7a2