### PR TITLE
Add Gallery Image component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Image.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Image.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ImageComponent } from '../src/components/Gallery/Image';
+
+test('renders without crashing', () => {
+  render(<ImageComponent />);
+});

--- a/libs/stream-chat-shim/src/components/Gallery/Image.tsx
+++ b/libs/stream-chat-shim/src/components/Gallery/Image.tsx
@@ -1,0 +1,72 @@
+import type { CSSProperties, MutableRefObject } from 'react';
+import React, { useState } from 'react';
+import { sanitizeUrl } from '@braintree/sanitize-url';
+
+import { BaseImage as DefaultBaseImage } from './BaseImage';
+import { Modal } from '../Modal';
+import { ModalGallery as DefaultModalGallery } from './ModalGallery';
+import { useComponentContext } from '../../context';
+
+// import type { Attachment } from 'stream-chat'; // TODO backend-wire-up
+type Attachment = any;
+import type { Dimensions } from '../../types/types';
+
+export type ImageProps = {
+  dimensions?: Dimensions;
+  innerRef?: MutableRefObject<HTMLImageElement | null>;
+  previewUrl?: string;
+  style?: CSSProperties;
+} & (
+  | {
+      /** The text fallback for the image */
+      fallback?: string;
+      /** The full size image url */
+      image_url?: string;
+      /** The thumb url */
+      thumb_url?: string;
+    }
+  | Attachment
+);
+
+/**
+ * A simple component that displays an image.
+ */
+export const ImageComponent = (props: ImageProps) => {
+  const {
+    dimensions = {},
+    fallback,
+    image_url,
+    innerRef,
+    previewUrl,
+    style,
+    thumb_url,
+  } = props;
+
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const { BaseImage = DefaultBaseImage, ModalGallery = DefaultModalGallery } =
+    useComponentContext('ImageComponent');
+
+  const imageSrc = sanitizeUrl(previewUrl || image_url || thumb_url);
+
+  const toggleModal = () => setModalIsOpen((modalIsOpen) => !modalIsOpen);
+
+  return (
+    <>
+      <BaseImage
+        alt={fallback}
+        className='str-chat__message-attachment--img'
+        data-testid='image-test'
+        onClick={toggleModal}
+        src={imageSrc}
+        style={style}
+        tabIndex={0}
+        title={fallback}
+        {...dimensions}
+        {...(innerRef && { ref: innerRef })}
+      />
+      <Modal className='str-chat__image-modal' onClose={toggleModal} open={modalIsOpen}>
+        <ModalGallery images={[props]} index={0} />
+      </Modal>
+    </>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Gallery/index.tsx
+++ b/libs/stream-chat-shim/src/components/Gallery/index.tsx
@@ -1,0 +1,4 @@
+export * from './BaseImage';
+export * from './Gallery';
+export * from './Image';
+export * from './ModalGallery';


### PR DESCRIPTION
## Summary
- port `components/Gallery/Image.tsx` from upstream stream-ui
- expose Gallery pieces in an index
- add a basic Jest test for `ImageComponent`

## Testing
- `pnpm -r build` *(fails: Module not found 'stream-chat-react')*
- `pnpm --filter frontend exec tsc --noEmit` *(fails with type errors)*
- `pnpm test` *(fails to parse turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_685de01d6adc8326a7affd1b12f76a2d