### PR TITLE
Add textComposerEmojiMiddleware shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/textComposerEmojiMiddleware.test.ts
+++ b/libs/stream-chat-shim/__tests__/textComposerEmojiMiddleware.test.ts
@@ -1,0 +1,11 @@
+import { createTextComposerEmojiMiddleware } from '../src/textComposerEmojiMiddleware';
+
+describe('createTextComposerEmojiMiddleware', () => {
+  test('returns middleware with default handlers', () => {
+    const emojiSearchIndex = { search: jest.fn() } as any;
+    const mw = createTextComposerEmojiMiddleware(emojiSearchIndex);
+    expect(mw.id).toBe('stream-io/emoji-middleware');
+    expect(typeof mw.handlers.onChange).toBe('function');
+    expect(typeof mw.handlers.onSuggestionItemSelect).toBe('function');
+  });
+});

--- a/libs/stream-chat-shim/src/textComposerEmojiMiddleware.ts
+++ b/libs/stream-chat-shim/src/textComposerEmojiMiddleware.ts
@@ -1,0 +1,37 @@
+import type {
+  Middleware,
+  TextComposerMiddlewareExecutorState,
+  TextComposerMiddlewareOptions,
+  TextComposerSuggestion,
+} from 'stream-chat';
+import type { EmojiSearchIndex, EmojiSearchIndexResult } from './MessageInput';
+
+/** Suggestion type used by the emoji middleware. */
+export type EmojiSuggestion<T extends EmojiSearchIndexResult = EmojiSearchIndexResult> =
+  TextComposerSuggestion<T>;
+
+/** Middleware type used by the text composer for emoji handling. */
+export type EmojiMiddleware<T extends EmojiSearchIndexResult = EmojiSearchIndexResult> =
+  Middleware<TextComposerMiddlewareExecutorState<EmojiSuggestion<T>>, 'onChange' | 'onSuggestionItemSelect'>;
+
+const DEFAULT_OPTIONS: TextComposerMiddlewareOptions = { minChars: 1, trigger: ':' };
+
+/**
+ * Placeholder implementation of Stream's `createTextComposerEmojiMiddleware`.
+ *
+ * The real middleware queries an emoji search index and updates the
+ * composer state with emoji suggestions. This stub simply forwards all
+ * calls without modification.
+ */
+export const createTextComposerEmojiMiddleware = (
+  _emojiSearchIndex: EmojiSearchIndex,
+  _options?: Partial<TextComposerMiddlewareOptions>,
+): EmojiMiddleware => ({
+  id: 'stream-io/emoji-middleware',
+  handlers: {
+    onChange: ({ forward }) => forward(),
+    onSuggestionItemSelect: ({ forward }) => forward(),
+  },
+});
+
+export default createTextComposerEmojiMiddleware;


### PR DESCRIPTION
## Summary
- add placeholder middleware for text composer emoji handling
- test shim creation
- mark symbol done

## Testing
- `pnpm -r --if-present build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acd2f2fec8326888b1050d54ebf4e