### PR TITLE
Add AudioRecordingInProgress shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/AudioRecordingInProgress.test.tsx
+++ b/libs/stream-chat-shim/__tests__/AudioRecordingInProgress.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AudioRecordingInProgress } from '../src/components/MediaRecorder/AudioRecorder/AudioRecordingInProgress';
+
+test('renders without crashing', () => {
+  render(<AudioRecordingInProgress />);
+});

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/AudioRecordingInProgress.tsx
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/AudioRecordingInProgress.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { useTimeElapsed } from './hooks/useTimeElapsed';
+import { useMessageInputContext } from '../../../context';
+import { RecordingTimer } from './RecordingTimer';
+
+type WaveformProps = {
+  maxDataPointsDrawn?: number;
+};
+
+const AudioRecordingWaveform = ({ maxDataPointsDrawn = 100 }: WaveformProps) => {
+  const {
+    recordingController: { recorder },
+  } = useMessageInputContext();
+
+  const [amplitudes, setAmplitudes] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!recorder?.amplitudeRecorder) return;
+    const amplitudesSubscription =
+      recorder.amplitudeRecorder.amplitudes.subscribe(setAmplitudes);
+    return () => {
+      amplitudesSubscription.unsubscribe();
+    };
+  }, [recorder]);
+
+  if (!recorder) return null;
+
+  return (
+    <div className='str-chat__waveform-box-container'>
+      <div className='str-chat__audio_recorder__waveform-box'>
+        {amplitudes.slice(-maxDataPointsDrawn).map((amplitude, i) => (
+          <div
+            className='str-chat__wave-progress-bar__amplitude-bar'
+            key={`amplitude-${i}-voice-recording`}
+            style={
+              {
+                '--str-chat__wave-progress-bar__amplitude-bar-height': amplitude
+                  ? amplitude * 100 + '%'
+                  : '0%',
+              } as React.CSSProperties
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+export const AudioRecordingInProgress = () => {
+  const { secondsElapsed, startCounter, stopCounter } = useTimeElapsed();
+  const {
+    recordingController: { recorder },
+  } = useMessageInputContext();
+
+  useEffect(() => {
+    if (!recorder?.mediaRecorder) return;
+    const { mediaRecorder } = recorder;
+
+    if (mediaRecorder.state === 'recording') {
+      startCounter();
+    }
+
+    mediaRecorder.addEventListener('start', startCounter);
+    mediaRecorder.addEventListener('resume', startCounter);
+    mediaRecorder.addEventListener('stop', stopCounter);
+    mediaRecorder.addEventListener('pause', stopCounter);
+
+    return () => {
+      mediaRecorder.removeEventListener('start', startCounter);
+      mediaRecorder.removeEventListener('resume', startCounter);
+      mediaRecorder.removeEventListener('stop', stopCounter);
+      mediaRecorder.removeEventListener('pause', stopCounter);
+    };
+  }, [recorder, startCounter, stopCounter]);
+
+  return (
+    <React.Fragment>
+      <RecordingTimer durationSeconds={secondsElapsed} />
+      <AudioRecordingWaveform />
+    </React.Fragment>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/RecordingTimer.tsx
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/RecordingTimer.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx';
+import { displayDuration } from '../../Attachment';
+import React from 'react';
+
+export type RecordingTimerProps = {
+  durationSeconds: number;
+};
+
+export const RecordingTimer = ({ durationSeconds }: RecordingTimerProps) => (
+  <div
+    className={clsx('str-chat__recording-timer', {
+      'str-chat__recording-timer--hours': durationSeconds >= 3600,
+    })}
+  >
+    {displayDuration(durationSeconds)}
+  </div>
+);

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/hooks/useTimeElapsed.ts
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/hooks/useTimeElapsed.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type UseTimeElapsedParams = {
+  startOnMount?: boolean;
+};
+
+// todo: provide start timestamp
+export const useTimeElapsed = ({ startOnMount }: UseTimeElapsedParams = {}) => {
+  const [secondsElapsed, setSecondsElapsed] = useState<number>(0);
+  const updateInterval = useRef<ReturnType<typeof setInterval>>(undefined);
+
+  const startCounter = useCallback(() => {
+    if (updateInterval.current) return;
+    updateInterval.current = setInterval(() => {
+      setSecondsElapsed((prev) => prev + 1);
+    }, 1000);
+  }, []);
+
+  const stopCounter = useCallback(() => {
+    clearInterval(updateInterval.current);
+    updateInterval.current = undefined;
+  }, []);
+
+  useEffect(() => {
+    if (!startOnMount) return;
+    startCounter();
+    return () => {
+      stopCounter();
+    };
+  }, [startCounter, startOnMount, stopCounter]);
+
+  return {
+    secondsElapsed,
+    startCounter,
+    stopCounter,
+  };
+};

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/index.ts
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/index.ts
@@ -1,0 +1,3 @@
+export * from './AudioRecorder';
+export * from './AudioRecordingButtons';
+export * from './RecordingTimer';


### PR DESCRIPTION
## Summary
- port `AudioRecordingInProgress` component from stream-chat-react
- include supporting `RecordingTimer` and `useTimeElapsed`
- expose exports via index file
- add basic render test

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685de11dee1c8326bf3d70fe7bab3031