### PR TITLE
Port PlayButton component

### DIFF
--- a/libs/stream-chat-shim/__tests__/PlayButton.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PlayButton.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PlayButton } from '../src/components/Attachment/components/PlayButton';
+
+test('renders without crashing', () => {
+  render(<PlayButton isPlaying={false} onClick={() => {}} />);
+});

--- a/libs/stream-chat-shim/src/components/Attachment/components/PlayButton.tsx
+++ b/libs/stream-chat-shim/src/components/Attachment/components/PlayButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PauseIcon, PlayTriangleIcon } from '../icons';
+
+type PlayButtonProps = {
+  isPlaying: boolean;
+  onClick: () => void;
+};
+
+export const PlayButton = ({ isPlaying, onClick }: PlayButtonProps) => (
+  <button
+    className='str-chat__message-attachment-audio-widget--play-button'
+    data-testid={isPlaying ? 'pause-audio' : 'play-audio'}
+    onClick={onClick}
+  >
+    {isPlaying ? <PauseIcon /> : <PlayTriangleIcon />}
+  </button>
+);

--- a/libs/stream-chat-shim/src/components/Attachment/components/index.ts
+++ b/libs/stream-chat-shim/src/components/Attachment/components/index.ts
@@ -1,0 +1,6 @@
+export * from './DownloadButton';
+export * from './FileSizeIndicator';
+export * from './ProgressBar';
+export * from './PlaybackRateButton';
+export * from './PlayButton';
+export * from './WaveProgressBar';

--- a/libs/stream-chat-shim/src/components/Attachment/icons.tsx
+++ b/libs/stream-chat-shim/src/components/Attachment/icons.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { IconProps } from '../../types/types';
+
+export const DownloadIcon = ({ className }: IconProps) => (
+  <svg
+    className={className}
+    data-testid='download'
+    fill='none'
+    height='24'
+    viewBox='0 0 24 24'
+    width='24'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <path
+      d='M19.35 10.04C18.67 6.59 15.64 4 12 4C9.11 4 6.6 5.64 5.35 8.04C2.34 8.36 0 10.91 0 14C0 17.31 2.69 20 6 20H19C21.76 20 24 17.76 24 15C24 12.36 21.95 10.22 19.35 10.04ZM19 18H6C3.79 18 2 16.21 2 14C2 11.95 3.53 10.24 5.56 10.03L6.63 9.92L7.13 8.97C8.08 7.14 9.94 6 12 6C14.62 6 16.88 7.86 17.39 10.43L17.69 11.93L19.22 12.04C20.78 12.14 22 13.45 22 15C22 16.65 20.65 18 19 18ZM13.45 10H10.55V13H8L12 17L16 13H13.45V10Z'
+      fill='black'
+    />
+  </svg>
+);
+
+export const PlayTriangleIcon = () => (
+  <svg fill='none' viewBox='0 0 12 14' xmlns='http://www.w3.org/2000/svg'>
+    <path d='M0.5 0V14L11.5 7L0.5 0Z' fill='#080707' />
+  </svg>
+);
+
+export const PauseIcon = () => (
+  <svg fill='none' viewBox='0 0 12 14' xmlns='http://www.w3.org/2000/svg'>
+    <path d='M0 14H4V0H0V14ZM8 0V14H12V0H8Z' fill='#080707' />
+  </svg>
+);

--- a/libs/stream-chat-shim/src/types/types.ts
+++ b/libs/stream-chat-shim/src/types/types.ts
@@ -1,0 +1,82 @@
+import type { PropsWithChildren } from 'react';
+import type { LoadingIndicatorProps } from '../components/Loading/LoadingIndicator';
+// import type { Attachment, ChannelState as StreamChannelState } from 'stream-chat'; // TODO backend-wire-up
+type Attachment = any;
+type StreamChannelState = any;
+
+export type UnknownType = Record<string, unknown>;
+export type PropsWithChildrenOnly = PropsWithChildren<Record<never, never>>;
+
+export type CustomMessageType = 'channel.intro' | 'message.date';
+
+export type GiphyVersions =
+  | 'original'
+  | 'fixed_height'
+  | 'fixed_height_still'
+  | 'fixed_height_downsampled'
+  | 'fixed_width'
+  | 'fixed_width_still'
+  | 'fixed_width_downsampled';
+
+export type PaginatorProps = {
+  /** callback to load the next page */
+  loadNextPage: () => void;
+  /** indicates if there is a next page to load */
+  hasNextPage?: boolean;
+  /** indicates if there is a previous page to load */
+  hasPreviousPage?: boolean;
+  /** indicates whether a loading request is in progress */
+  isLoading?: boolean;
+  /** The loading indicator to use */
+  LoadingIndicator?: React.ComponentType<LoadingIndicatorProps>;
+  /** callback to load the previous page */
+  loadPreviousPage?: () => void;
+  /**
+   * @desc indicates if there's currently any refreshing taking place
+   * @deprecated Use loading prop instead of refreshing. Planned for removal: https://github.com/GetStream/stream-chat-react/issues/1804
+   */
+  refreshing?: boolean;
+  /** display the items in opposite order */
+  reverse?: boolean;
+  /** Offset from when to start the loadNextPage call */
+  threshold?: number;
+};
+
+export interface IconProps {
+  className?: string;
+}
+
+export type Dimensions = { height?: string; width?: string };
+
+export type ImageAttachmentConfiguration = {
+  url: string;
+};
+
+export type VideoAttachmentConfiguration = ImageAttachmentConfiguration & {
+  thumbUrl?: string;
+};
+
+export type ImageAttachmentSizeHandler = (
+  attachment: Attachment,
+  element: HTMLElement,
+) => ImageAttachmentConfiguration;
+
+export type VideoAttachmentSizeHandler = (
+  attachment: Attachment,
+  element: HTMLElement,
+  shouldGenerateVideoThumbnail: boolean,
+) => VideoAttachmentConfiguration;
+
+export type ChannelUnreadUiState = Omit<ValuesType<StreamChannelState['read']>, 'user'>;
+
+export type Readable<T> = {
+  [key in keyof T]: T[key];
+} & {};
+
+export type ValuesType<T> = T[keyof T];
+
+export type PartialSelected<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type DeepRequired<T> = {
+  [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K];
+};


### PR DESCRIPTION
## Summary
- port `PlayButton` component from the Stream UI library
- include icon helpers and type definitions
- provide barrel exports for attachment components
- add minimal render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685dce90efb88326803fe61ee1777ea2