### PR TITLE
Add DialogAnchor component

### DIFF
--- a/libs/stream-chat-shim/__tests__/DialogAnchor.test.tsx
+++ b/libs/stream-chat-shim/__tests__/DialogAnchor.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DialogAnchor } from '../src/Dialog/DialogAnchor';
+
+test('renders without crashing', () => {
+  render(
+    <DialogAnchor id="dialog" open={true} placement="auto" referenceElement={null}>
+      content
+    </DialogAnchor>
+  );
+});

--- a/libs/stream-chat-shim/src/components/Dialog/DialogAnchor.tsx
+++ b/libs/stream-chat-shim/src/components/Dialog/DialogAnchor.tsx
@@ -1,0 +1,118 @@
+import clsx from 'clsx';
+import type { Placement } from '@popperjs/core';
+import type { ComponentProps, PropsWithChildren } from 'react';
+import React, { useEffect, useState } from 'react';
+import { FocusScope } from '@react-aria/focus';
+import { usePopper } from 'react-popper';
+import { DialogPortalEntry } from './DialogPortal';
+import { useDialog, useDialogIsOpen } from './hooks';
+
+export interface DialogAnchorOptions {
+  open: boolean;
+  placement: Placement;
+  referenceElement: HTMLElement | null;
+}
+
+export function useDialogAnchor<T extends HTMLElement>({
+  open,
+  placement,
+  referenceElement,
+}: DialogAnchorOptions) {
+  const [popperElement, setPopperElement] = useState<T | null>(null);
+  const { attributes, styles, update } = usePopper(referenceElement, popperElement, {
+    modifiers: [
+      {
+        name: 'eventListeners',
+        options: {
+          // It's not safe to update popper position on resize and scroll, since popper's
+          // reference element might not be visible at the time.
+          resize: false,
+          scroll: false,
+        },
+      },
+    ],
+    placement,
+  });
+
+  useEffect(() => {
+    if (open && popperElement) {
+      // Since the popper's reference element might not be (and usually is not) visible
+      // all the time, it's safer to force popper update before showing it.
+      // update is non-null only if popperElement is non-null
+      update?.();
+    }
+  }, [open, popperElement, update]);
+
+  if (popperElement && !open) {
+    setPopperElement(null);
+  }
+
+  return {
+    attributes,
+    setPopperElement,
+    styles,
+  };
+}
+
+export type DialogAnchorProps = PropsWithChildren<Partial<DialogAnchorOptions>> & {
+  id: string;
+  focus?: boolean;
+  trapFocus?: boolean;
+} & ComponentProps<'div'>;
+
+export const DialogAnchor = ({
+  children,
+  className,
+  focus = true,
+  id,
+  placement = 'auto',
+  referenceElement = null,
+  tabIndex,
+  trapFocus,
+  ...restDivProps
+}: DialogAnchorProps) => {
+  const dialog = useDialog({ id });
+  const open = useDialogIsOpen(id);
+  const { attributes, setPopperElement, styles } = useDialogAnchor<HTMLDivElement>({
+    open,
+    placement,
+    referenceElement,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const hideOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      dialog?.close();
+    };
+
+    document.addEventListener('keyup', hideOnEscape);
+
+    return () => {
+      document.removeEventListener('keyup', hideOnEscape);
+    };
+  }, [dialog, open]);
+
+  // prevent rendering the dialog contents if the dialog should not be open / shown
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <DialogPortalEntry dialogId={id}>
+      <FocusScope autoFocus={focus} contain={trapFocus} restoreFocus>
+        <div
+          {...restDivProps}
+          {...attributes.popper}
+          className={clsx('str-chat__dialog-contents', className)}
+          data-testid='str-chat__dialog-contents'
+          ref={setPopperElement}
+          style={styles.popper}
+          tabIndex={typeof tabIndex !== 'undefined' ? tabIndex : 0}
+        >
+          {children}
+        </div>
+      </FocusScope>
+    </DialogPortalEntry>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Dialog/hooks/index.ts
+++ b/libs/stream-chat-shim/src/components/Dialog/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useDialog';

--- a/libs/stream-chat-shim/src/components/Dialog/hooks/useDialog.ts
+++ b/libs/stream-chat-shim/src/components/Dialog/hooks/useDialog.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect } from 'react';
+import { useDialogManager } from '../../../context';
+import { useStateStore } from '../../../store';
+
+import type { DialogManagerState, GetOrCreateDialogParams } from '../DialogManager';
+
+export const useDialog = ({ id }: GetOrCreateDialogParams) => {
+  const { dialogManager } = useDialogManager();
+
+  useEffect(
+    () => () => {
+      // Since this cleanup can run even if the component is still mounted
+      // and dialog id is unchanged (e.g. in <StrictMode />), it's safer to
+      // mark state as unused and only remove it after a timeout, rather than
+      // to remove it immediately.
+      dialogManager.markForRemoval(id);
+    },
+    [dialogManager, id],
+  );
+
+  return dialogManager.getOrCreate({ id });
+};
+
+export const useDialogIsOpen = (id: string) => {
+  const { dialogManager } = useDialogManager();
+  const dialogIsOpenSelector = useCallback(
+    ({ dialogsById }: DialogManagerState) => ({ isOpen: !!dialogsById[id]?.isOpen }),
+    [id],
+  );
+  return useStateStore(dialogManager.state, dialogIsOpenSelector).isOpen;
+};
+
+const openedDialogCountSelector = (nextValue: DialogManagerState) => ({
+  openedDialogCount: Object.values(nextValue.dialogsById).reduce((count, dialog) => {
+    if (dialog.isOpen) return count + 1;
+    return count;
+  }, 0),
+});
+
+export const useOpenedDialogCount = () => {
+  const { dialogManager } = useDialogManager();
+  return useStateStore(dialogManager.state, openedDialogCountSelector).openedDialogCount;
+};

--- a/libs/stream-chat-shim/src/components/Dialog/index.ts
+++ b/libs/stream-chat-shim/src/components/Dialog/index.ts
@@ -1,0 +1,5 @@
+export * from './ButtonWithSubmenu';
+export * from './DialogAnchor';
+export * from './DialogManager';
+export * from './DialogPortal';
+export * from './hooks';


### PR DESCRIPTION
## Summary
- port `DialogAnchor` component and hooks from upstream
- include barrel exports
- add smoke test

## Testing
- `pnpm exec tsc --noEmit` *(fails: Cannot find module errors)*
- `pnpm exec jest` *(fails to run due to TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dd3770c9c83268f50ef86c1a8bcd5