### PR TITLE
Add ChannelSearch SearchInput component

### DIFF
--- a/libs/stream-chat-shim/__tests__/SearchInput.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SearchInput.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SearchInput } from '../src/components/ChannelSearch/SearchInput';
+
+test('renders without crashing', () => {
+  const inputRef = React.createRef<HTMLInputElement>();
+  render(
+    <SearchInput
+      clearState={() => {}}
+      inputRef={inputRef}
+      onSearch={() => {}}
+      query=""
+    />
+  );
+});

--- a/libs/stream-chat-shim/src/components/ChannelSearch/SearchInput.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/SearchInput.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+// import { useTranslationContext } from '../../context/TranslationContext'; // TODO backend-wire-up
+const useTranslationContext = (_componentName?: string) => ({
+  t: (key: string) => key,
+});
+
+export type SearchInputController = {
+  /** Clears the channel search state */
+  clearState: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  /** Search input change handler */
+  onSearch: React.ChangeEventHandler<HTMLInputElement>;
+  /** Current search string */
+  query: string;
+};
+
+export type AdditionalSearchInputProps = {
+  /** Sets the input element into disabled state */
+  disabled?: boolean;
+  /** Custom placeholder text to be displayed in the search input */
+  placeholder?: string;
+};
+
+export type SearchInputProps = AdditionalSearchInputProps & SearchInputController;
+
+export const SearchInput = (props: SearchInputProps) => {
+  const { disabled, inputRef, onSearch, placeholder, query } = props;
+
+  const { t } = useTranslationContext('SearchInput');
+
+  return (
+    <input
+      className='str-chat__channel-search-input'
+      data-testid='search-input'
+      disabled={disabled}
+      onChange={onSearch}
+      placeholder={placeholder ?? t('Search')}
+      ref={inputRef}
+      type='text'
+      value={query}
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/ChannelSearch/index.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/index.ts
@@ -1,0 +1,9 @@
+export * from './ChannelSearch';
+export * from './SearchBar';
+export * from './SearchInput';
+export * from './SearchResults';
+export * from './utils';
+export type {
+  ChannelSearchFunctionParams,
+  ChannelSearchParams,
+} from './hooks/useChannelSearch';


### PR DESCRIPTION
## Summary
- port `SearchInput` from stream-chat-react
- expose ChannelSearch re-exports
- test SearchInput render

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685dd2f972cc8326a135d51cb9aac007