### PR TITLE
Add MessageBlocked component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageBlocked.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageBlocked.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageBlocked } from '../src/components/Message/MessageBlocked';
+
+test('renders without crashing', () => {
+  render(<MessageBlocked />);
+});

--- a/libs/stream-chat-shim/src/components/Message/MessageBlocked.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageBlocked.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import clsx from 'clsx';
+
+// import { useUserRole } from './hooks/useUserRole'; // TODO backend-wire-up
+const useUserRole = (_message: any) => ({ isMyMessage: false } as any);
+// import { useTranslationContext } from '../../context/TranslationContext'; // TODO backend-wire-up
+const useTranslationContext = (_?: string) => ({ t: (key: string) => key } as any);
+// import { useMessageContext } from '../../context'; // TODO backend-wire-up
+const useMessageContext = () => ({ message: { id: '', type: '' } } as any);
+
+export const MessageBlocked = () => {
+  const { message } = useMessageContext();
+  const { t } = useTranslationContext('MessageBlocked');
+
+  const { isMyMessage } = useUserRole(message);
+
+  const messageClasses = clsx(
+    'str-chat__message str-chat__message-simple str-chat__message--blocked',
+    message.type,
+    {
+      'str-chat__message--me str-chat__message-simple--me': isMyMessage,
+      'str-chat__message--other': !isMyMessage,
+    },
+  );
+
+  return (
+    <div
+      className={messageClasses}
+      data-testid='message-blocked-component'
+      key={message.id}
+    >
+      <div className='str-chat__message--blocked-inner'>
+        {t('Message was blocked by moderation policies')}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `MessageBlocked` component
- add a basic test for `MessageBlocked`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685de17a3bdc832695830c17fa2864c7