### PR TITLE
Add LoadingChannels component from upstream

### DIFF
--- a/libs/stream-chat-shim/__tests__/LoadingChannels.test.tsx
+++ b/libs/stream-chat-shim/__tests__/LoadingChannels.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LoadingChannels } from '../src/components/Loading/LoadingChannels';
+
+test('renders without crashing', () => {
+  render(<LoadingChannels />);
+});

--- a/libs/stream-chat-shim/src/components/Loading/LoadingChannels.tsx
+++ b/libs/stream-chat-shim/src/components/Loading/LoadingChannels.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const LoadingItems = () => (
+  <div className='str-chat__loading-channels-item str-chat__channel-preview-loading'>
+    <div className='str-chat__loading-channels-avatar' />
+    <div className='str-chat__loading-channels-meta str-chat__channel-preview-end-loading'>
+      <div className='str-chat__loading-channels-username' />
+      <div className='str-chat__loading-channels-status' />
+    </div>
+  </div>
+);
+
+const UnMemoizedLoadingChannels = () => (
+  <div className='str-chat__loading-channels'>
+    <LoadingItems />
+    <LoadingItems />
+    <LoadingItems />
+  </div>
+);
+
+/**
+ * Loading indicator for the ChannelList
+ */
+export const LoadingChannels = React.memo(UnMemoizedLoadingChannels);

--- a/libs/stream-chat-shim/src/components/Loading/index.ts
+++ b/libs/stream-chat-shim/src/components/Loading/index.ts
@@ -1,0 +1,3 @@
+export * from './LoadingChannels';
+export * from './LoadingErrorIndicator';
+export * from './LoadingIndicator';


### PR DESCRIPTION
## Summary
- port `LoadingChannels` component
- export from `components/Loading`
- add basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685de098436c8326a598e0cc1970dc87