### PR TITLE
Port LoadingErrorIndicator component

### DIFF
--- a/libs/stream-chat-shim/__tests__/LoadingErrorIndicator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/LoadingErrorIndicator.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LoadingErrorIndicator } from '../src/components/Loading/LoadingErrorIndicator';
+
+test('renders without crashing', () => {
+  render(<LoadingErrorIndicator />);
+});

--- a/libs/stream-chat-shim/src/components/Loading/LoadingErrorIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Loading/LoadingErrorIndicator.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export type LoadingErrorIndicatorProps = {
+  /** Error object */
+  error?: Error;
+};
+
+/**
+ * UI component for error indicator in a Channel
+ */
+const UnMemoizedLoadingErrorIndicator = ({ error }: LoadingErrorIndicatorProps) => {
+  const { t } = useTranslationContext('LoadingErrorIndicator');
+
+  if (!error) return null;
+
+  return <div>{t('Error: {{ errorMessage }}', { errorMessage: error.message })}</div>;
+};
+
+export const LoadingErrorIndicator = React.memo(
+  UnMemoizedLoadingErrorIndicator,
+  (prevProps, nextProps) => prevProps.error?.message === nextProps.error?.message,
+) as typeof UnMemoizedLoadingErrorIndicator;

--- a/libs/stream-chat-shim/src/components/Loading/index.ts
+++ b/libs/stream-chat-shim/src/components/Loading/index.ts
@@ -1,0 +1,3 @@
+export * from './LoadingChannels';
+export * from './LoadingErrorIndicator';
+export * from './LoadingIndicator';


### PR DESCRIPTION
## Summary
- copy LoadingErrorIndicator from Stream Chat React to stream-chat-shim
- export it via a new Loading index file
- add a simple render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_685de0c5ccf483268f5261440ca0d4c4