### PR TITLE
feat(chat-shim): add AudioRecordingPreview component

### DIFF
--- a/libs/stream-chat-shim/__tests__/AudioRecordingPreview.test.tsx
+++ b/libs/stream-chat-shim/__tests__/AudioRecordingPreview.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AudioRecordingPreview } from '../src/components/MediaRecorder/AudioRecorder/AudioRecordingPreview';
+
+test('renders without crashing', () => {
+  render(<AudioRecordingPreview durationSeconds={0} />);
+});

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/AudioRecordingPreview.tsx
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/AudioRecordingPreview.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+// import { PauseIcon, PlayIcon } from '../../MessageInput/icons'; // TODO backend-wire-up
+const PauseIcon = () => null as any;
+const PlayIcon = () => null as any;
+import { RecordingTimer } from './RecordingTimer';
+// import { useAudioController } from '../../Attachment/hooks/useAudioController'; // TODO backend-wire-up
+const useAudioController = () => ({
+  audioRef: { current: null } as React.MutableRefObject<HTMLAudioElement | null>,
+  isPlaying: false,
+  progress: 0,
+  secondsElapsed: 0,
+  seek: () => {},
+  togglePlay: () => {},
+});
+// import { WaveProgressBar } from '../../Attachment'; // TODO backend-wire-up
+const WaveProgressBar = () => null as any;
+
+export type AudioRecordingPlayerProps = React.ComponentProps<'audio'> & {
+  durationSeconds: number;
+  mimeType?: string;
+  waveformData?: number[];
+};
+
+export const AudioRecordingPreview = ({
+  durationSeconds,
+  mimeType,
+  waveformData,
+  ...props
+}: AudioRecordingPlayerProps) => {
+  const { audioRef, isPlaying, progress, secondsElapsed, seek, togglePlay } =
+    useAudioController({
+      durationSeconds,
+      mimeType,
+    });
+
+  const displayedDuration = secondsElapsed || durationSeconds;
+
+  return (
+    <React.Fragment>
+      <audio ref={audioRef}>
+        <source src={props.src} type={mimeType} />
+      </audio>
+      <button
+        className='str-chat__audio_recorder__toggle-playback-button'
+        data-testid='audio-recording-preview-toggle-play-btn'
+        onClick={togglePlay}
+      >
+        {isPlaying ? <PauseIcon /> : <PlayIcon />}
+      </button>
+      <RecordingTimer durationSeconds={displayedDuration} />
+      <div className='str-chat__wave-progress-bar__track-container'>
+        <WaveProgressBar
+          progress={progress}
+          seek={seek}
+          waveformData={waveformData || []}
+        />
+      </div>
+    </React.Fragment>
+  );
+};


### PR DESCRIPTION
## Summary
- port AudioRecordingPreview component from stream-ui
- add temporary shims for missing dependencies
- include a basic render test

## Testing
- `pnpm -r --if-present build` *(fails: stream-chat-react build script missing dependencies)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: several TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685de12bc4b083269c9fc3343b7a1a15