### PR TITLE
Add ModalGallery component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ModalGallery.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ModalGallery.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ModalGallery } from '../src/components/Gallery/ModalGallery';
+
+test('renders without crashing', () => {
+  render(<ModalGallery images={[]} />);
+});

--- a/libs/stream-chat-shim/src/components/Gallery/ModalGallery.tsx
+++ b/libs/stream-chat-shim/src/components/Gallery/ModalGallery.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+import type { ReactImageGalleryItem } from 'react-image-gallery';
+import ImageGallery from 'react-image-gallery';
+import { BaseImage } from './BaseImage';
+// import { useTranslationContext } from '../../context'; // TODO backend-wire-up
+const useTranslationContext = () => ({ t: (s: string) => s }); // temporary shim
+
+import type { Attachment } from 'chat-shim';
+
+export type ModalGalleryProps = {
+  /** The images for the Carousel component */
+  images: Attachment[];
+  /** The index for the component */
+  index?: number;
+};
+
+const onError: React.ReactEventHandler<HTMLImageElement> = (e) => {
+  // Prevent having alt attribute on img as the img takes the height of the alt text
+  // instead of the CSS / element width & height when the CSS mask (fallback) is applied.
+  (e.target as HTMLImageElement).alt = '';
+};
+
+const renderItem = ({ original, originalAlt }: ReactImageGalleryItem) => (
+  <BaseImage
+    alt={originalAlt}
+    className='image-gallery-image'
+    onError={onError}
+    src={original}
+  />
+);
+
+export const ModalGallery = (props: ModalGalleryProps) => {
+  const { images, index } = props;
+  const { t } = useTranslationContext('ModalGallery');
+
+  const formattedArray = useMemo(
+    () =>
+      images.map((image) => {
+        const imageSrc = image.image_url || image.thumb_url || '';
+        return {
+          original: imageSrc,
+          originalAlt: t('User uploaded content'),
+          source: imageSrc,
+        };
+      }),
+    [images, t],
+  );
+
+  return (
+    // @ts-expect-error ignore the TS error as react-image-gallery was on @types/react@18 while stream-chat-react being upgraded to React 19 (https://github.com/xiaolin/react-image-gallery/issues/809)
+    <ImageGallery
+      items={formattedArray}
+      renderItem={renderItem}
+      showIndex={true}
+      showPlayButton={false}
+      showThumbnails={false}
+      startIndex={index}
+    />
+  );
+};


### PR DESCRIPTION
## Summary
- port `ModalGallery` from Stream Chat React
- add a basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `npx jest` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685de02b79848326abb9c9091eaf25de