### PR TITLE
Port EmptyStateIndicator component

### DIFF
--- a/libs/stream-chat-shim/__tests__/EmptyStateIndicator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/EmptyStateIndicator.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EmptyStateIndicator } from '../src/components/EmptyStateIndicator';
+
+test('renders without crashing', () => {
+  render(<EmptyStateIndicator />);
+});

--- a/libs/stream-chat-shim/src/components/EmptyStateIndicator/EmptyStateIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/EmptyStateIndicator/EmptyStateIndicator.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+import { ChatBubble } from './icons';
+
+export type EmptyStateIndicatorProps = {
+  /** List Type: channel | message */
+  listType?: 'channel' | 'message' | 'thread';
+};
+
+const UnMemoizedEmptyStateIndicator = (props: EmptyStateIndicatorProps) => {
+  const { listType } = props;
+
+  const { t } = useTranslationContext('EmptyStateIndicator');
+
+  if (listType === 'thread') return null;
+
+  if (listType === 'channel') {
+    const text = t('You have no channels currently');
+    return (
+      <>
+        <div className='str-chat__channel-list-empty'>
+          <ChatBubble />
+          <p role='listitem'>{text}</p>
+        </div>
+      </>
+    );
+  }
+
+  if (listType === 'message') {
+    const text = t('No chats here yet…');
+    return (
+      <div className='str-chat__empty-channel'>
+        <ChatBubble />
+        <p className='str-chat__empty-channel-text' role='listitem'>
+          {text}
+        </p>
+      </div>
+    );
+  }
+
+  return <p>No items exist</p>;
+};
+
+export const EmptyStateIndicator = React.memo(
+  UnMemoizedEmptyStateIndicator,
+) as typeof UnMemoizedEmptyStateIndicator;

--- a/libs/stream-chat-shim/src/components/EmptyStateIndicator/icons.tsx
+++ b/libs/stream-chat-shim/src/components/EmptyStateIndicator/icons.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export const ChatBubble = () => (
+  <svg
+    data-testid='chat-bubble'
+    fill='none'
+    height='96'
+    viewBox='0 0 136 136'
+    width='96'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <path
+      d='M106 24.5H30C24.775 24.5 20.5 28.775 20.5 34V119.5L39.5 100.5H106C111.225 100.5 115.5 96.225 115.5 91V34C115.5 28.775 111.225 24.5 106 24.5ZM106 91H39.5L30 100.5V34H106V91Z'
+      fill='#B4B7BB'
+    />
+  </svg>
+);

--- a/libs/stream-chat-shim/src/components/EmptyStateIndicator/index.ts
+++ b/libs/stream-chat-shim/src/components/EmptyStateIndicator/index.ts
@@ -1,0 +1,1 @@
+export * from './EmptyStateIndicator';


### PR DESCRIPTION
## Summary
- add EmptyStateIndicator from stream-chat-react
- include index and icon helper
- add basic render test

## Testing
- `pnpm -r build` *(fails: Module not found 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails with type errors)*
- `pnpm test` *(fails to parse turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dd40499a4832680a9300bdf742792