### PR TITLE
Port RecordingTimer from stream-ui

### DIFF
--- a/libs/stream-chat-shim/__tests__/RecordingTimer.test.tsx
+++ b/libs/stream-chat-shim/__tests__/RecordingTimer.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RecordingTimer } from '../src/components/MediaRecorder/AudioRecorder/RecordingTimer';
+
+describe('RecordingTimer component', () => {
+  test('renders duration', () => {
+    const html = renderToStaticMarkup(<RecordingTimer durationSeconds={10} />);
+    expect(html).toContain('10');
+  });
+});

--- a/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/RecordingTimer.tsx
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/AudioRecorder/RecordingTimer.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx';
+import { displayDuration } from '../../Attachment';
+import React from 'react';
+
+export type RecordingTimerProps = {
+  durationSeconds: number;
+};
+
+export const RecordingTimer = ({ durationSeconds }: RecordingTimerProps) => (
+  <div
+    className={clsx('str-chat__recording-timer', {
+      'str-chat__recording-timer--hours': durationSeconds >= 3600,
+    })}
+  >
+    {displayDuration(durationSeconds)}
+  </div>
+);


### PR DESCRIPTION
## Summary
- copy RecordingTimer component from stream-chat-react
- add simple test to render RecordingTimer

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de14090ec83269fc55c015708e98f