### PR TITLE
Add useSearchQueriesInProgress shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/useSearchQueriesInProgress.test.tsx
+++ b/libs/stream-chat-shim/__tests__/useSearchQueriesInProgress.test.tsx
@@ -1,0 +1,20 @@
+import { act, renderHook } from '@testing-library/react';
+import { useSearchQueriesInProgress } from '../src/useSearchQueriesInProgress';
+
+describe('useSearchQueriesInProgress', () => {
+  it('tracks the number of in-flight search queries', () => {
+    const { result } = renderHook(() => useSearchQueriesInProgress());
+
+    expect(result.current.queriesInProgress).toBe(0);
+
+    act(() => {
+      result.current.startQuery();
+    });
+    expect(result.current.queriesInProgress).toBe(1);
+
+    act(() => {
+      result.current.endQuery();
+    });
+    expect(result.current.queriesInProgress).toBe(0);
+  });
+});

--- a/libs/stream-chat-shim/src/useSearchQueriesInProgress.ts
+++ b/libs/stream-chat-shim/src/useSearchQueriesInProgress.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Minimal placeholder implementation of Stream's `useSearchQueriesInProgress` hook.
+ * Tracks the number of active search queries and exposes helpers to update it.
+ */
+export const useSearchQueriesInProgress = () => {
+  const [queriesInProgress, setQueriesInProgress] = useState(0);
+
+  const startQuery = useCallback(() => {
+    setQueriesInProgress((count) => count + 1);
+  }, []);
+
+  const endQuery = useCallback(() => {
+    setQueriesInProgress((count) => Math.max(0, count - 1));
+  }, []);
+
+  return { queriesInProgress, startQuery, endQuery } as const;
+};
+
+export default useSearchQueriesInProgress;


### PR DESCRIPTION
## Summary
- implement placeholder hook `useSearchQueriesInProgress`
- add corresponding unit test
- mark symbol as done

## Testing
- `pnpm build` *(fails: command not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no script)*
- `npx jest libs/stream-chat-shim/__tests__/useSearchQueriesInProgress.test.tsx` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685accab89008326bc16bb834a3a583b