### PR TITLE
Add MessageEditedTimestamp component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageEditedTimestamp.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageEditedTimestamp.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageEditedTimestamp } from '../src/components/Message/MessageEditedTimestamp';
+
+test('renders without crashing', () => {
+  render(
+    <MessageEditedTimestamp
+      open={true}
+      message={{ message_text_updated_at: new Date() } as any}
+    />
+  );
+});

--- a/libs/stream-chat-shim/src/components/Message/MessageEditedTimestamp.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageEditedTimestamp.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import clsx from 'clsx';
+import {
+  useComponentContext,
+  useMessageContext,
+  useTranslationContext,
+} from '../../context';
+import { Timestamp as DefaultTimestamp } from './Timestamp';
+import { isMessageEdited } from './utils';
+
+import type { MessageTimestampProps } from './MessageTimestamp';
+
+export type MessageEditedTimestampProps = MessageTimestampProps & {
+  open: boolean;
+};
+
+export function MessageEditedTimestamp({
+  message: propMessage,
+  open,
+  ...timestampProps
+}: MessageEditedTimestampProps) {
+  const { t } = useTranslationContext('MessageEditedTimestamp');
+  const { message: contextMessage } = useMessageContext('MessageEditedTimestamp');
+  const { Timestamp = DefaultTimestamp } = useComponentContext('MessageEditedTimestamp');
+  const message = propMessage || contextMessage;
+
+  if (!isMessageEdited(message)) {
+    return null;
+  }
+
+  return (
+    <div
+      className={clsx(
+        'str-chat__message-edited-timestamp',
+        open
+          ? 'str-chat__message-edited-timestamp--open'
+          : 'str-chat__message-edited-timestamp--collapsed',
+      )}
+      data-testid='message-edited-timestamp'
+    >
+      {t('Edited')}{' '}
+      <Timestamp timestamp={message.message_text_updated_at} {...timestampProps} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- port `MessageEditedTimestamp` component from Stream
- add a basic render test

## Testing
- `pnpm -r run build` *(fails: module not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo json parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685de190415c8326ae43162e9a3cb1a9