### PR TITLE
Add stream-types shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/stream-types.test.ts
+++ b/libs/stream-chat-shim/__tests__/stream-types.test.ts
@@ -1,0 +1,21 @@
+import type {
+  DefaultStreamChatGenerics,
+  UnknownType,
+  UserResponse,
+  StreamMessage,
+  Channel,
+} from '../src/stream-types';
+
+describe('stream-types', () => {
+  test('allows basic typed usage', () => {
+    const generics: DefaultStreamChatGenerics = {};
+    const user: UserResponse = { id: 'u1' };
+    const msg: StreamMessage = { id: 'm1', text: 'hi', user };
+    const channel: Channel<UnknownType> = { id: 'c1', type: 'messaging' };
+
+    expect(user.id).toBe('u1');
+    expect(msg.text).toBe('hi');
+    expect(channel.type).toBe('messaging');
+    expect(generics).toBeDefined();
+  });
+});

--- a/libs/stream-chat-shim/src/stream-types.ts
+++ b/libs/stream-chat-shim/src/stream-types.ts
@@ -1,0 +1,40 @@
+// Placeholder type definitions used across the Stream UI shims.
+// These should be replaced with real types once the original
+// implementations are ported.
+
+export interface DefaultStreamChatGenerics {
+  attachmentType?: unknown;
+  channelType?: unknown;
+  commandType?: unknown;
+  eventType?: unknown;
+  messageType?: unknown;
+  reactionType?: unknown;
+  userType?: unknown;
+}
+
+/** Generic map for unknown values. */
+export type UnknownType = Record<string, any>;
+
+/** Minimal representation of a chat user. */
+export interface UserResponse {
+  id: string;
+  [key: string]: any;
+}
+
+/** Minimal representation of a chat message. */
+export interface StreamMessage<T = UnknownType> {
+  id?: string;
+  text?: string;
+  user?: UserResponse;
+  attachments?: T[];
+  [key: string]: any;
+}
+
+/** Minimal representation of a channel. */
+export interface Channel<T = UnknownType> {
+  id: string;
+  type: string;
+  cid?: string;
+  data?: T;
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- implement `stream-types` shim with placeholder type definitions
- test type exports in `stream-types`
- mark symbol as done

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8847a288326bb15a24f1f628b7c