### PR TITLE
Port MessageThreadReplyInChannelButtonIndicator

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageThreadReplyInChannelButtonIndicator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageThreadReplyInChannelButtonIndicator.test.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { MessageThreadReplyInChannelButtonIndicator } from '../src/MessageThreadReplyInChannelButtonIndicator';
+import { MessageThreadReplyInChannelButtonIndicator } from '../src/components/Message/MessageThreadReplyInChannelButtonIndicator';
 
 describe('MessageThreadReplyInChannelButtonIndicator', () => {
-  it('renders placeholder', () => {
-    const { getByTestId } = render(<MessageThreadReplyInChannelButtonIndicator />);
-    expect(
-      getByTestId('message-thread-reply-in-channel-button-indicator-placeholder')
-    ).toBeTruthy();
+  test('renders without crashing', () => {
+    render(<MessageThreadReplyInChannelButtonIndicator />);
   });
 });

--- a/libs/stream-chat-shim/src/components/Message/MessageThreadReplyInChannelButtonIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageThreadReplyInChannelButtonIndicator.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef } from 'react';
+// import type { LocalMessage } from 'stream-chat'; // TODO backend-wire-up
+// import { formatMessage } from 'stream-chat'; // TODO backend-wire-up
+const formatMessage = (m: any) => m as any;
+type LocalMessage = any;
+import {
+  useChannelActionContext,
+  useChannelStateContext,
+  useChatContext,
+  useMessageContext,
+  useTranslationContext,
+} from '../../context';
+
+export const MessageThreadReplyInChannelButtonIndicator = () => {
+  const { client } = useChatContext();
+  const { t } = useTranslationContext();
+  const { channel } = useChannelStateContext();
+  const { openThread } = useChannelActionContext();
+  const { message } = useMessageContext();
+  const parentMessageRef = useRef<LocalMessage | null | undefined>(undefined);
+
+  const querySearchParent = () =>
+    /* TODO backend-wire-up: search */
+    Promise.resolve<{ results: any[] }>({ results: [] })
+      .then(({ results }) => {
+        if (!results.length) {
+          throw new Error('Thread has not been found');
+        }
+        parentMessageRef.current = formatMessage((results[0] as any).message);
+      })
+      .catch((error: Error) => {
+        client.notifications.addError({
+          message: t('Thread has not been found'),
+          options: {
+            originalError: error,
+            type: 'api:message:search:not-found',
+          },
+          origin: {
+            context: { threadReply: message },
+            emitter: 'MessageThreadReplyInChannelButtonIndicator',
+          },
+        });
+      });
+
+  useEffect(() => {
+    if (
+      parentMessageRef.current ||
+      parentMessageRef.current === null ||
+      !message.parent_id
+    )
+      return;
+    const localMessage = channel.state.findMessage(message.parent_id);
+    if (localMessage) {
+      parentMessageRef.current = localMessage;
+      return;
+    }
+  }, [channel, message]);
+
+  if (!message.parent_id) return null;
+
+  return (
+    <div className='str-chat__message-is-thread-reply-button-wrapper'>
+      <button
+        className='str-chat__message-is-thread-reply-button'
+        data-testid='message-is-thread-reply-button'
+        onClick={async () => {
+          if (!parentMessageRef.current) {
+            // search query is performed here in order to prevent multiple search queries in useEffect
+            // due to the message list 3x remounting its items
+            await querySearchParent();
+            if (parentMessageRef.current) {
+              openThread(parentMessageRef.current);
+            } else {
+              // prevent further search queries if the message is not found in the DB
+              parentMessageRef.current = null;
+            }
+            return;
+          }
+          openThread(parentMessageRef.current);
+        }}
+        type='button'
+      >
+        {t('Thread reply')}
+      </button>
+    </div>
+  );
+};
+
+export default MessageThreadReplyInChannelButtonIndicator;


### PR DESCRIPTION
## Summary
- port `MessageThreadReplyInChannelButtonIndicator` from upstream `stream-chat-react`
- update the existing test to ensure the component renders

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685de206679483268682b0a7df7f7bdd