### PR TITLE
Add RecordingPermissionDeniedNotification

### DIFF
--- a/libs/stream-chat-shim/__tests__/RecordingPermissionDeniedNotification.test.tsx
+++ b/libs/stream-chat-shim/__tests__/RecordingPermissionDeniedNotification.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RecordingPermissionDeniedNotification } from '../src/components/MediaRecorder/RecordingPermissionDeniedNotification';
+
+describe('RecordingPermissionDeniedNotification component', () => {
+  it('renders translation text', () => {
+    const html = renderToStaticMarkup(
+      <RecordingPermissionDeniedNotification permissionName="camera" onClose={() => {}} />
+    );
+    expect(html).toContain('str-chat__recording-permission-denied-notification');
+  });
+});

--- a/libs/stream-chat-shim/src/components/MediaRecorder/RecordingPermissionDeniedNotification.tsx
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/RecordingPermissionDeniedNotification.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useTranslationContext } from '../../context';
+
+import type { RecordingPermission } from './classes/BrowserPermission';
+
+export type RecordingPermissionDeniedNotificationProps = {
+  onClose: () => void;
+  permissionName: RecordingPermission;
+};
+
+export const RecordingPermissionDeniedNotification = ({
+  onClose,
+  permissionName,
+}: RecordingPermissionDeniedNotificationProps) => {
+  const { t } = useTranslationContext();
+  const permissionTranslations = {
+    body: {
+      camera: t('To start recording, allow the camera access in your browser'),
+      microphone: t('To start recording, allow the microphone access in your browser'),
+    },
+    heading: {
+      camera: t('Allow access to camera'),
+      microphone: t('Allow access to microphone'),
+    },
+  };
+
+  return (
+    <div className='str-chat__recording-permission-denied-notification'>
+      <div className='str-chat__recording-permission-denied-notification__heading'>
+        {permissionTranslations.heading[permissionName]}
+      </div>
+      <p className='str-chat__recording-permission-denied-notification__message'>
+        {permissionTranslations.body[permissionName]}
+      </p>
+      <div className='str-chat__recording-permission-denied-notification__dismiss-button-container'>
+        <button
+          className='str-chat__recording-permission-denied-notification__dismiss-button'
+          onClick={onClose}
+        >
+          {t('Ok')}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MediaRecorder/index.ts
+++ b/libs/stream-chat-shim/src/components/MediaRecorder/index.ts
@@ -1,0 +1,6 @@
+export * from './RecordingPermissionDeniedNotification';
+export * from './AudioRecorder';
+export * from './hooks';
+export { MediaRecordingState } from './classes/MediaRecorderController';
+export { RecordingPermission } from './classes/BrowserPermission';
+export type { CustomAudioRecordingConfig } from './classes';


### PR DESCRIPTION
## Summary
- port `RecordingPermissionDeniedNotification` component
- export it in MediaRecorder index
- add test for the new component

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*
- `npx jest --runTestsByPath libs/stream-chat-shim/__tests__/RecordingPermissionDeniedNotification.test.tsx` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685de154c64c8326b999c1e2a00f1f85