### PR TITLE
Port InfiniteScroll component

### DIFF
--- a/libs/stream-chat-shim/__tests__/InfiniteScrollPaginator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/InfiniteScrollPaginator.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { InfiniteScroll } from '../src/components/InfiniteScrollPaginator/InfiniteScroll';
+
+test('renders without crashing', () => {
+  render(<InfiniteScroll />);
+});

--- a/libs/stream-chat-shim/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
+++ b/libs/stream-chat-shim/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
@@ -1,0 +1,186 @@
+import type { PropsWithChildren } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import type { PaginatorProps } from '../../types/types';
+import { deprecationAndReplacementWarning } from '../../utils/deprecationWarning';
+import { DEFAULT_LOAD_PAGE_SCROLL_THRESHOLD } from '../../constants/limits';
+
+/**
+ * Prevents Chrome hangups
+ * See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
+ */
+const mousewheelListener = (event: Event) => {
+  if (event instanceof WheelEvent && event.deltaY === 1) {
+    event.preventDefault();
+  }
+};
+
+export type InfiniteScrollProps = PaginatorProps & {
+  className?: string;
+  element?: React.ElementType;
+  /**
+   * @desc Flag signalling whether more pages with older items can be loaded
+   * @deprecated Use hasPreviousPage prop instead. Planned for removal: https://github.com/GetStream/stream-chat-react/issues/1804
+   */
+  hasMore?: boolean;
+  /**
+   * @desc Flag signalling whether more pages with newer items can be loaded
+   * @deprecated Use hasNextPage prop instead. Planned for removal: https://github.com/GetStream/stream-chat-react/issues/1804
+   */
+  hasMoreNewer?: boolean;
+  /** Element to be rendered at the top of the thread message list. By default, Message and ThreadStart components */
+  head?: React.ReactNode;
+  initialLoad?: boolean;
+  isLoading?: boolean;
+  listenToScroll?: (offset: number, reverseOffset: number, threshold: number) => void;
+  loader?: React.ReactNode;
+  /**
+   * @desc Function that loads previous page with older items
+   * @deprecated Use loadPreviousPage prop instead. Planned for removal: https://github.com/GetStream/stream-chat-react/issues/1804
+   */
+  loadMore?: () => void;
+  /**
+   * @desc Function that loads next page with newer items
+   * @deprecated Use loadNextPage prop instead. Planned for removal: https://github.com/GetStream/stream-chat-react/issues/1804
+   */
+  loadMoreNewer?: () => void;
+  useCapture?: boolean;
+};
+
+/**
+ * This component serves a single purpose - load more items on scroll inside the MessageList component
+ * It is not a general purpose infinite scroll controller, because:
+ * 1. It is re-rendered whenever queryInProgress, hasNext, hasPrev changes. This can lead to scrollListener to have stale data.
+ * 2. It pretends to invoke scrollListener on resize event even though this event is emitted only on window resize. It should
+ * rather use ResizeObserver. But then again, it ResizeObserver would invoke a stale version of scrollListener.
+ *
+ * In general, the infinite scroll controller should not aim for checking the loading state and whether there is more data to load.
+ * That should be controlled by the loading function.
+ */
+export const InfiniteScroll = (props: PropsWithChildren<InfiniteScrollProps>) => {
+  const {
+    children,
+    element: Component = 'div',
+    hasMore,
+    hasMoreNewer,
+    hasNextPage,
+    hasPreviousPage,
+    head,
+    initialLoad = true,
+    isLoading,
+    listenToScroll,
+    loader,
+    loadMore,
+    loadMoreNewer,
+    loadNextPage,
+    loadPreviousPage,
+    threshold = DEFAULT_LOAD_PAGE_SCROLL_THRESHOLD,
+    useCapture = false,
+    ...elementProps
+  } = props;
+
+  const loadNextPageFn = loadNextPage || loadMoreNewer;
+  const loadPreviousPageFn = loadPreviousPage || loadMore;
+  const hasNextPageFlag = hasNextPage || hasMoreNewer;
+  const hasPreviousPageFlag = hasPreviousPage || hasMore;
+
+  const [scrollComponent, setScrollComponent] = useState<HTMLElement | null>(null);
+  const previousOffset = useRef<number | undefined>(undefined);
+  const previousReverseOffset = useRef<number | undefined>(undefined);
+
+  const scrollListenerRef = useRef<() => void>(undefined);
+  scrollListenerRef.current = () => {
+    const element = scrollComponent;
+
+    if (!element || element.offsetParent === null) {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const parentElement = element.parentElement!;
+
+    const offset =
+      element.scrollHeight - parentElement.scrollTop - parentElement.clientHeight;
+    const reverseOffset = parentElement.scrollTop;
+
+    if (listenToScroll) {
+      listenToScroll(offset, reverseOffset, threshold);
+    }
+
+    if (isLoading) return;
+
+    if (
+      previousOffset.current === offset &&
+      previousReverseOffset.current === reverseOffset
+    )
+      return;
+    previousOffset.current = offset;
+    previousReverseOffset.current = reverseOffset;
+
+    // FIXME: this triggers loadMore call when a user types messages in thread and the scroll container expands
+    if (
+      reverseOffset < Number(threshold) &&
+      typeof loadPreviousPageFn === 'function' &&
+      hasPreviousPageFlag
+    ) {
+      loadPreviousPageFn();
+    }
+
+    if (
+      offset < Number(threshold) &&
+      typeof loadNextPageFn === 'function' &&
+      hasNextPageFlag
+    ) {
+      loadNextPageFn();
+    }
+  };
+
+  useEffect(() => {
+    deprecationAndReplacementWarning(
+      [
+        [{ hasMoreNewer }, { hasNextPage }],
+        [{ loadMoreNewer }, { loadNextPage }],
+        [{ hasMore }, { hasPreviousPage }],
+        [{ loadMore }, { loadPreviousPage }],
+      ],
+      'InfiniteScroll',
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const scrollElement = scrollComponent?.parentNode;
+
+    if (!scrollElement) return;
+
+    const scrollListener = () => scrollListenerRef.current?.();
+
+    scrollElement.addEventListener('scroll', scrollListener, useCapture);
+    scrollElement.addEventListener('resize', scrollListener, useCapture);
+    scrollListener();
+
+    return () => {
+      scrollElement.removeEventListener('scroll', scrollListener, useCapture);
+      scrollElement.removeEventListener('resize', scrollListener, useCapture);
+    };
+  }, [initialLoad, scrollComponent, useCapture]);
+
+  useEffect(() => {
+    const scrollElement = scrollComponent?.parentNode;
+
+    if (!scrollElement) return;
+
+    scrollElement.addEventListener('wheel', mousewheelListener, { passive: false });
+
+    return () => {
+      scrollElement.removeEventListener('wheel', mousewheelListener, useCapture);
+    };
+  }, [scrollComponent, useCapture]);
+
+  return (
+    <Component {...elementProps} ref={setScrollComponent}>
+      {head}
+      {loader}
+      {children}
+    </Component>
+  );
+};

--- a/libs/stream-chat-shim/src/components/InfiniteScrollPaginator/hooks/useCursorPaginator.ts
+++ b/libs/stream-chat-shim/src/components/InfiniteScrollPaginator/hooks/useCursorPaginator.ts
@@ -1,0 +1,64 @@
+import uniqBy from 'lodash.uniqby';
+import { useCallback, useEffect, useMemo } from 'react';
+import { StateStore } from 'stream-chat';
+
+export type CursorPaginatorState<T> = {
+  hasNextPage: boolean;
+  items: T[];
+  latestPageItems: T[];
+  loading: boolean;
+  error?: Error;
+  next?: string | null;
+};
+
+export type CursorPaginatorStateStore<T> = StateStore<CursorPaginatorState<T>>;
+
+export type PaginationFn<T> = (next?: string) => Promise<{ items: T[]; next?: string }>;
+
+export const useCursorPaginator = <T>(
+  paginationFn: PaginationFn<T>,
+  loadFirstPage?: boolean,
+) => {
+  const cursorPaginatorState = useMemo(
+    () =>
+      new StateStore<CursorPaginatorState<T>>({
+        hasNextPage: true,
+        items: [],
+        latestPageItems: [],
+        loading: false,
+      }),
+    [],
+  );
+
+  const loadMore = useCallback(async () => {
+    const { loading, next: currentNext } = cursorPaginatorState.getLatestValue();
+    if (currentNext === null || loading) return;
+
+    cursorPaginatorState.partialNext({ loading: true });
+
+    try {
+      const { items, next } = await paginationFn(currentNext);
+      cursorPaginatorState.next((prev) => ({
+        ...prev,
+        hasNextPage: !!next,
+        items: uniqBy(prev.items.concat(items), 'id'),
+        latestPageItems: items,
+        next: next || null,
+      }));
+    } catch (error) {
+      cursorPaginatorState.partialNext({ error: error as Error });
+    }
+    cursorPaginatorState.partialNext({ loading: false });
+  }, [cursorPaginatorState, paginationFn]);
+
+  useEffect(() => {
+    const { items } = cursorPaginatorState.getLatestValue();
+    if (!loadFirstPage || items.length) return;
+    loadMore();
+  }, [cursorPaginatorState, loadFirstPage, loadMore]);
+
+  return {
+    cursorPaginatorState,
+    loadMore,
+  };
+};

--- a/libs/stream-chat-shim/src/components/InfiniteScrollPaginator/index.ts
+++ b/libs/stream-chat-shim/src/components/InfiniteScrollPaginator/index.ts
@@ -1,0 +1,1 @@
+export * from './InfiniteScroll';


### PR DESCRIPTION
## Summary
- port the `InfiniteScroll` component from stream-ui and its cursor paginator hook
- provide an index to re-export InfiniteScroll
- add a basic render test

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails: TS errors in frontend)*

------
https://chatgpt.com/codex/tasks/task_e_685de04c406083269d6c9fd781d025d8