### PR TITLE
Port MessageDeleted component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageDeletedComponent.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageDeletedComponent.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageDeleted } from '../src/components/Message/MessageDeleted';
+
+test('renders without crashing', () => {
+  render(<MessageDeleted message={{ id: '1', type: 'deleted' } as any} />);
+});

--- a/libs/stream-chat-shim/src/components/Message/MessageDeleted.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageDeleted.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { useUserRole } from './hooks/useUserRole';
+import { useTranslationContext } from '../../context/TranslationContext';
+
+/* TODO backend-wire-up: LocalMessage import excised */
+// import type { LocalMessage } from 'stream-chat';
+
+export type MessageDeletedProps = {
+  message: LocalMessage;
+};
+
+export const MessageDeleted = (props: MessageDeletedProps) => {
+  const { message } = props;
+
+  const { t } = useTranslationContext('MessageDeleted');
+
+  const { isMyMessage } = useUserRole(message);
+
+  const messageClasses = isMyMessage
+    ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
+    : 'str-chat__message str-chat__message-simple str-chat__message--other';
+
+  return (
+    <div
+      className={`${messageClasses} str-chat__message--deleted ${message.type} `}
+      data-testid={'message-deleted-component'}
+      key={message.id}
+    >
+      <div className='str-chat__message--deleted-inner'>
+        {t('This message was deleted...')}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `MessageDeleted` component from stream-chat-react
- add a basic render test for `MessageDeleted`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685de186655c8326bd78e47c61a990c2