### PR TITLE
Add SearchSourceResultsContext shim

### DIFF
--- a/libs/stream-chat-shim/src/SearchSourceResultsContext.tsx
+++ b/libs/stream-chat-shim/src/SearchSourceResultsContext.tsx
@@ -1,0 +1,27 @@
+import type { PropsWithChildren } from 'react';
+import React, { createContext, useContext } from 'react';
+import type { SearchSource } from 'stream-chat';
+
+export type SearchSourceResultsContextValue = {
+  searchSource: SearchSource;
+};
+
+export const SearchSourceResultsContext = createContext<
+  SearchSourceResultsContextValue | undefined
+>(undefined);
+
+export const SearchSourceResultsContextProvider = ({
+  children,
+  value,
+}: PropsWithChildren<{
+  value: SearchSourceResultsContextValue;
+}>) => (
+  <SearchSourceResultsContext.Provider value={value as unknown as SearchSourceResultsContextValue}>
+    {children}
+  </SearchSourceResultsContext.Provider>
+);
+
+export const useSearchSourceResultsContext = () => {
+  const contextValue = useContext(SearchSourceResultsContext);
+  return contextValue as unknown as SearchSourceResultsContextValue;
+};


### PR DESCRIPTION
## Summary
- stub SearchSourceResultsContext in stream-chat-shim
- mark SearchSourceResultsContext shim as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: "None of the selected packages has a 'tsc' script")*
- `pnpm tsc --noEmit` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685acc7cc0708326ad10d2006f9ae277