### PR TITLE
Add AudioRecordingButtons component

### DIFF
--- a/libs/stream-chat-shim/__tests__/AudioRecordingButtons.test.tsx
+++ b/libs/stream-chat-shim/__tests__/AudioRecordingButtons.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { StartRecordingAudioButton } from '../src/components/MediaRecorder/AudioRecorder/AudioRecordingButtons';
+
+test('renders without crashing', () => {
+  render(<StartRecordingAudioButton />);
+});

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/AudioRecordingButtons.tsx
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/AudioRecordingButtons.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { MicIcon } from '../../MessageInput/icons';
+
+export type StartRecordingAudioButtonProps = React.ComponentProps<'button'>;
+
+export const StartRecordingAudioButton = (props: StartRecordingAudioButtonProps) => (
+  <button
+    aria-label='Start recording audio'
+    className='str-chat__start-recording-audio-button'
+    data-testid='start-recording-audio-button'
+    {...props}
+  >
+    <MicIcon />
+  </button>
+);

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/index.ts
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/index.ts
@@ -1,0 +1,3 @@
+export * from './AudioRecorder';
+export * from './AudioRecordingButtons';
+export * from './RecordingTimer';


### PR DESCRIPTION
## Summary
- port `AudioRecordingButtons` from stream-chat-react
- expose it via `index.ts`
- add a smoke test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685de1117cbc8326afc2ce00a873b859