### PR TITLE
Add PlaybackRateButton component

### DIFF
--- a/libs/stream-chat-shim/__tests__/PlaybackRateButton.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PlaybackRateButton.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PlaybackRateButton } from '../src/components/Attachment/components/PlaybackRateButton';
+
+test('renders without crashing', () => {
+  render(<PlaybackRateButton />);
+});

--- a/libs/stream-chat-shim/src/components/Attachment/components/PlaybackRateButton.tsx
+++ b/libs/stream-chat-shim/src/components/Attachment/components/PlaybackRateButton.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export type PlaybackRateButtonProps = React.ComponentProps<'button'>;
+
+export const PlaybackRateButton = ({ children, onClick }: PlaybackRateButtonProps) => (
+  <button
+    className='str-chat__message_attachment__playback-rate-button'
+    data-testid='playback-rate-button'
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);

--- a/libs/stream-chat-shim/src/components/Attachment/components/index.ts
+++ b/libs/stream-chat-shim/src/components/Attachment/components/index.ts
@@ -1,0 +1,6 @@
+export * from './DownloadButton';
+export * from './FileSizeIndicator';
+export * from './ProgressBar';
+export * from './PlaybackRateButton';
+export * from './PlayButton';
+export * from './WaveProgressBar';

--- a/libs/stream-chat-shim/src/components/Attachment/index.ts
+++ b/libs/stream-chat-shim/src/components/Attachment/index.ts
@@ -1,0 +1,11 @@
+export * from './Attachment';
+export * from './AttachmentActions';
+export * from './AttachmentContainer';
+export * from './Audio';
+export * from './audioSampling';
+export * from './Card';
+export * from './components';
+export * from './UnsupportedAttachment';
+export * from './FileAttachment';
+export * from './utils';
+export { useAudioController } from './hooks/useAudioController';


### PR DESCRIPTION
## Summary
- port `PlaybackRateButton` component
- export playback components
- add shim test

## Testing
- `pnpm -F frontend build` *(fails: Can't resolve 'stream-chat-react')*
- `pnpm --filter frontend exec tsc --noEmit` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dd0b76c988326bbf5518980731cb5