### PR TITLE
Port Channel support files

### DIFF
--- a/libs/stream-chat-shim/__tests__/LoadingChannel.test.tsx
+++ b/libs/stream-chat-shim/__tests__/LoadingChannel.test.tsx
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react';
+import { LoadingChannel } from '../components/Channel/LoadingChannel';
+
+test('renders without crashing', () => {
+  render(<LoadingChannel />);
+});

--- a/libs/stream-chat-shim/src/components/Channel/LoadingChannel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/LoadingChannel.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const LoadingMessage = () => (
+  <div className='str-chat__loading-channel-message'>
+    <div className='str-chat__loading-channel-message-avatar'></div>
+    <div className='str-chat__loading-channel-message-end'>
+      <div className='str-chat__loading-channel-message-sender'></div>
+      <div className='str-chat__loading-channel-message-last-row'>
+        <div className='str-chat__loading-channel-message-text'></div>
+        <div className='str-chat__loading-channel-message-date'></div>
+      </div>
+    </div>
+  </div>
+);
+
+const LoadingMessageInput = () => (
+  <div className='str-chat__loading-channel-message-input-row'>
+    <div className='str-chat__loading-channel-message-input'></div>
+    <div className='str-chat__loading-channel-message-send'></div>
+  </div>
+);
+
+const LoadingChannelHeader = () => (
+  <div className='str-chat__loading-channel-header'>
+    <div className='str-chat__loading-channel-header-avatar'></div>
+    <div className='str-chat__loading-channel-header-end'>
+      <div className='str-chat__loading-channel-header-name'></div>
+      <div className='str-chat__loading-channel-header-info'></div>
+    </div>
+  </div>
+);
+
+export const LoadingChannel = () => (
+  <div className='str-chat__loading-channel'>
+    <LoadingChannelHeader />
+    <div className='str-chat__loading-channel-message-list'>
+      {Array.from(Array(3)).map((_, i) => (
+        <LoadingMessage key={`loading-message-${i}`} />
+      ))}
+    </div>
+    <LoadingMessageInput />
+  </div>
+);

