### PR TITLE
Add DialogMenu component

### DIFF
--- a/libs/stream-chat-shim/__tests__/DialogMenu.test.tsx
+++ b/libs/stream-chat-shim/__tests__/DialogMenu.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DialogMenuButton } from '../src/components/Dialog/DialogMenu';
+
+test('renders without crashing', () => {
+  render(<DialogMenuButton>Test</DialogMenuButton>);
+});

--- a/libs/stream-chat-shim/src/components/Dialog/DialogMenu.tsx
+++ b/libs/stream-chat-shim/src/components/Dialog/DialogMenu.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps } from 'react';
+import React from 'react';
+import clsx from 'clsx';
+
+export type DialogMenuButtonProps = ComponentProps<'button'>;
+
+export const DialogMenuButton = ({
+  children,
+  className,
+  ...props
+}: DialogMenuButtonProps) => (
+  <button className={clsx('str-chat__dialog-menu__button', className)} {...props}>
+    <div className='str-chat__dialog-menu__button-icon' />
+    <div className='str-chat__dialog-menu__button-text'>{children}</div>
+  </button>
+);


### PR DESCRIPTION
## Summary
- port DialogMenuButton from stream-chat-react
- add DialogMenu tests

## Testing
- `pnpm -r build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd390087883268570f226c1654b98