### PR TITLE
Add PromptDialog component

### DIFF
--- a/libs/stream-chat-shim/__tests__/PromptDialog.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PromptDialog.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PromptDialog } from '../src/components/Dialog/PromptDialog';
+
+test('renders without crashing', () => {
+  render(<PromptDialog prompt="confirm?" actions={[]} />);
+});

--- a/libs/stream-chat-shim/src/components/Dialog/PromptDialog.tsx
+++ b/libs/stream-chat-shim/src/components/Dialog/PromptDialog.tsx
@@ -1,0 +1,33 @@
+import type { ComponentProps } from 'react';
+import React from 'react';
+import clsx from 'clsx';
+
+export type ConfirmationDialogProps = {
+  actions: ComponentProps<'button'>[];
+  prompt: string;
+  className?: string;
+  title?: string;
+};
+
+export const PromptDialog = ({
+  actions,
+  className,
+  prompt,
+  title,
+}: ConfirmationDialogProps) => (
+  <div className={clsx('str-chat__dialog str-chat__dialog--prompt', className)}>
+    <div className='str-chat__dialog__body'>
+      {title && <div className='str-chat__dialog__title'>{title}</div>}
+      <div className='str-chat__dialog__prompt'>{prompt}</div>
+    </div>
+    <div className='str-chat__dialog__controls'>
+      {actions.map(({ className, ...props }, i) => (
+        <button
+          className={clsx(`str-chat__dialog__controls-button`, className)}
+          key={`prompt-dialog__controls-button--${i}`}
+          {...props}
+        />
+      ))}
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Summary
- port PromptDialog component from Stream UI
- add minimal test

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685dd3beda988326a3c0e710f74fe5a9