### PR TITLE
Add RemindMeSubmenu component

### DIFF
--- a/libs/stream-chat-shim/__tests__/RemindMeSubmenu.test.tsx
+++ b/libs/stream-chat-shim/__tests__/RemindMeSubmenu.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RemindMeSubmenu } from '../src/components/MessageActions/RemindMeSubmenu';
+
+test('renders without crashing', () => {
+  render(<RemindMeSubmenu />);
+});

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useChatContext, useMessageContext, useTranslationContext } from '../../context';
+import { ButtonWithSubmenu } from '../Dialog';
+import type { ComponentProps } from 'react';
+
+export const RemindMeActionButton = ({
+  className,
+  isMine,
+}: { isMine: boolean } & ComponentProps<'button'>) => {
+  const { t } = useTranslationContext();
+
+  return (
+    <ButtonWithSubmenu
+      aria-selected='false'
+      className={className}
+      placement={isMine ? 'left-start' : 'right-start'}
+      Submenu={RemindMeSubmenu}
+    >
+      {t('Remind Me')}
+    </ButtonWithSubmenu>
+  );
+};
+
+export const RemindMeSubmenu = () => {
+  const { t } = useTranslationContext();
+  const { client } = useChatContext();
+  const { message } = useMessageContext();
+  return (
+    <div
+      aria-label={t('aria/Remind Me Options')}
+      className='str-chat__message-actions-box__submenu'
+      role='listbox'
+    >
+      {client.reminders.scheduledOffsetsMs.map((offsetMs) => (
+        <button
+          className='str-chat__message-actions-list-item-button'
+          key={`reminder-offset-option--${offsetMs}`}
+            onClick={() => {
+              /* TODO backend-wire-up: upsertReminder */
+              Promise.resolve(undefined);
+            }}
+        >
+          {t('duration/Remind Me', { milliseconds: offsetMs })}
+        </button>
+      ))}
+      {/* todo: potential improvement to add a custom option that would trigger rendering modal with custom date picker - we need date picker */}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add `RemindMeSubmenu` from Stream Chat React and stub SaaS call
- include smoke test for the new component

## Testing
- `pnpm -r build` *(fails: Module not found: 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails with TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685de2d57b388326812c1882adbb77dd