--- a/libs/stream-chat-shim/src/components/Channel/channelState.ts
+++ b/libs/stream-chat-shim/src/components/Channel/channelState.ts
@@ -1,0 +1,288 @@
+import type {
+  Channel,
+  LocalMessage,
+  MessageResponse,
+  ChannelState as StreamChannelState,
+} from 'chat-shim';
+
+import type { ChannelState } from '../../context/ChannelStateContext';
+
+export type ChannelStateReducerAction =
+  | {
+      type: 'closeThread';
+    }
+  | {
+      type: 'clearHighlightedMessage';
+    }
+  | {
+      channel: Channel;
+      type: 'copyMessagesFromChannel';
+      parentId?: string | null;
+    }
+  | {
+      channel: Channel;
+      type: 'copyStateFromChannelOnEvent';
+    }
+  | {
+      channel: Channel;
+      highlightedMessageId: string;
+      type: 'jumpToMessageFinished';
+    }
+  | {
+      channel: Channel;
+      hasMore: boolean;
+      type: 'initStateFromChannel';
+    }
+  | {
+      hasMore: boolean;
+      messages: LocalMessage[];
+      type: 'loadMoreFinished';
+    }
+  | {
+      hasMoreNewer: boolean;
+      messages: LocalMessage[];
+      type: 'loadMoreNewerFinished';
+    }
+  | {
+      threadHasMore: boolean;
+      threadMessages: Array<ReturnType<StreamChannelState['formatMessage']>>;
+      type: 'loadMoreThreadFinished';
+    }
+  | {
+      channel: Channel;
+      message: LocalMessage;
+      type: 'openThread';
+    }
+  | {
+      error: Error;
+      type: 'setError';
+    }
+  | {
+      loadingMore: boolean;
+      type: 'setLoadingMore';
+    }
+  | {
+      loadingMoreNewer: boolean;
+      type: 'setLoadingMoreNewer';
+    }
+  | {
+      message: LocalMessage;
+      type: 'setThread';
+    }
+  | {
+      channel: Channel;
+      type: 'setTyping';
+    }
+  | {
+      type: 'startLoadingThread';
+    }
+  | {
+      channel: Channel;
+      message: MessageResponse;
+      type: 'updateThreadOnEvent';
+    }
+  | {
+      type: 'jumpToLatestMessage';
+    };
+
+export const makeChannelReducer =
+  () => (state: ChannelState, action: ChannelStateReducerAction) => {
+    switch (action.type) {
+      case 'closeThread': {
+        return {
+          ...state,
+          thread: null,
+          threadLoadingMore: false,
+          threadMessages: [],
+        };
+      }
+
+      case 'copyMessagesFromChannel': {
+        const { channel, parentId } = action;
+        return {
+          ...state,
+          messages: [...channel.state.messages],
+          pinnedMessages: [...channel.state.pinnedMessages],
+          // copying messages from channel happens with new message - this resets the suppressAutoscroll
+          suppressAutoscroll: false,
+          threadMessages: parentId
+            ? { ...channel.state.threads }[parentId] || []
+            : state.threadMessages,
+        };
+      }
+
+      case 'copyStateFromChannelOnEvent': {
+        const { channel } = action;
+        return {
+          ...state,
+          members: { ...channel.state.members },
+          messages: [...channel.state.messages],
+          pinnedMessages: [...channel.state.pinnedMessages],
+          read: { ...channel.state.read },
+          watcherCount: channel.state.watcher_count,
+          watchers: { ...channel.state.watchers },
+        };
+      }
+
+      case 'initStateFromChannel': {
+        const { channel, hasMore } = action;
+        return {
+          ...state,
+          hasMore,
+          loading: false,
+          members: { ...channel.state.members },
+          messages: [...channel.state.messages],
+          pinnedMessages: [...channel.state.pinnedMessages],
+          read: { ...channel.state.read },
+          watcherCount: channel.state.watcher_count,
+          watchers: { ...channel.state.watchers },
+        };
+      }
+
+      case 'jumpToLatestMessage': {
+        return {
+          ...state,
+          hasMoreNewer: false,
+          highlightedMessageId: undefined,
+          loading: false,
+          suppressAutoscroll: false,
+        };
+      }
+
+      case 'jumpToMessageFinished': {
+        return {
+          ...state,
+          hasMoreNewer: action.channel.state.messagePagination.hasNext,
+          highlightedMessageId: action.highlightedMessageId,
+          messages: action.channel.state.messages,
+        };
+      }
+
+      case 'clearHighlightedMessage': {
+        return {
+          ...state,
+          highlightedMessageId: undefined,
+        };
+      }
+
+      case 'loadMoreFinished': {
+        const { hasMore, messages } = action;
+        return {
+          ...state,
+          hasMore,
+          loadingMore: false,
+          messages,
+          suppressAutoscroll: false,
+        };
+      }
+
+      case 'loadMoreNewerFinished': {
+        const { hasMoreNewer, messages } = action;
+        return {
+          ...state,
+          hasMoreNewer,
+          loadingMoreNewer: false,
+          messages,
+        };
+      }
+
+      case 'loadMoreThreadFinished': {
+        const { threadHasMore, threadMessages } = action;
+        return {
+          ...state,
+          threadHasMore,
+          threadLoadingMore: false,
+          threadMessages,
+        };
+      }
+
+      case 'openThread': {
+        const { channel, message } = action;
+        return {
+          ...state,
+          thread: message,
+          threadHasMore: true,
+          threadMessages: message.id
+            ? { ...channel.state.threads }[message.id] || []
+            : [],
+          threadSuppressAutoscroll: false,
+        };
+      }
+
+      case 'setError': {
+        const { error } = action;
+        return { ...state, error };
+      }
+
+      case 'setLoadingMore': {
+        const { loadingMore } = action;
+        // suppress the autoscroll behavior
+        return { ...state, loadingMore, suppressAutoscroll: loadingMore };
+      }
+
+      case 'setLoadingMoreNewer': {
+        const { loadingMoreNewer } = action;
+        return { ...state, loadingMoreNewer };
+      }
+
+      case 'setThread': {
+        const { message } = action;
+        return { ...state, thread: message };
+      }
+
+      case 'setTyping': {
+        const { channel } = action;
+        return {
+          ...state,
+          typing: { ...channel.state.typing },
+        };
+      }
+
+      case 'startLoadingThread': {
+        return {
+          ...state,
+          threadLoadingMore: true,
+          threadSuppressAutoscroll: true,
+        };
+      }
+
+      case 'updateThreadOnEvent': {
+        const { channel, message } = action;
+        if (!state.thread) return state;
+        return {
+          ...state,
+          thread:
+            message?.id === state.thread.id
+              ? channel.state.formatMessage(message)
+              : state.thread,
+          threadMessages: state.thread?.id
+            ? { ...channel.state.threads }[state.thread.id] || []
+            : [],
+        };
+      }
+
+      default:
+        return state;
+    }
+  };
+
+export const initialState = {
+  error: null,
+  hasMore: true,
+  hasMoreNewer: false,
+  loading: true,
+  loadingMore: false,
+  members: {},
+  messages: [],
+  pinnedMessages: [],
+  read: {},
+  suppressAutoscroll: false,
+  thread: null,
+  threadHasMore: true,
+  threadLoadingMore: false,
+  threadMessages: [],
+  threadSuppressAutoscroll: false,
+  typing: {},
+  watcherCount: 0,
+  watchers: {},
+};

