### PR TITLE
Port ChannelListMessenger component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ChannelListMessenger.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ChannelListMessenger.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ChannelListMessenger } from '../src/components/ChannelList/ChannelListMessenger';
+
+test('renders without crashing', () => {
+  render(<ChannelListMessenger error={null} />);
+});

--- a/libs/stream-chat-shim/src/components/ChannelList/ChannelListMessenger.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelList/ChannelListMessenger.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { PropsWithChildren } from 'react';
+/* TODO backend-wire-up: StreamChat import excised */
+
+import { LoadingChannels } from '../Loading/LoadingChannels';
+import { NullComponent } from '../UtilityComponents';
+import { useTranslationContext } from '../../context';
+
+export type ChannelListMessengerProps = {
+  /** Whether the channel query request returned an errored response */
+  error: ErrorFromResponse<APIErrorResponse> | null;
+  /** The channels currently loaded in the list, only defined if `sendChannelsToList` on `ChannelList` is true */
+  loadedChannels?: Channel[];
+  /** Whether the channels are currently loading */
+  loading?: boolean;
+  /** Custom UI component to display the loading error indicator, defaults to component that renders null */
+  LoadingErrorIndicator?: React.ComponentType;
+  /** Custom UI component to display a loading indicator, defaults to and accepts same props as: [LoadingChannels](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Loading/LoadingChannels.tsx) */
+  LoadingIndicator?: React.ComponentType;
+  /** Local state hook that resets the currently loaded channels */
+  setChannels?: React.Dispatch<React.SetStateAction<Channel[]>>;
+};
+
+/**
+ * A preview list of channels, allowing you to select the channel you want to open
+ */
+export const ChannelListMessenger = (
+  props: PropsWithChildren<ChannelListMessengerProps>,
+) => {
+  const {
+    children,
+    error = null,
+    loading,
+    LoadingErrorIndicator = NullComponent,
+    LoadingIndicator = LoadingChannels,
+  } = props;
+  const { t } = useTranslationContext('ChannelListMessenger');
+
+  if (error) {
+    return <LoadingErrorIndicator />;
+  }
+
+  if (loading) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <div className='str-chat__channel-list-messenger str-chat__channel-list-messenger-react'>
+      <div
+        aria-label={t('aria/Channel list')}
+        className='str-chat__channel-list-messenger__main str-chat__channel-list-messenger-react__main'
+        role='listbox'
+      >
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/ChannelList/index.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/index.ts
@@ -1,0 +1,4 @@
+export * from './ChannelList';
+export * from './ChannelListMessenger';
+export * from './hooks';
+export * from './utils';


### PR DESCRIPTION
## Summary
- port `ChannelListMessenger` from stream-ui
- add local index export for ChannelList
- add test for `ChannelListMessenger`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_685dd20e68648326b96cadda798695f4