### PR TITLE
Add Avatar component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Avatar.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Avatar.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Avatar } from '../src/components/Avatar/Avatar';
+
+test('renders without crashing', () => {
+  render(<Avatar />);
+});

--- a/libs/stream-chat-shim/src/components/Avatar/Avatar.tsx
+++ b/libs/stream-chat-shim/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,82 @@
+import clsx from 'clsx';
+import React, { useEffect, useState } from 'react';
+// import type { UserResponse } from 'stream-chat'; // TODO backend-wire-up
+import type { UserResponse } from '../../../⛔_legacy_ui/stream-types';
+// import { Icon } from '../Threads/icons'; // TODO backend-wire-up
+const Icon = { User: () => null } as any;
+import { getWholeChar } from '../../utils';
+
+export type AvatarProps = {
+  /** Custom root element class that will be merged with the default class */
+  className?: string;
+  /** Image URL or default is an image of the first initial of the name if there is one  */
+  image?: string | null;
+  /** Name of the image, used for title tag fallback */
+  name?: string;
+  /** click event handler attached to the component root element */
+  onClick?: (event: React.BaseSyntheticEvent) => void;
+  /** mouseOver event handler attached to the component root element */
+  onMouseOver?: (event: React.BaseSyntheticEvent) => void;
+  /** The entire user object for the chat user displayed in the component */
+  user?: UserResponse;
+};
+
+/**
+ * A round avatar image with fallback to username's first letter
+ */
+export const Avatar = (props: AvatarProps) => {
+  const {
+    className,
+    image,
+    name,
+    onClick = () => undefined,
+    onMouseOver = () => undefined,
+  } = props;
+
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setError(false);
+  }, [image]);
+
+  const nameStr = name?.toString() || '';
+  const initials = getWholeChar(nameStr, 0);
+  const showImage = image && !error;
+
+  return (
+    <div
+      className={clsx(`str-chat__avatar str-chat__message-sender-avatar`, className, {
+        ['str-chat__avatar--multiple-letters']: initials.length > 1,
+        ['str-chat__avatar--no-letters']: !initials.length,
+        ['str-chat__avatar--one-letter']: initials.length === 1,
+      })}
+      data-testid='avatar'
+      onClick={onClick}
+      onMouseOver={onMouseOver}
+      role='button'
+      title={name}
+    >
+      {showImage ? (
+        <img
+          alt={initials}
+          className='str-chat__avatar-image'
+          data-testid='avatar-img'
+          onError={() => setError(true)}
+          src={image}
+        />
+      ) : (
+        <>
+          {!!initials.length && (
+            <div
+              className={clsx('str-chat__avatar-fallback')}
+              data-testid='avatar-fallback'
+            >
+              {initials}
+            </div>
+          )}
+          {!initials.length && <Icon.User />}
+        </>
+      )}
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Avatar/ChannelAvatar.tsx
+++ b/libs/stream-chat-shim/src/components/Avatar/ChannelAvatar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Avatar, GroupAvatar } from './';
+import type { AvatarProps, GroupAvatarProps } from './';
+
+export type ChannelAvatarProps = Partial<GroupAvatarProps> & AvatarProps;
+
+export const ChannelAvatar = ({
+  groupChannelDisplayInfo,
+  image,
+  name,
+  user,
+  ...sharedProps
+}: ChannelAvatarProps) => {
+  if (groupChannelDisplayInfo) {
+    return (
+      <GroupAvatar groupChannelDisplayInfo={groupChannelDisplayInfo} {...sharedProps} />
+    );
+  }
+  return <Avatar image={image} name={name} user={user} {...sharedProps} />;
+};

--- a/libs/stream-chat-shim/src/components/Avatar/GroupAvatar.tsx
+++ b/libs/stream-chat-shim/src/components/Avatar/GroupAvatar.tsx
@@ -1,0 +1,44 @@
+import clsx from 'clsx';
+import React from 'react';
+import type { AvatarProps } from './Avatar';
+import { Avatar } from './Avatar';
+// import type { GroupChannelDisplayInfo } from '../ChannelPreview'; // TODO backend-wire-up
+type GroupChannelDisplayInfo = { image?: string; name?: string }[]; // temporary shim
+
+export type GroupAvatarProps = Pick<
+  AvatarProps,
+  'className' | 'onClick' | 'onMouseOver'
+> & {
+  /** Mapping of image URLs to names which initials will be used as fallbacks in case image assets fail to load. */
+  groupChannelDisplayInfo: GroupChannelDisplayInfo;
+};
+
+export const GroupAvatar = ({
+  className,
+  groupChannelDisplayInfo,
+  onClick,
+  onMouseOver,
+}: GroupAvatarProps) => (
+  <div
+    className={clsx(
+      `str-chat__avatar-group`,
+      { 'str-chat__avatar-group--three-part': groupChannelDisplayInfo.length === 3 },
+      className,
+    )}
+    data-testid='group-avatar'
+    onClick={onClick}
+    onMouseOver={onMouseOver}
+    role='button'
+  >
+    {groupChannelDisplayInfo.slice(0, 4).map(({ image, name }, i) => (
+      <Avatar
+        className={clsx({
+          'str-chat__avatar--single': groupChannelDisplayInfo.length === 3 && i === 0,
+        })}
+        image={image}
+        key={`${name}-${image}-${i}`}
+        name={name}
+      />
+    ))}
+  </div>
+);

--- a/libs/stream-chat-shim/src/components/Avatar/index.ts
+++ b/libs/stream-chat-shim/src/components/Avatar/index.ts
@@ -1,0 +1,3 @@
+export * from './Avatar';
+export * from './ChannelAvatar';
+export * from './GroupAvatar';


### PR DESCRIPTION
## Summary
- port Avatar components from Stream repo
- include ChannelAvatar and GroupAvatar helpers
- provide index barrel and basic test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685dd13fa13c83268154ae44f569c94a