### PR TITLE
Port UnsupportedAttachment component

### DIFF
--- a/libs/stream-chat-shim/__tests__/UnsupportedAttachment.test.tsx
+++ b/libs/stream-chat-shim/__tests__/UnsupportedAttachment.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { UnsupportedAttachment } from '../src/components/Attachment/UnsupportedAttachment';
+
+test('renders without crashing', () => {
+  render(<UnsupportedAttachment attachment={{}} as any />);
+});

--- a/libs/stream-chat-shim/src/components/Attachment/UnsupportedAttachment.tsx
+++ b/libs/stream-chat-shim/src/components/Attachment/UnsupportedAttachment.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+/* TODO backend-wire-up: Attachment import excised */
+type Attachment = any;
+
+import { FileIcon } from '../ReactFileUtilities';
+import { useTranslationContext } from '../../context';
+
+export type UnsupportedAttachmentProps = {
+  attachment: Attachment;
+};
+
+export const UnsupportedAttachment = ({ attachment }: UnsupportedAttachmentProps) => {
+  const { t } = useTranslationContext('UnsupportedAttachment');
+  return (
+    <div
+      className='str-chat__message-attachment-unsupported'
+      data-testid='attachment-unsupported'
+    >
+      <FileIcon className='str-chat__file-icon' />
+      <div className='str-chat__message-attachment-unsupported__metadata'>
+        <div
+          className='str-chat__message-attachment-unsupported__title'
+          data-testid='unsupported-attachment-title'
+        >
+          {attachment.title || t('Unsupported attachment')}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Attachment/index.ts
+++ b/libs/stream-chat-shim/src/components/Attachment/index.ts
@@ -1,0 +1,11 @@
+export * from './Attachment';
+export * from './AttachmentActions';
+export * from './AttachmentContainer';
+export * from './Audio';
+export * from './audioSampling';
+export * from './Card';
+export * from './components';
+export * from './UnsupportedAttachment';
+export * from './FileAttachment';
+export * from './utils';
+export { useAudioController } from './hooks/useAudioController';


### PR DESCRIPTION
## Summary
- copy UnsupportedAttachment from Stream's UI lib
- include Attachment re-export index
- add basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script defined)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dce2cf870832685aed49e38ed5eaf