### PR TITLE
Port SearchInput to shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchInput.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchInput.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SearchInput } from '../src/ChannelSearch/SearchInput';
+
+test('renders search input', () => {
+  const inputRef = React.createRef<HTMLInputElement>();
+  const { getByTestId } = render(
+    <SearchInput
+      clearState={() => {}}
+      inputRef={inputRef}
+      onSearch={() => {}}
+      query=""
+    />
+  );
+  expect(getByTestId('search-input')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/components/ChannelSearch/SearchInput.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/SearchInput.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export type SearchInputController = {
+  /** Clears the channel search state */
+  clearState: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  /** Search input change handler */
+  onSearch: React.ChangeEventHandler<HTMLInputElement>;
+  /** Current search string */
+  query: string;
+};
+
+export type AdditionalSearchInputProps = {
+  /** Sets the input element into disabled state */
+  disabled?: boolean;
+  /** Custom placeholder text to be displayed in the search input */
+  placeholder?: string;
+};
+
+export type SearchInputProps = AdditionalSearchInputProps & SearchInputController;
+
+export const SearchInput = (props: SearchInputProps) => {
+  const { disabled, inputRef, onSearch, placeholder, query } = props;
+
+  const { t } = useTranslationContext('SearchInput');
+
+  return (
+    <input
+      className='str-chat__channel-search-input'
+      data-testid='search-input'
+      disabled={disabled}
+      onChange={onSearch}
+      placeholder={placeholder ?? t('Search')}
+      ref={inputRef}
+      type='text'
+      value={query}
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/ChannelSearch/index.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/index.ts
@@ -1,0 +1,9 @@
+export * from './ChannelSearch';
+export * from './SearchBar';
+export * from './SearchInput';
+export * from './SearchResults';
+export * from './utils';
+export type {
+  ChannelSearchFunctionParams,
+  ChannelSearchParams,
+} from './hooks/useChannelSearch';


### PR DESCRIPTION
## Summary
- port SearchInput component from stream-ui
- add index barrel for ChannelSearch
- add basic test for SearchInput

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: Cannot find type definition file for 'jest', etc.)*
- `pnpm test` *(fails to parse turbo json)*

------
https://chatgpt.com/codex/tasks/task_e_685dd2df727483268013724ba35ee5f8