### PR TITLE
Add LoadMorePaginator component shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/LoadMorePaginator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/LoadMorePaginator.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LoadMorePaginator } from '../src/components/LoadMore/LoadMorePaginator';
+
+test('renders without crashing', () => {
+  render(<LoadMorePaginator />);
+});

--- a/libs/stream-chat-shim/src/components/LoadMore/LoadMorePaginator.tsx
+++ b/libs/stream-chat-shim/src/components/LoadMore/LoadMorePaginator.tsx
@@ -1,0 +1,53 @@
+import type { PropsWithChildren } from 'react';
+import React, { useEffect } from 'react';
+
+// import type { LoadMoreButtonProps } from './LoadMoreButton'; // TODO backend-wire-up
+type LoadMoreButtonProps = any; // temporary shim
+// import { LoadMoreButton as DefaultLoadMoreButton } from './LoadMoreButton'; // TODO backend-wire-up
+const DefaultLoadMoreButton = (() => null) as unknown as React.ComponentType<LoadMoreButtonProps>;
+// import type { PaginatorProps } from '../../types/types'; // TODO backend-wire-up
+type PaginatorProps = any; // temporary shim
+// import { deprecationAndReplacementWarning } from '../../utils/deprecationWarning'; // TODO backend-wire-up
+const deprecationAndReplacementWarning = () => {};
+
+export type LoadMorePaginatorProps = PaginatorProps & {
+  /** A UI button component that handles pagination logic */
+  LoadMoreButton?: React.ComponentType<LoadMoreButtonProps>;
+  /** indicates if the `LoadMoreButton` should be displayed at the top of the list of channels instead of the bottom of the list (the default) */
+  reverse?: boolean;
+};
+
+export const UnMemoizedLoadMorePaginator = (
+  props: PropsWithChildren<LoadMorePaginatorProps>,
+) => {
+  const {
+    children,
+    hasNextPage,
+    isLoading,
+    LoadMoreButton = DefaultLoadMoreButton,
+    loadNextPage,
+    refreshing,
+    reverse,
+  } = props;
+  const loadingState = typeof isLoading !== 'undefined' ? isLoading : refreshing;
+
+  useEffect(() => {
+    deprecationAndReplacementWarning(
+      [[{ refreshing }, { isLoading }]],
+      'LoadMorePaginator',
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      {!reverse && children}
+      {hasNextPage && <LoadMoreButton isLoading={loadingState} onClick={loadNextPage} />}
+      {reverse && children}
+    </>
+  );
+};
+
+export const LoadMorePaginator = React.memo(
+  UnMemoizedLoadMorePaginator,
+) as typeof UnMemoizedLoadMorePaginator;

--- a/libs/stream-chat-shim/src/components/LoadMore/index.ts
+++ b/libs/stream-chat-shim/src/components/LoadMore/index.ts
@@ -1,0 +1,1 @@
+export * from './LoadMorePaginator';


### PR DESCRIPTION
## Summary
- port LoadMorePaginator from stream-chat-react
- stub missing dependencies for backend wiring
- expose component via index file
- add basic render test

## Testing
- `pnpm -r build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de08c51dc83268191e79432a58139