### PR TITLE
Add mock-index shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/mock-index.test.tsx
+++ b/libs/stream-chat-shim/__tests__/mock-index.test.tsx
@@ -1,0 +1,15 @@
+import { getTestClient, mockClient } from '../src/mock-index';
+import { StreamChat } from 'stream-chat';
+
+describe('mock-index shim', () => {
+  it('creates a StreamChat instance', () => {
+    const client = getTestClient();
+    expect(client).toBeInstanceOf(StreamChat);
+  });
+
+  it('returns same client from mockClient', () => {
+    const original = new StreamChat('test');
+    const wrapped = mockClient(original);
+    expect(wrapped).toBe(original);
+  });
+});

--- a/libs/stream-chat-shim/src/mock-index.ts
+++ b/libs/stream-chat-shim/src/mock-index.ts
@@ -1,0 +1,31 @@
+import { StreamChat } from 'stream-chat';
+
+/** Options for configuring mocked behaviour of the chat client. */
+export type MockClientOptions = Record<string, unknown>;
+
+/**
+ * Returns the provided StreamChat client. This placeholder does not apply any
+ * mocks. In a real implementation this would attach mock handlers to the
+ * client instance.
+ */
+export function mockClient(
+  client: StreamChat,
+  _mocks?: MockClientOptions,
+): StreamChat {
+  return client;
+}
+
+/**
+ * Creates a StreamChat client instance for use in tests. This placeholder just
+ * instantiates the client with a dummy API key and returns it.
+ */
+export function getTestClient(_mocks?: MockClientOptions): StreamChat {
+  const apiKey = 'test';
+  const client = new StreamChat(apiKey);
+  return mockClient(client, _mocks);
+}
+
+export default {
+  getTestClient,
+  mockClient,
+};


### PR DESCRIPTION
## Summary
- stub out mock-index shim with `getTestClient` and `mockClient`
- add basic unit tests for the shim
- mark mock-index as implemented

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pnpm build` *(fails: command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685acd1ea0b48326a78345fc7e8fc09c