### PR TITLE
feat(stream-chat-shim): port MessageBouncePrompt

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageBouncePrompt.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageBouncePrompt.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageBouncePrompt } from '../src/components/MessageBounce/MessageBouncePrompt';
+
+test('renders without crashing', () => {
+  render(<MessageBouncePrompt />);
+});

--- a/libs/stream-chat-shim/src/components/MessageBounce/MessageBounceModal.tsx
+++ b/libs/stream-chat-shim/src/components/MessageBounce/MessageBounceModal.tsx
@@ -1,0 +1,25 @@
+import type { ComponentType, PropsWithChildren } from 'react';
+import React from 'react';
+import type { ModalProps } from '../Modal';
+import { Modal } from '../Modal';
+import { MessageBounceProvider } from '../../context';
+import type { MessageBouncePromptProps } from './MessageBouncePrompt';
+
+export type MessageBounceModalProps = PropsWithChildren<
+  ModalProps & {
+    MessageBouncePrompt: ComponentType<MessageBouncePromptProps>;
+  }
+>;
+
+export function MessageBounceModal({
+  MessageBouncePrompt,
+  ...modalProps
+}: MessageBounceModalProps) {
+  return (
+    <Modal className='str-chat__message-bounce-modal' {...modalProps}>
+      <MessageBounceProvider>
+        <MessageBouncePrompt onClose={modalProps.onClose} />
+      </MessageBounceProvider>
+    </Modal>
+  );
+}

--- a/libs/stream-chat-shim/src/components/MessageBounce/MessageBouncePrompt.tsx
+++ b/libs/stream-chat-shim/src/components/MessageBounce/MessageBouncePrompt.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useMessageBounceContext, useTranslationContext } from '../../context';
+
+import type { MouseEventHandler, PropsWithChildren } from 'react';
+
+import type { ModalProps } from '../Modal';
+
+export type MessageBouncePromptProps = PropsWithChildren<Pick<ModalProps, 'onClose'>>;
+
+export function MessageBouncePrompt({ children, onClose }: MessageBouncePromptProps) {
+  const { handleDelete, handleEdit, handleRetry } =
+    useMessageBounceContext('MessageBouncePrompt');
+  const { t } = useTranslationContext('MessageBouncePrompt');
+
+  function createHandler(
+    handle: MouseEventHandler<HTMLButtonElement>,
+  ): MouseEventHandler<HTMLButtonElement> {
+    return (e) => {
+      handle(e);
+      onClose?.(e);
+    };
+  }
+
+  return (
+    <div className='str-chat__message-bounce-prompt' data-testid='message-bounce-prompt'>
+      <div className='str-chat__message-bounce-prompt-header'>
+        {children ?? t('This message did not meet our content guidelines')}
+      </div>
+      <div className='str-chat__message-bounce-actions'>
+        <button
+          className='str-chat__message-bounce-edit'
+          data-testid='message-bounce-edit'
+          onClick={createHandler(handleEdit)}
+          type='button'
+        >
+          {t('Edit Message')}
+        </button>
+        <button
+          className='str-chat__message-bounce-send'
+          data-testid='message-bounce-send'
+          onClick={createHandler(handleRetry)}
+        >
+          {t('Send Anyway')}
+        </button>
+        <button
+          className='str-chat__message-bounce-delete'
+          data-testid='message-bounce-delete'
+          onClick={createHandler(handleDelete)}
+        >
+          {t('Delete')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/libs/stream-chat-shim/src/components/MessageBounce/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageBounce/index.ts
@@ -1,0 +1,2 @@
+export * from './MessageBounceModal';
+export * from './MessageBouncePrompt';


### PR DESCRIPTION
## Summary
- copy MessageBouncePrompt and supporting files from stream-chat-react
- add basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de31439c08326a54a89ac6b9053b6