### PR TITLE
Add SearchResultItem.test shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchResultItem.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchResultItem.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { SearchResultItem } from '../src/SearchResultItem'
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<SearchResultItem />)
+  expect(getByTestId('search-result-item-placeholder')).toBeTruthy()
+})

--- a/libs/stream-chat-shim/src/SearchResultItem.tsx
+++ b/libs/stream-chat-shim/src/SearchResultItem.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+
+/** Placeholder implementation of the SearchResultItem component. */
+export type SearchResultItemProps = Record<string, any>
+
+export const SearchResultItem = (_props: SearchResultItemProps) => {
+  return (
+    <div data-testid="search-result-item-placeholder">SearchResultItem placeholder</div>
+  )
+}
+
+export default SearchResultItem


### PR DESCRIPTION
## Summary
- add `SearchResultItem` placeholder component
- add unit test verifying the placeholder
- mark symbol complete

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685acc8f09188326b8a991aeced6f45f