### PR TITLE
Port Chat component to shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/ChatNested.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ChatNested.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Chat } from '../src/components/Chat/Chat';
+
+test('renders without crashing', () => {
+  render(<Chat client={{} as any} />);
+});

--- a/libs/stream-chat-shim/src/components/Chat/Chat.tsx
+++ b/libs/stream-chat-shim/src/components/Chat/Chat.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo } from 'react';
+/* TODO backend-wire-up: StreamChat imports excised */
+import type { PropsWithChildren } from 'react';
+
+// Minimal stubs until backend integration
+type StreamChat = any;
+class SearchController {
+  constructor(_opts: any) {}
+}
+class ChannelSearchSource {
+  constructor(_client: any) {}
+}
+class MessageSearchSource {
+  constructor(_client: any) {}
+}
+class UserSearchSource {
+  constructor(_client: any) {}
+}
+
+import { useChat } from './hooks/useChat';
+import { useCreateChatContext } from './hooks/useCreateChatContext';
+import { useChannelsQueryState } from './hooks/useChannelsQueryState';
+import { ChatProvider } from '../../context/ChatContext';
+import { TranslationProvider } from '../../context/TranslationContext';
+import type { CustomClasses } from '../../context/ChatContext';
+import type { MessageContextValue } from '../../context';
+import type { SupportedTranslations } from '../../i18n/types';
+import type { Streami18n } from '../../i18n/Streami18n';
+
+export type ChatProps = {
+  /** The StreamChat client object */
+  client: StreamChat;
+  /** Object containing custom CSS classnames to override the library's default container CSS */
+  customClasses?: CustomClasses;
+  /** Sets the default fallback language for UI component translation, defaults to 'en' for English */
+  defaultLanguage?: SupportedTranslations;
+  /** Instance of Stream i18n */
+  i18nInstance?: Streami18n;
+  /** Initial status of mobile navigation */
+  initialNavOpen?: boolean;
+  /** Instance of SearchController class that allows to control all the search operations. */
+  searchController?: SearchController;
+  /** Used for injecting className/s to the Channel and ChannelList components */
+  theme?: string;
+  /**
+   * Windows 10 does not support country flag emojis out of the box. It chooses to render these emojis as characters instead. Stream
+   * Chat can override this behavior by loading a custom web font that will render images instead (PNGs or SVGs depending on the platform).
+   * Set this prop to true if you want to use these custom emojis for Windows users.
+   *
+   * Note: requires importing `stream-chat-react/css/v2/emoji-replacement.css` style sheet
+   */
+  useImageFlagEmojisOnWindows?: boolean;
+} & Partial<Pick<MessageContextValue, 'isMessageAIGenerated'>>;
+
+/**
+ * Wrapper component for a StreamChat application. Chat needs to be placed around any other chat components
+ * as it provides the ChatContext.
+ */
+export const Chat = (props: PropsWithChildren<ChatProps>) => {
+  const {
+    children,
+    client,
+    customClasses,
+    defaultLanguage,
+    i18nInstance,
+    initialNavOpen = true,
+    isMessageAIGenerated,
+    searchController: customChannelSearchController,
+    theme = 'messaging light',
+    useImageFlagEmojisOnWindows = false,
+  } = props;
+
+  const {
+    channel,
+    closeMobileNav,
+    getAppSettings,
+    latestMessageDatesByChannels,
+    mutes,
+    navOpen,
+    openMobileNav,
+    setActiveChannel,
+    translators,
+  } = useChat({ client, defaultLanguage, i18nInstance, initialNavOpen });
+
+  const channelsQueryState = useChannelsQueryState();
+
+  const searchController = useMemo(
+    () =>
+      customChannelSearchController ??
+      new SearchController({
+        sources: [
+          new ChannelSearchSource(client),
+          new UserSearchSource(client),
+          new MessageSearchSource(client),
+        ],
+      }),
+    [client, customChannelSearchController],
+  );
+
+  const chatContextValue = useCreateChatContext({
+    channel,
+    channelsQueryState,
+    client,
+    closeMobileNav,
+    customClasses,
+    getAppSettings,
+    isMessageAIGenerated,
+    latestMessageDatesByChannels,
+    mutes,
+    navOpen,
+    openMobileNav,
+    searchController,
+    setActiveChannel,
+    theme,
+    useImageFlagEmojisOnWindows,
+  });
+
+  if (!translators.t) return null;
+
+  return (
+    <ChatProvider value={chatContextValue}>
+      <TranslationProvider value={translators}>{children}</TranslationProvider>
+    </ChatProvider>
+  );
+};


### PR DESCRIPTION
## Summary
- port Chat from stream-chat-react into stream-chat-shim
- add simple render test for the component

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve 'stream-chat-react')*
- `pnpm -F frontend tsc --noEmit` *(fails: script not found)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685d9e8b9cb08326855e7b711dd32754