### PR TITLE
Simplified Channel component

### DIFF
--- a/libs/stream-chat-shim/src/Channel.tsx
+++ b/libs/stream-chat-shim/src/Channel.tsx
@@ -1,18 +1,54 @@
-import React from 'react';
+import type {
+  Channel as StreamChannel,
+  ChannelQueryOptions,
+  LocalMessage,
+  Message,
+  MessageResponse,
+  SendMessageOptions,
+  StreamChat,
+  UpdateMessageOptions,
+} from 'stream-chat';
+import React, { PropsWithChildren } from 'react';
+
+import { useChatContext } from './ChatContext';
 
 /**
- * Very-light placeholder for Stream’s `<Channel>` component.
- * (Just renders its children until a fuller implementation lands.)
+ * Simplified placeholder for Stream's `Channel` component.
+ * Only renders its children while exposing a few props matching the upstream
+ * API surface. The real implementation from Stream Chat React is large and
+ * integrates deeply with their backend SDK.
  */
-export interface ChannelProps {
-  /** Channel instance from the chat client (optional, not used yet) */
-  channel?: any;
+export type ChannelProps = {
+  /** The connected and active channel */
+  channel?: StreamChannel;
+  /** Optional configuration parameters used for the initial channel query */
+  channelQueryOptions?: ChannelQueryOptions;
+  /** Custom action handler to override the default `channel.sendMessage` request */
+  doSendMessageRequest?: (
+    channel: StreamChannel,
+    message: Message,
+    options?: SendMessageOptions,
+  ) => ReturnType<StreamChannel['sendMessage']> | void;
+  /** Custom action handler to override the default `client.updateMessage` request */
+  doUpdateMessageRequest?: (
+    cid: string,
+    updatedMessage: LocalMessage | MessageResponse,
+    options?: UpdateMessageOptions,
+  ) => ReturnType<StreamChat['updateMessage']>;
   /** React children to render inside the channel */
   children?: React.ReactNode;
-}
+};
 
-export const Channel: React.FC<ChannelProps> = ({ children }) => (
-  <div data-testid="channel">{children}</div>
-);
+export const Channel = (
+  props: PropsWithChildren<ChannelProps>,
+) => {
+  const { children } = props;
+  const { setActiveChannel } = useChatContext('Channel');
+  // TODO backend-wire-up: initialization logic removed
+  // When connected to the backend, this would watch the channel and handle
+  // events. For now we simply expose the children inside a container.
+
+  return <div data-testid="channel">{children}</div>;
+};
 
 export default Channel;


### PR DESCRIPTION
## Summary
- rework Channel shim with typed props
- expose minimal API surface based on upstream

## Testing
- `npm run test` *(fails: `turbo` not found)*
- `pnpm build` *(fails: command not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a3d60f88326b4bf3b06bf4445d8