### PR TITLE
Add getChannel shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/getChannel.test.ts
+++ b/libs/stream-chat-shim/__tests__/getChannel.test.ts
@@ -1,0 +1,22 @@
+import { getChannel } from '../src/getChannel';
+
+describe('getChannel', () => {
+  test('throws if channel and type are not provided', async () => {
+    await expect(
+      getChannel({ client: {} as any })
+    ).rejects.toThrowError();
+  });
+
+  test('watches channel once when called concurrently', async () => {
+    const watch = jest.fn().mockResolvedValue(undefined);
+    const channel: any = { id: 'c1', cid: 'messaging:c1', type: 'messaging', watch };
+    const client: any = { channel: jest.fn(() => channel) };
+
+    await Promise.all([
+      getChannel({ client, channel }),
+      getChannel({ client, channel }),
+    ]);
+
+    expect(watch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/stream-chat-shim/src/getChannel.ts
+++ b/libs/stream-chat-shim/src/getChannel.ts
@@ -1,0 +1,80 @@
+import type {
+  Channel,
+  ChannelQueryOptions,
+  QueryChannelAPIResponse,
+  StreamChat,
+} from 'stream-chat';
+
+/**
+ * prevent from duplicate invocation of channel.watch()
+ * when events 'notification.message_new' and 'notification.added_to_channel' arrive at the same time
+ */
+const WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL: Record<string, Promise<QueryChannelAPIResponse> | undefined> = {};
+
+export type GetChannelParams = {
+  client: StreamChat;
+  channel?: Channel;
+  id?: string;
+  members?: string[];
+  options?: ChannelQueryOptions;
+  type?: string;
+};
+
+/**
+ * Calls channel.watch() if it was not already recently called. Waits for watch promise to resolve even if it was invoked previously.
+ * @param client
+ * @param members
+ * @param options
+ * @param type
+ * @param id
+ * @param channel
+ */
+export const getChannel = async ({
+  channel,
+  client,
+  id,
+  members,
+  options,
+  type,
+}: GetChannelParams) => {
+  if (!channel && !type) {
+    throw new Error('Channel or channel type have to be provided to query a channel.');
+  }
+
+  // unfortunately typescript is not able to infer that if (!channel && !type) === false, then channel or type has to be truthy
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const theChannel = channel || client.channel(type!, id, { members });
+
+  // need to keep as with call to channel.watch the id can be changed from undefined to an actual ID generated server-side
+  const originalCid = theChannel?.id
+    ? theChannel.cid
+    : members && members.length
+      ? generateChannelTempCid(theChannel.type, members)
+      : undefined;
+
+  if (!originalCid) {
+    throw new Error('Channel ID or channel members array have to be provided to query a channel.');
+  }
+
+  const queryPromise = WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+
+  if (queryPromise) {
+    await queryPromise;
+  } else {
+    try {
+      WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch(options);
+      await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+    } finally {
+      delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+    }
+  }
+
+  return theChannel;
+};
+
+// Channels created without ID need to be referenced by an identifier until the back-end generates the final ID.
+const generateChannelTempCid = (channelType: string, members?: string[]) => {
+  if (!members) return;
+  const membersStr = [...members].sort().join(',');
+  return `${channelType}:!members-${membersStr}`;
+};


### PR DESCRIPTION
## Summary
- implement `getChannel` shim with minimal logic
- add tests for `getChannel`
- mark symbol status

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definition file)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad89fd1f483269d9da4ae004e22b5