### PR TITLE
Port ChannelPreviewActionButtons

### DIFF
--- a/libs/stream-chat-shim/__tests__/ChannelPreviewActionButtons.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ChannelPreviewActionButtons.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ChannelPreviewActionButtons } from '../src/components/ChannelPreview/ChannelPreviewActionButtons';
+
+test('renders without crashing', () => {
+  render(<ChannelPreviewActionButtons channel={{} as any} />);
+});

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { Channel } from 'chat-shim';
+
+import { useChannelMembershipState } from '../ChannelList';
+import { Icon } from './icons';
+import { useTranslationContext } from '../../context';
+
+export type ChannelPreviewActionButtonsProps = {
+  channel: Channel;
+};
+
+export function ChannelPreviewActionButtons({
+  channel,
+}: ChannelPreviewActionButtonsProps) {
+  const membership = useChannelMembershipState(channel);
+  const { t } = useTranslationContext();
+
+  return (
+    <div className='str-chat__channel-preview__action-buttons'>
+      <button
+        aria-label={membership.pinned_at ? t('Unpin') : t('Pin')}
+        className={clsx(
+          'str-chat__channel-preview__action-button',
+          'str-chat__channel-preview__action-button--pin',
+          membership.pinned_at && 'str-chat__channel-preview__action-button--active',
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (membership.pinned_at) {
+            /* TODO backend-wire-up: unpin */ Promise.resolve(undefined);
+          } else {
+            /* TODO backend-wire-up: pin */ Promise.resolve(undefined);
+          }
+        }}
+        title={membership.pinned_at ? t('Unpin') : t('Pin')}
+      >
+        <Icon.Pin />
+      </button>
+      <button
+        aria-label={membership.archived_at ? t('Unarchive') : t('Archive')}
+        className={clsx(
+          'str-chat__channel-preview__action-button',
+          'str-chat__channel-preview__action-button--archive',
+          membership.archived_at && 'str-chat__channel-preview__action-button--active',
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (membership.archived_at) {
+            /* TODO backend-wire-up: unarchive */ Promise.resolve(undefined);
+          } else {
+            /* TODO backend-wire-up: archive */ Promise.resolve(undefined);
+          }
+        }}
+        title={membership.archived_at ? t('Unarchive') : t('Archive')}
+      >
+        <Icon.ArchiveBox />
+      </button>
+    </div>
+  );
+}

--- a/libs/stream-chat-shim/src/components/ChannelPreview/icons.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/icons.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
+
+export const Icon = {
+  ArchiveBox: (props: ComponentPropsWithoutRef<'svg'>) => (
+    <svg
+      className='str-chat__icon str-chat__icon--archive-box'
+      fill='currentColor'
+      viewBox='0 0 512 512'
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+    >
+      <path d='M32 32l448 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32L32 128C14.3 128 0 113.7 0 96L0 64C0 46.3 14.3 32 32 32zm0 128l448 0 0 256c0 35.3-28.7 64-64 64L96 480c-35.3 0-64-28.7-64-64l0-256zm128 80c0 8.8 7.2 16 16 16l160 0c8.8 0 16-7.2 16-16s-7.2-16-16-16l-160 0c-8.8 0-16 7.2-16 16z' />
+    </svg>
+  ),
+  Pin: (props: ComponentPropsWithoutRef<'svg'>) => (
+    <svg
+      className='str-chat__icon str-chat__icon--pin'
+      fill='currentColor'
+      viewBox='0 0 384 512'
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+    >
+      <path d='M32 32C32 14.3 46.3 0 64 0L320 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-29.5 0 11.4 148.2c36.7 19.9 65.7 53.2 79.5 94.7l1 3c3.3 9.8 1.6 20.5-4.4 28.8s-15.7 13.3-26 13.3L32 352c-10.3 0-19.9-4.9-26-13.3s-7.7-19.1-4.4-28.8l1-3c13.8-41.5 42.8-74.8 79.5-94.7L93.5 64 64 64C46.3 64 32 49.7 32 32zM160 384l64 0 0 96c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-96z' />
+    </svg>
+  ),
+};


### PR DESCRIPTION
## Summary
- port ChannelPreviewActionButtons component from stream-chat-react
- add ChannelPreview icons
- add basic render test

## Testing
- `pnpm -r build` *(fails: Can't resolve 'stream-chat-react')*
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails with TS errors)*
- `npm test` *(fails parsing turbo json)*

------
https://chatgpt.com/codex/tasks/task_e_685dd25a11e483269d9a78dd1f13b8e9