### PR TITLE
Port Emoji renderer

### DIFF
--- a/libs/stream-chat-shim/__tests__/Emoji.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Emoji.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Emoji } from '../src/components/Message/renderText/componentRenderers/Emoji';
+
+test('renders without crashing', () => {
+  render(<Emoji>😀</Emoji>);
+});

--- a/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/Emoji.tsx
+++ b/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/Emoji.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import type { PropsWithChildrenOnly } from '../../../../types/types';
+
+export const Emoji = ({ children }: PropsWithChildrenOnly) => (
+  <span className='inline-text-emoji' data-testid='inline-text-emoji'>
+    {children}
+  </span>
+);

--- a/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/index.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/index.ts
@@ -1,0 +1,3 @@
+export * from './Anchor';
+export * from './Emoji';
+export * from './Mention';


### PR DESCRIPTION
## Summary
- port `Emoji` component from stream-chat-react
- add test for `Emoji`
- include componentRenderers index

## Testing
- `pnpm -r build` *(fails: Can't resolve 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685de276b3008326834b24739340a484