### PR TITLE
Port CustomMessageActionsList component

### DIFF
--- a/libs/stream-chat-shim/__tests__/CustomMessageActionsListComponent.test.tsx
+++ b/libs/stream-chat-shim/__tests__/CustomMessageActionsListComponent.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CustomMessageActionsList } from '../src/components/MessageActions/CustomMessageActionsList';
+
+test('renders without crashing', () => {
+  render(<CustomMessageActionsList message={{} as any} customMessageActions={{}} />);
+});

--- a/libs/stream-chat-shim/src/components/MessageActions/CustomMessageActionsList.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/CustomMessageActionsList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+/* TODO backend-wire-up: LocalMessage import excised */
+// import type { LocalMessage } from 'stream-chat';
+import type { CustomMessageActions } from '../../context/MessageContext';
+
+export type CustomMessageActionsListProps = {
+  message: LocalMessage;
+  customMessageActions?: CustomMessageActions;
+};
+
+export const CustomMessageActionsList = (props: CustomMessageActionsListProps) => {
+  const { customMessageActions, message } = props;
+
+  if (!customMessageActions) return null;
+
+  const customActionsArray = Object.keys(customMessageActions);
+
+  return (
+    <>
+      {customActionsArray.map((customAction) => {
+        const customHandler = customMessageActions[customAction];
+
+        return (
+          <button
+            aria-selected='false'
+            className='str-chat__message-actions-list-item str-chat__message-actions-list-item-button'
+            key={customAction}
+            onClick={(event) => customHandler(message, event)}
+            role='option'
+          >
+            {customAction}
+          </button>
+        );
+      })}
+    </>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageActions/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageActions/index.ts
@@ -1,0 +1,3 @@
+export * from './MessageActions';
+export * from './MessageActionsBox';
+export * from './CustomMessageActionsList';


### PR DESCRIPTION
## Summary
- port `CustomMessageActionsList` from stream-ui
- include index barrel for MessageActions components
- add basic render test

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685de2ab5344832696b8b66d8b85fa61