### PR TITLE
Add real Window component

### DIFF
--- a/libs/stream-chat-shim/__tests__/WindowComponent.test.tsx
+++ b/libs/stream-chat-shim/__tests__/WindowComponent.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Window } from '../src/components/Window/Window';
+
+test('renders without crashing', () => {
+  render(<Window />);
+});

--- a/libs/stream-chat-shim/src/components/Window/Window.tsx
+++ b/libs/stream-chat-shim/src/components/Window/Window.tsx
@@ -1,0 +1,30 @@
+import React, { PropsWithChildren } from 'react';
+import clsx from 'clsx';
+
+import { useChannelStateContext } from '../../context/ChannelStateContext';
+import type { LocalMessage } from 'stream-chat';
+
+export type WindowProps = {
+  /** optional prop to force addition of class str-chat__main-panel--thread-open to the Window root element */
+  thread?: LocalMessage;
+};
+
+/**
+ * A UI component for conditionally displaying a Thread or Channel
+ */
+const UnMemoizedWindow = (props: PropsWithChildren<WindowProps>) => {
+  const { children, thread: propThread } = props;
+  const { thread: contextThread } = useChannelStateContext('Window');
+
+  return (
+    <div
+      className={clsx('str-chat__main-panel', {
+        'str-chat__main-panel--thread-open': contextThread || propThread,
+      })}
+    >
+      {children}
+    </div>
+  );
+};
+
+export const Window = React.memo(UnMemoizedWindow);


### PR DESCRIPTION
## Summary
- port Window from stream-chat-react into shim
- test that shim Window renders

## Testing
- `pnpm build`
- `pnpm -F frontend exec tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npx jest libs/stream-chat-shim/__tests__/WindowComponent.test.tsx` *(fails to find React typings)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a53de948326bc4ab86a8cd9aaca