### PR TITLE
Add FileSizeIndicator component

### DIFF
--- a/libs/stream-chat-shim/__tests__/FileSizeIndicator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/FileSizeIndicator.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FileSizeIndicator } from '../src/components/Attachment/components/FileSizeIndicator';
+
+test('renders without crashing', () => {
+  const { getByTestId } = render(<FileSizeIndicator fileSize={1024} />);
+  expect(getByTestId('file-size-indicator')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/components/Attachment/components/FileSizeIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Attachment/components/FileSizeIndicator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { prettifyFileSize } from '../../MessageInput/hooks/utils';
+
+type FileSizeIndicatorProps = {
+  /** file size in byte */
+  fileSize?: number | string;
+  /**
+   The maximum number of fraction digits to display. If not set, the default behavior is to round to 3 significant digits.
+   @default undefined
+   */
+  maximumFractionDigits?: number;
+};
+
+export const FileSizeIndicator = ({
+  fileSize,
+  maximumFractionDigits,
+}: FileSizeIndicatorProps) => {
+  const actualFileSize = typeof fileSize === 'string' ? parseFloat(fileSize) : fileSize;
+
+  if (typeof actualFileSize === 'undefined' || !Number.isFinite(Number(actualFileSize))) {
+    return null;
+  }
+
+  return (
+    <span
+      className='str-chat__message-attachment-file--item-size'
+      data-testid='file-size-indicator'
+    >
+      {prettifyFileSize(actualFileSize, maximumFractionDigits)}
+    </span>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Attachment/components/index.ts
+++ b/libs/stream-chat-shim/src/components/Attachment/components/index.ts
@@ -1,0 +1,6 @@
+export * from './DownloadButton';
+export * from './FileSizeIndicator';
+export * from './ProgressBar';
+export * from './PlaybackRateButton';
+export * from './PlayButton';
+export * from './WaveProgressBar';

--- a/libs/stream-chat-shim/src/components/MessageInput/hooks/utils.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/hooks/utils.ts
@@ -1,0 +1,11 @@
+export function prettifyFileSize(bytes: number, precision = 3) {
+  const units = ['B', 'kB', 'MB', 'GB'];
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
+  const mantissa = bytes / 1024 ** exponent;
+  const formattedMantissa =
+    precision === 0 ? Math.round(mantissa).toString() : mantissa.toPrecision(precision);
+  return `${formattedMantissa} ${units[exponent]}`;
+}


### PR DESCRIPTION
## Summary
- port FileSizeIndicator component from stream-chat-react
- expose component via Attachment/components index
- add prettifyFileSize helper
- test basic render

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dce7cbdf483268bbb580e2d44b02e