### PR TITLE
Add SwitchField component to shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/SwitchField.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SwitchField.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SwitchField } from '../src/components/Form/SwitchField';
+
+test('renders without crashing', () => {
+  render(<SwitchField />);
+});

--- a/libs/stream-chat-shim/src/components/Form/SwitchField.tsx
+++ b/libs/stream-chat-shim/src/components/Form/SwitchField.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+import type {
+  ComponentProps,
+  ElementRef,
+  KeyboardEventHandler,
+  PropsWithChildren,
+} from 'react';
+import React, { useRef } from 'react';
+
+export type SwitchFieldProps = PropsWithChildren<ComponentProps<'input'>>;
+
+export const SwitchField = ({ children, ...props }: SwitchFieldProps) => {
+  const inputRef = useRef<ElementRef<'input'>>(null);
+  const handleKeyUp: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (![' ', 'Enter'].includes(event.key) || !inputRef.current) return;
+    event.preventDefault();
+    inputRef.current.click();
+  };
+
+  return (
+    <div className='str-chat__form__field str-chat__form__switch-field'>
+      <label>
+        <div className='str-chat__form__field str-chat__form__switch-field-content'>
+          {children}
+        </div>
+        <input type='checkbox' {...props} ref={inputRef} />
+        <div
+          className={clsx('str-chat__form__switch-field__switch', {
+            'str-chat__form__switch-field__switch--on': props.checked,
+          })}
+          onKeyUp={handleKeyUp}
+          tabIndex={0}
+        >
+          <div className='str-chat__form__switch-field__switch-handle' />
+        </div>
+      </label>
+    </div>
+  );
+};
+
+export type SimpleSwitchFieldProps = ComponentProps<'input'> & {
+  labelText: string;
+};
+
+export const SimpleSwitchField = ({ labelText, ...props }: SimpleSwitchFieldProps) => (
+  <SwitchField {...props}>
+    <div className='str-chat__form__field str-chat__form__switch-field__text'>
+      {labelText}
+    </div>
+  </SwitchField>
+);


### PR DESCRIPTION
## Summary
- port `SwitchField` from stream-chat-react into shim
- add basic render test

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve 'stream-chat-react')*
- `tsc -p frontend --noEmit` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dd47c451c8326905a1e3a563905dc