### PR TITLE
Add placeholder shim for add-message.stories ✅

### DIFF
--- a/libs/stream-chat-shim/src/add-message.stories.tsx
+++ b/libs/stream-chat-shim/src/add-message.stories.tsx
@@ -1,0 +1,4 @@
+// Placeholder shim for add-message.stories
+// The original file defined Storybook stories and exported nothing.
+// This shim ensures TypeScript module resolution succeeds.
+export {};


### PR DESCRIPTION
## Summary
- add a placeholder shim for `add-message.stories`
- mark the symbol as done

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_685acd4e04e48326be6240bff2c096a7