### PR TITLE
Port DateSeparator component

### DIFF
--- a/libs/stream-chat-shim/__tests__/DateSeparator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/DateSeparator.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DateSeparator } from '../src/components/DateSeparator/DateSeparator';
+
+test('renders without crashing', () => {
+  render(<DateSeparator date={new Date()} />);
+});

--- a/libs/stream-chat-shim/src/components/DateSeparator/DateSeparator.tsx
+++ b/libs/stream-chat-shim/src/components/DateSeparator/DateSeparator.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+import { getDateString } from '../../i18n/utils';
+
+import type { TimestampFormatterOptions } from '../../i18n/types';
+
+export type DateSeparatorProps = TimestampFormatterOptions & {
+  /** The date to format */
+  date: Date;
+  /** Override the default formatting of the date. This is a function that has access to the original date object. */
+  formatDate?: (date: Date) => string;
+  /** Set the position of the date in the separator, options are 'left', 'center', 'right', @default right */
+  position?: 'left' | 'center' | 'right';
+  /** If following messages are not new */
+  unread?: boolean;
+};
+
+const UnMemoizedDateSeparator = (props: DateSeparatorProps) => {
+  const {
+    calendar,
+    date: messageCreatedAt,
+    formatDate,
+    position = 'right',
+    unread,
+    ...restTimestampFormatterOptions
+  } = props;
+
+  const { t, tDateTimeParser } = useTranslationContext('DateSeparator');
+
+  const formattedDate = getDateString({
+    calendar,
+    ...restTimestampFormatterOptions,
+    formatDate,
+    messageCreatedAt,
+    t,
+    tDateTimeParser,
+    timestampTranslationKey: 'timestamp/DateSeparator',
+  });
+
+  return (
+    <div className='str-chat__date-separator' data-testid='date-separator'>
+      {(position === 'right' || position === 'center') && (
+        <hr className='str-chat__date-separator-line' />
+      )}
+      <div className='str-chat__date-separator-date'>
+        {unread ? `${t('New')} - ${formattedDate}` : formattedDate}
+      </div>
+      {(position === 'left' || position === 'center') && (
+        <hr className='str-chat__date-separator-line' />
+      )}
+    </div>
+  );
+};
+
+/**
+ * A simple date separator between messages.
+ */
+export const DateSeparator = React.memo(
+  UnMemoizedDateSeparator,
+) as typeof UnMemoizedDateSeparator;

--- a/libs/stream-chat-shim/src/components/DateSeparator/index.ts
+++ b/libs/stream-chat-shim/src/components/DateSeparator/index.ts
@@ -1,0 +1,1 @@
+export * from './DateSeparator';


### PR DESCRIPTION
## Summary
- copy `DateSeparator` component from stream-ui
- expose component barrel
- add basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685dd382af0c8326aafc1f35f61bd625