### PR TITLE
Port Timestamp component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Timestamp.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Timestamp.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Timestamp } from '../src/components/Message/Timestamp';
+
+test('renders without crashing', () => {
+  render(<Timestamp />);
+});

--- a/libs/stream-chat-shim/src/components/Message/Timestamp.tsx
+++ b/libs/stream-chat-shim/src/components/Message/Timestamp.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+
+import { useMessageContext } from '../../context/MessageContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+import { getDateString, isDate } from '../../i18n/utils';
+import type { TimestampFormatterOptions } from '../../i18n/types';
+
+export interface TimestampProps extends TimestampFormatterOptions {
+  /* Adds a CSS class name to the component's outer `time` container. */
+  customClass?: string;
+  /* Timestamp to display */
+  timestamp?: Date | string;
+}
+
+export function Timestamp(props: TimestampProps) {
+  const { calendar, calendarFormats, customClass, format, timestamp } = props;
+
+  const { formatDate } = useMessageContext('MessageTimestamp');
+  const { t, tDateTimeParser } = useTranslationContext('MessageTimestamp');
+
+  const normalizedTimestamp =
+    timestamp && isDate(timestamp) ? timestamp.toISOString() : timestamp;
+
+  const when = useMemo(
+    () =>
+      getDateString({
+        calendar,
+        calendarFormats,
+        format,
+        formatDate,
+        messageCreatedAt: normalizedTimestamp,
+        t,
+        tDateTimeParser,
+        timestampTranslationKey: 'timestamp/MessageTimestamp',
+      }),
+    [
+      calendar,
+      calendarFormats,
+      format,
+      formatDate,
+      normalizedTimestamp,
+      t,
+      tDateTimeParser,
+    ],
+  );
+
+  if (!when) {
+    return null;
+  }
+
+  return (
+    <time
+      className={customClass}
+      dateTime={normalizedTimestamp}
+      title={normalizedTimestamp}
+    >
+      {when}
+    </time>
+  );
+}


### PR DESCRIPTION
## Summary
- port `Timestamp` component
- add a basic render test

## Testing
- `pnpm install` *(fails: turbo_json_parse_error)*
- `npx jest libs/stream-chat-shim/__tests__/Timestamp.test.tsx` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685de24ad8c48326bf01310af3e1ba74