### PR TITLE
Add ProgressBar component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ProgressBar.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ProgressBar } from '../src/components/Attachment/components/ProgressBar';
+
+test('renders without crashing', () => {
+  render(<ProgressBar progress={50} />);
+});

--- a/libs/stream-chat-shim/src/components/Attachment/components/ProgressBar.tsx
+++ b/libs/stream-chat-shim/src/components/Attachment/components/ProgressBar.tsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx';
+import React from 'react';
+
+export type ProgressBarProps = {
+  /** Progress expressed in fractional number value btw 0 and 100. */
+  progress: number;
+} & Pick<React.ComponentProps<'div'>, 'className' | 'onClick'>;
+
+export const ProgressBar = ({ className, onClick, progress }: ProgressBarProps) => (
+  <div
+    className={clsx(
+      'str-chat__message-attachment-audio-widget--progress-track',
+      className,
+    )}
+    data-progress={progress}
+    data-testid='audio-progress'
+    onClick={onClick}
+    role='progressbar'
+    style={
+      {
+        '--str-chat__message-attachment-audio-widget-progress': progress + '%',
+      } as React.CSSProperties
+    }
+  >
+    <div
+      className='str-chat__message-attachment-audio-widget--progress-slider'
+      style={{ left: `${progress}px` }}
+    />
+  </div>
+);

--- a/libs/stream-chat-shim/src/components/Attachment/components/index.ts
+++ b/libs/stream-chat-shim/src/components/Attachment/components/index.ts
@@ -1,0 +1,6 @@
+export * from './DownloadButton';
+export * from './FileSizeIndicator';
+export * from './ProgressBar';
+export * from './PlaybackRateButton';
+export * from './PlayButton';
+export * from './WaveProgressBar';


### PR DESCRIPTION
## Summary
- port `ProgressBar` from `stream-chat-react`
- add barrel file for attachment components
- add basic render test

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685dd0de09d88326b3137146a0cb8574