### PR TITLE
Port MessageTimestamp component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageTimestamp.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageTimestamp.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageTimestamp } from '../src/components/Message/MessageTimestamp';
+
+test('renders without crashing', () => {
+  render(<MessageTimestamp />);
+});

--- a/libs/stream-chat-shim/src/components/Message/MessageTimestamp.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageTimestamp.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useMessageContext } from '../../context/MessageContext';
+import { Timestamp as DefaultTimestamp } from './Timestamp';
+import { useComponentContext } from '../../context';
+
+/* TODO backend-wire-up: LocalMessage import excised */
+type LocalMessage = any;
+import type { TimestampFormatterOptions } from '../../i18n/types';
+
+export type MessageTimestampProps = TimestampFormatterOptions & {
+  /* Adds a CSS class name to the component's outer `time` container. */
+  customClass?: string;
+  /* The `StreamChat` message object, which provides necessary data to the underlying UI components (overrides the value from `MessageContext`) */
+  message?: LocalMessage;
+};
+
+const UnMemoizedMessageTimestamp = (props: MessageTimestampProps) => {
+  const { message: propMessage, ...timestampProps } = props;
+  const { message: contextMessage } = useMessageContext('MessageTimestamp');
+  const { Timestamp = DefaultTimestamp } = useComponentContext('MessageTimestamp');
+  const message = propMessage || contextMessage;
+  return <Timestamp timestamp={message.created_at} {...timestampProps} />;
+};
+
+export const MessageTimestamp = React.memo(
+  UnMemoizedMessageTimestamp,
+) as typeof UnMemoizedMessageTimestamp;

--- a/libs/stream-chat-shim/src/components/Message/Timestamp.tsx
+++ b/libs/stream-chat-shim/src/components/Message/Timestamp.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+
+import { useMessageContext } from '../../context/MessageContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+import { getDateString, isDate } from '../../i18n/utils';
+import type { TimestampFormatterOptions } from '../../i18n/types';
+
+export interface TimestampProps extends TimestampFormatterOptions {
+  /* Adds a CSS class name to the component's outer `time` container. */
+  customClass?: string;
+  /* Timestamp to display */
+  timestamp?: Date | string;
+}
+
+export function Timestamp(props: TimestampProps) {
+  const { calendar, calendarFormats, customClass, format, timestamp } = props;
+
+  const { formatDate } = useMessageContext('MessageTimestamp');
+  const { t, tDateTimeParser } = useTranslationContext('MessageTimestamp');
+
+  const normalizedTimestamp =
+    timestamp && isDate(timestamp) ? timestamp.toISOString() : timestamp;
+
+  const when = useMemo(
+    () =>
+      getDateString({
+        calendar,
+        calendarFormats,
+        format,
+        formatDate,
+        messageCreatedAt: normalizedTimestamp,
+        t,
+        tDateTimeParser,
+        timestampTranslationKey: 'timestamp/MessageTimestamp',
+      }),
+    [
+      calendar,
+      calendarFormats,
+      format,
+      formatDate,
+      normalizedTimestamp,
+      t,
+      tDateTimeParser,
+    ],
+  );
+
+  if (!when) {
+    return null;
+  }
+
+  return (
+    <time
+      className={customClass}
+      dateTime={normalizedTimestamp}
+      title={normalizedTimestamp}
+    >
+      {when}
+    </time>
+  );
+}


### PR DESCRIPTION
## Summary
- port `MessageTimestamp` and `Timestamp` from `stream-ui`
- add accompanying test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*
- `npx jest libs/stream-chat-shim/__tests__/MessageTimestamp.test.tsx --runInBand` *(fails: requires installing jest)*

------
https://chatgpt.com/codex/tasks/task_e_685de2144af48326b2703a30e9305f2d