### PR TITLE
Add navigate-long-message-lists stories shim

### DIFF
--- a/libs/stream-chat-shim/src/navigate-long-message-lists.stories.tsx
+++ b/libs/stream-chat-shim/src/navigate-long-message-lists.stories.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+/** Placeholder for Storybook stories for navigating long message lists. */
+export default function NavigateLongMessageListsStories() {
+  return <div>navigate-long-message-lists.stories not implemented</div>;
+}


### PR DESCRIPTION
## Summary
- add placeholder for `navigate-long-message-lists.stories`
- mark symbol as done

## Testing
- `pnpm -r build` *(fails: components import error)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685ad85979c08326bd640fd2156e1561