### PR TITLE
Add draftUpdated shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/draftUpdated.test.ts
+++ b/libs/stream-chat-shim/__tests__/draftUpdated.test.ts
@@ -1,0 +1,8 @@
+import { draftUpdated } from '../src/draftUpdated';
+
+describe('draftUpdated builder', () => {
+  it('creates a draft.updated event object', () => {
+    const event = draftUpdated();
+    expect(event.type).toBe('draft.updated');
+  });
+});

--- a/libs/stream-chat-shim/src/draftUpdated.ts
+++ b/libs/stream-chat-shim/src/draftUpdated.ts
@@ -1,0 +1,26 @@
+import type { DraftResponse, StreamChat } from 'stream-chat';
+
+/** Parameters for the `draftUpdated` mock event builder. */
+export interface DraftUpdatedParams {
+  /** Draft object returned from Stream Chat */
+  draft?: DraftResponse;
+  /** Client instance associated with the event */
+  client?: StreamChat;
+}
+
+/**
+ * Minimal placeholder for Stream's `draftUpdated` mock builder.
+ * Returns a basic event-like object mirroring the `draft.updated` event.
+ */
+export const draftUpdated = (
+  params: DraftUpdatedParams = {},
+): Record<string, unknown> => {
+  const { draft, client } = params;
+  return {
+    type: 'draft.updated',
+    draft,
+    user: client?.user,
+  };
+};
+
+export default draftUpdated;


### PR DESCRIPTION
## Summary
- add `draftUpdated` placeholder in stream-chat shim
- test creation of `draft.updated` event
- mark symbol done

## Testing
- `pnpm -r build` *(fails: `next build` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685accf313ac8326acbbc0251446bb88