### PR TITLE
Port MML component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MML.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MML.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MML } from '../src/components/MML/MML';
+
+test('renders without crashing', () => {
+  render(<MML source="" />);
+});

--- a/libs/stream-chat-shim/src/components/MML/MML.tsx
+++ b/libs/stream-chat-shim/src/components/MML/MML.tsx
@@ -1,0 +1,41 @@
+import React, { Suspense } from 'react';
+
+import { useChatContext } from '../../context/ChatContext';
+
+import type { ActionHandlerReturnType } from '../Message/hooks/useActionHandler';
+
+const MMLReact = React.lazy(async () => {
+  const mml = await import('mml-react');
+  return { default: mml.MML };
+});
+
+export type MMLProps = {
+  /** MML source string */
+  source: string;
+  /** Submit handler for mml actions */
+  actionHandler?: ActionHandlerReturnType;
+  /** Align MML components to left/right, defaults to right */
+  align?: 'left' | 'right';
+};
+
+/**
+ * A wrapper component around MML-React library
+ */
+export const MML: React.FC<MMLProps> = (props) => {
+  const { actionHandler, align = 'right', source } = props;
+
+  const { theme } = useChatContext('MML');
+
+  return (
+    <Suspense fallback={null}>
+      <MMLReact
+        className={`mml-align-${align}`}
+        Loading={null}
+        onSubmit={actionHandler}
+        source={source}
+        Success={null}
+        theme={(theme || '').replace(' ', '-')}
+      />
+    </Suspense>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MML/index.ts
+++ b/libs/stream-chat-shim/src/components/MML/index.ts
@@ -1,0 +1,1 @@
+export * from './MML';


### PR DESCRIPTION
## Summary
- port `MML` from stream-ui to stream-chat-shim
- add barrel file for `MML`
- add minimal render test for `MML`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685de0f520848326ac057bf08caf6b40