--- a/libs/stream-chat-shim/src/components/Channel/constants.ts
+++ b/libs/stream-chat-shim/src/components/Channel/constants.ts
@@ -1,0 +1,1 @@
+export const CHANNEL_CONTAINER_ID = 'str-chat__channel';

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useChannelContainerClasses.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useChannelContainerClasses.ts
@@ -1,0 +1,24 @@
+import { useChatContext } from '../../../context/ChatContext';
+import type { ChatContextValue } from '../../../context/ChatContext';
+
+export const useImageFlagEmojisOnWindowsClass = () => {
+  const { useImageFlagEmojisOnWindows } = useChatContext('Channel');
+  return useImageFlagEmojisOnWindows && navigator.userAgent.match(/Win/)
+    ? 'str-chat--windows-flags'
+    : '';
+};
+
+export const getChatContainerClass = (customClass?: string) =>
+  customClass ?? 'str-chat__container';
+
+export const useChannelContainerClasses = ({
+  customClasses,
+}: Pick<ChatContextValue, 'customClasses'>) => {
+  const windowsEmojiClass = useImageFlagEmojisOnWindowsClass();
+  return {
+    channelClass: customClasses?.channel ?? 'str-chat__channel',
+    chatClass: customClasses?.chat ?? 'str-chat',
+    chatContainerClass: getChatContainerClass(customClasses?.chatContainer),
+    windowsEmojiClass,
+  };
+};

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useCreateChannelStateContext.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useCreateChannelStateContext.ts
@@ -1,0 +1,159 @@
+import { useMemo } from 'react';
+
+import { isDate, isDayOrMoment } from '../../../i18n';
+
+import type { ChannelStateContextValue } from '../../../context/ChannelStateContext';
+
+export const useCreateChannelStateContext = (
+  value: Omit<ChannelStateContextValue, 'channelCapabilities'> & {
+    channelCapabilitiesArray: string[];
+    skipMessageDataMemoization?: boolean;
+  },
+) => {
+  const {
+    channel,
+    channelCapabilitiesArray = [],
+    channelConfig,
+    channelUnreadUiState,
+    error,
+    giphyVersion,
+    hasMore,
+    hasMoreNewer,
+    highlightedMessageId,
+    imageAttachmentSizeHandler,
+    loading,
+    loadingMore,
+    members,
+    messages = [],
+    mutes,
+    notifications,
+    pinnedMessages,
+    read = {},
+    shouldGenerateVideoThumbnail,
+    skipMessageDataMemoization,
+    suppressAutoscroll,
+    thread,
+    threadHasMore,
+    threadLoadingMore,
+    threadMessages = [],
+    videoAttachmentSizeHandler,
+    watcher_count,
+    watcherCount,
+    watchers,
+  } = value;
+
+  const channelId = channel.cid;
+  const lastRead = channel.initialized && channel.lastRead()?.getTime();
+  const membersLength = Object.keys(members || []).length;
+  const notificationsLength = notifications.length;
+  const readUsers = Object.values(read);
+  const readUsersLength = readUsers.length;
+  const readUsersLastReads = readUsers
+    .map(({ last_read }) => last_read.toISOString())
+    .join();
+  const threadMessagesLength = threadMessages?.length;
+
+  const channelCapabilities: Record<string, boolean> = {};
+
+  channelCapabilitiesArray.forEach((capability) => {
+    channelCapabilities[capability] = true;
+  });
+
+  const memoizedMessageData = skipMessageDataMemoization
+    ? messages
+    : messages
+        .map(
+          ({
+            deleted_at,
+            latest_reactions,
+            pinned,
+            reply_count,
+            status,
+            updated_at,
+            user,
+          }) =>
+            `${deleted_at}${
+              latest_reactions ? latest_reactions.map(({ type }) => type).join() : ''
+            }${pinned}${reply_count}${status}${
+              updated_at && (isDayOrMoment(updated_at) || isDate(updated_at))
+                ? updated_at.toISOString()
+                : updated_at || ''
+            }${user?.updated_at}`,
+        )
+        .join();
+
+  const memoizedThreadMessageData = threadMessages
+    .map(
+      ({ deleted_at, latest_reactions, pinned, status, updated_at, user }) =>
+        `${deleted_at}${
+          latest_reactions ? latest_reactions.map(({ type }) => type).join() : ''
+        }${pinned}${status}${
+          updated_at && (isDayOrMoment(updated_at) || isDate(updated_at))
+            ? updated_at.toISOString()
+            : updated_at || ''
+        }${user?.updated_at}`,
+    )
+    .join();
+
+  const channelStateContext: ChannelStateContextValue = useMemo(
+    () => ({
+      channel,
+      channelCapabilities,
+      channelConfig,
+      channelUnreadUiState,
+      error,
+      giphyVersion,
+      hasMore,
+      hasMoreNewer,
+      highlightedMessageId,
+      imageAttachmentSizeHandler,
+      loading,
+      loadingMore,
+      members,
+      messages,
+      mutes,
+      notifications,
+      pinnedMessages,
+      read,
+      shouldGenerateVideoThumbnail,
+      suppressAutoscroll,
+      thread,
+      threadHasMore,
+      threadLoadingMore,
+      threadMessages,
+      videoAttachmentSizeHandler,
+      watcher_count,
+      watcherCount,
+      watchers,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      channel.data?.name, // otherwise ChannelHeader will not be updated
+      channelId,
+      channelUnreadUiState,
+      error,
+      hasMore,
+      hasMoreNewer,
+      highlightedMessageId,
+      lastRead,
+      loading,
+      loadingMore,
+      membersLength,
+      memoizedMessageData,
+      memoizedThreadMessageData,
+      notificationsLength,
+      readUsersLength,
+      readUsersLastReads,
+      shouldGenerateVideoThumbnail,
+      skipMessageDataMemoization,
+      suppressAutoscroll,
+      thread,
+      threadHasMore,
+      threadLoadingMore,
+      threadMessagesLength,
+      watcherCount,
+    ],
+  );
+
+  return channelStateContext;
+};

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useCreateTypingContext.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useCreateTypingContext.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+
+import type { TypingContextValue } from '../../../context/TypingContext';
+
+export const useCreateTypingContext = (value: TypingContextValue) => {
+  const { typing } = value;
+
+  const typingValue = Object.keys(typing || {}).join();
+
+  const typingContext: TypingContextValue = useMemo(
+    () => ({
+      typing,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [typingValue],
+  );
+
+  return typingContext;
+};

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useEditMessageHandler.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useEditMessageHandler.ts
@@ -1,0 +1,31 @@
+import type {
+  LocalMessage,
+  MessageResponse,
+  StreamChat,
+  UpdateMessageOptions,
+} from 'chat-shim';
+
+import { useChatContext } from '../../../context/ChatContext';
+
+type UpdateHandler = (
+  cid: string,
+  updatedMessage: LocalMessage | MessageResponse,
+  options?: UpdateMessageOptions,
+) => ReturnType<StreamChat['updateMessage']>;
+
+export const useEditMessageHandler = (doUpdateMessageRequest?: UpdateHandler) => {
+  const { channel, client } = useChatContext('useEditMessageHandler');
+
+  return (
+    updatedMessage: LocalMessage | MessageResponse,
+    options?: UpdateMessageOptions,
+  ) => {
+    if (doUpdateMessageRequest && channel) {
+      return Promise.resolve(
+        doUpdateMessageRequest(channel.cid, updatedMessage, options),
+      );
+    }
+    /* TODO backend-wire-up: updateMessage */
+    return Promise.resolve(undefined);
+  };
+};

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useIsMounted.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useIsMounted.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react';
+
+export const useIsMounted = () => {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted;
+};

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useMentionsHandlers.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useMentionsHandlers.ts
@@ -1,0 +1,50 @@
+import type React from 'react';
+import { useCallback } from 'react';
+import type { UserResponse } from 'chat-shim';
+
+export type OnMentionAction = (
+  event: React.BaseSyntheticEvent,
+  user?: UserResponse,
+) => void;
+
+export const useMentionsHandlers = (
+  onMentionsHover?: OnMentionAction,
+  onMentionsClick?: OnMentionAction,
+) =>
+  useCallback(
+    (event: React.BaseSyntheticEvent, mentioned_users: UserResponse[]) => {
+      if (
+        (!onMentionsHover && !onMentionsClick) ||
+        !(event.target instanceof HTMLElement)
+      ) {
+        return;
+      }
+
+      const target = event.target;
+      const textContent = target.innerHTML.replace('*', '');
+
+      if (textContent[0] === '@') {
+        const userName = textContent.replace('@', '');
+        const user = mentioned_users?.find(
+          ({ id, name }) => name === userName || id === userName,
+        );
+
+        if (
+          onMentionsHover &&
+          typeof onMentionsHover === 'function' &&
+          event.type === 'mouseover'
+        ) {
+          onMentionsHover(event, user);
+        }
+
+        if (
+          onMentionsClick &&
+          event.type === 'click' &&
+          typeof onMentionsClick === 'function'
+        ) {
+          onMentionsClick(event, user);
+        }
+      }
+    },
+    [onMentionsClick, onMentionsHover],
+  );

--- a/libs/stream-chat-shim/src/components/Channel/index.ts
+++ b/libs/stream-chat-shim/src/components/Channel/index.ts
@@ -1,0 +1,3 @@
+export * from './Channel';
+export { useEditMessageHandler as useChannelEditMessageHandler } from './hooks/useEditMessageHandler';
+export { useMentionsHandlers as useChannelMentionsHandler } from './hooks/useMentionsHandlers';

--- a/libs/stream-chat-shim/src/components/Channel/utils.ts
+++ b/libs/stream-chat-shim/src/components/Channel/utils.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 import type { Dispatch, SetStateAction } from 'react';
-import type { ChannelState, MessageResponse, StreamChat } from 'stream-chat';
+import type { ChannelState, MessageResponse, StreamChat } from 'chat-shim';
 import type { ChannelNotifications } from '../../context/ChannelStateContext';
 
 export const makeAddNotifications =


### PR DESCRIPTION
## Summary
- port Channel hooks, state, constants, and LoadingChannel
- export Channel utilities via index
- stub SaaS calls and swap imports for chat-shim
- add smoke test for LoadingChannel

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*


------
https://chatgpt.com/codex/tasks/task_e_685dd1b5cef08326a51d4096db55bb36