### PR TITLE
Add Anchor component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Anchor.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Anchor.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Anchor } from '../src/components/Message/renderText/componentRenderers/Anchor';
+
+describe('Anchor', () => {
+  test('renders without crashing', () => {
+    render(<Anchor href='http://example.com'>Link</Anchor>);
+  });
+});

--- a/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/Anchor.tsx
+++ b/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/Anchor.tsx
@@ -1,0 +1,21 @@
+import clsx from 'clsx';
+import type { ComponentProps } from 'react';
+import React from 'react';
+
+export const Anchor = ({ children, href }: ComponentProps<'a'>) => {
+  const isEmail = href?.startsWith('mailto:');
+  const isUrl = href?.startsWith('http');
+
+  if (!href || (!isEmail && !isUrl)) return <>{children}</>;
+
+  return (
+    <a
+      className={clsx({ 'str-chat__message-url-link': isUrl })}
+      href={href}
+      rel='nofollow noreferrer noopener'
+      target='_blank'
+    >
+      {children}
+    </a>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/index.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/index.ts
@@ -1,0 +1,3 @@
+export * from './Anchor';
+export * from './Emoji';
+export * from './Mention';


### PR DESCRIPTION
## Summary
- port Anchor component under `components/Message` renderText
- export Anchor in index
- add sanity test for Anchor

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: none of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685de26a89bc8326a5462c723a044062