### PR TITLE
Port AttachmentPreviewList component ✔︎

### DIFF
--- a/libs/stream-chat-shim/__tests__/AttachmentPreviewList.test.tsx
+++ b/libs/stream-chat-shim/__tests__/AttachmentPreviewList.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { AttachmentPreviewList } from '../src/AttachmentPreviewList'
+import { AttachmentPreviewList } from '../src/components/MessageInput/AttachmentPreviewList'
 
-test('renders placeholder', () => {
-  const { getByTestId } = render(<AttachmentPreviewList />)
-  expect(getByTestId('attachment-preview-list')).toBeTruthy()
+test('renders without crashing', () => {
+  render(<AttachmentPreviewList />)
 })

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/AttachmentPreviewList.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/AttachmentPreviewList.tsx
@@ -1,0 +1,129 @@
+import type { ComponentType } from 'react';
+import React from 'react';
+// import {
+//   isLocalAttachment,
+//   isLocalAudioAttachment,
+//   isLocalFileAttachment,
+//   isLocalImageAttachment,
+//   isLocalVideoAttachment,
+//   isLocalVoiceRecordingAttachment,
+//   isScrapedContent,
+// } from 'stream-chat'; // TODO backend-wire-up
+import {
+  isLocalAttachment,
+  isLocalAudioAttachment,
+  isLocalFileAttachment,
+  isLocalImageAttachment,
+  isLocalVideoAttachment,
+  isLocalVoiceRecordingAttachment,
+  isScrapedContent,
+} from '../../../../../chat-shim';
+import type { UnsupportedAttachmentPreviewProps } from './UnsupportedAttachmentPreview';
+import { UnsupportedAttachmentPreview as DefaultUnknownAttachmentPreview } from './UnsupportedAttachmentPreview';
+import { VoiceRecordingPreview as DefaultVoiceRecordingPreview } from './VoiceRecordingPreview';
+import { FileAttachmentPreview as DefaultFilePreview } from './FileAttachmentPreview';
+import { ImageAttachmentPreview as DefaultImagePreview } from './ImageAttachmentPreview';
+// import { useAttachmentManagerState, useMessageComposer } from '../hooks'; // TODO backend-wire-up
+const useAttachmentManagerState = () => ({ attachments: [] as any[] });
+const useMessageComposer = () => ({
+  attachmentManager: {
+    uploadAttachment: (_a: any) => {},
+    removeAttachments: (_ids: string[]) => {},
+  },
+});
+import type { VoiceRecordingPreviewProps } from './VoiceRecordingPreview';
+import type { FileAttachmentPreviewProps } from './FileAttachmentPreview';
+import type { ImageAttachmentPreviewProps } from './ImageAttachmentPreview';
+
+export type AttachmentPreviewListProps = {
+  AudioAttachmentPreview?: ComponentType<FileAttachmentPreviewProps>;
+  FileAttachmentPreview?: ComponentType<FileAttachmentPreviewProps>;
+  ImageAttachmentPreview?: ComponentType<ImageAttachmentPreviewProps>;
+  UnsupportedAttachmentPreview?: ComponentType<UnsupportedAttachmentPreviewProps>;
+  VideoAttachmentPreview?: ComponentType<FileAttachmentPreviewProps>;
+  VoiceRecordingPreview?: ComponentType<VoiceRecordingPreviewProps>;
+};
+
+export const AttachmentPreviewList = ({
+  AudioAttachmentPreview = DefaultFilePreview,
+  FileAttachmentPreview = DefaultFilePreview,
+  ImageAttachmentPreview = DefaultImagePreview,
+  UnsupportedAttachmentPreview = DefaultUnknownAttachmentPreview,
+  VideoAttachmentPreview = DefaultFilePreview,
+  VoiceRecordingPreview = DefaultVoiceRecordingPreview,
+}: AttachmentPreviewListProps) => {
+  const messageComposer = useMessageComposer();
+
+  const { attachments } = useAttachmentManagerState();
+
+  if (!attachments.length) return null;
+
+  return (
+    <div className='str-chat__attachment-preview-list'>
+      <div
+        className='str-chat__attachment-list-scroll-container'
+        data-testid='attachment-list-scroll-container'
+      >
+        {attachments.map((attachment) => {
+          if (isScrapedContent(attachment)) return null;
+          if (isLocalVoiceRecordingAttachment(attachment)) {
+            return (
+              <VoiceRecordingPreview
+                attachment={attachment}
+                handleRetry={messageComposer.attachmentManager.uploadAttachment}
+                key={attachment.localMetadata.id || attachment.asset_url}
+                removeAttachments={messageComposer.attachmentManager.removeAttachments}
+              />
+            );
+          } else if (isLocalAudioAttachment(attachment)) {
+            return (
+              <AudioAttachmentPreview
+                attachment={attachment}
+                handleRetry={messageComposer.attachmentManager.uploadAttachment}
+                key={attachment.localMetadata.id || attachment.asset_url}
+                removeAttachments={messageComposer.attachmentManager.removeAttachments}
+              />
+            );
+          } else if (isLocalVideoAttachment(attachment)) {
+            return (
+              <VideoAttachmentPreview
+                attachment={attachment}
+                handleRetry={messageComposer.attachmentManager.uploadAttachment}
+                key={attachment.localMetadata.id || attachment.asset_url}
+                removeAttachments={messageComposer.attachmentManager.removeAttachments}
+              />
+            );
+          } else if (isLocalImageAttachment(attachment)) {
+            return (
+              <ImageAttachmentPreview
+                attachment={attachment}
+                handleRetry={messageComposer.attachmentManager.uploadAttachment}
+                key={attachment.localMetadata.id || attachment.image_url}
+                removeAttachments={messageComposer.attachmentManager.removeAttachments}
+              />
+            );
+          } else if (isLocalFileAttachment(attachment)) {
+            return (
+              <FileAttachmentPreview
+                attachment={attachment}
+                handleRetry={messageComposer.attachmentManager.uploadAttachment}
+                key={attachment.localMetadata.id || attachment.asset_url}
+                removeAttachments={messageComposer.attachmentManager.removeAttachments}
+              />
+            );
+          } else if (isLocalAttachment(attachment)) {
+            return (
+              <UnsupportedAttachmentPreview
+                attachment={attachment}
+                handleRetry={messageComposer.attachmentManager.uploadAttachment}
+                key={attachment.localMetadata.id}
+                removeAttachments={messageComposer.attachmentManager.removeAttachments}
+              />
+            );
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/FileAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/FileAttachmentPreview.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+// import { useTranslationContext } from '../../../context'; // TODO backend-wire-up
+const useTranslationContext = (_?: string) => ({ t: (s: any) => s });
+// import { FileIcon } from '../../ReactFileUtilities'; // TODO backend-wire-up
+const FileIcon = (_props: any) => null;
+// import { CloseIcon, DownloadIcon, LoadingIndicatorIcon, RetryIcon } from '../icons'; // TODO backend-wire-up
+const CloseIcon = () => null;
+const DownloadIcon = () => null;
+const LoadingIndicatorIcon = (_props: any) => null;
+const RetryIcon = () => null;
+
+// import type {
+//   LocalAudioAttachment,
+//   LocalFileAttachment,
+//   LocalVideoAttachment,
+// } from 'stream-chat'; // TODO backend-wire-up
+import type {
+  LocalAudioAttachment,
+  LocalFileAttachment,
+  LocalVideoAttachment,
+} from '../../../../../chat-shim';
+import type { UploadAttachmentPreviewProps } from './types';
+
+export type FileAttachmentPreviewProps<CustomLocalMetadata = unknown> =
+  UploadAttachmentPreviewProps<
+    | LocalFileAttachment<CustomLocalMetadata>
+    | LocalAudioAttachment<CustomLocalMetadata>
+    | LocalVideoAttachment<CustomLocalMetadata>
+  >;
+
+export const FileAttachmentPreview = ({
+  attachment,
+  handleRetry,
+  removeAttachments,
+}: FileAttachmentPreviewProps) => {
+  const { t } = useTranslationContext('FilePreview');
+  const uploadState = attachment.localMetadata?.uploadState;
+
+  return (
+    <div
+      className='str-chat__attachment-preview-file'
+      data-testid='attachment-preview-file'
+    >
+      <div className='str-chat__attachment-preview-file-icon'>
+        <FileIcon filename={attachment.title} mimeType={attachment.mime_type} />
+      </div>
+
+      <button
+        aria-label={t('aria/Remove attachment')}
+        className='str-chat__attachment-preview-delete'
+        data-testid='file-preview-item-delete-button'
+        disabled={uploadState === 'uploading'}
+        onClick={() =>
+          attachment.localMetadata?.id &&
+          removeAttachments([attachment.localMetadata?.id])
+        }
+      >
+        <CloseIcon />
+      </button>
+
+      {['blocked', 'failed'].includes(uploadState) && !!handleRetry && (
+        <button
+          className='str-chat__attachment-preview-error str-chat__attachment-preview-error-file'
+          data-testid='file-preview-item-retry-button'
+          onClick={() => {
+            handleRetry(attachment);
+          }}
+        >
+          <RetryIcon />
+        </button>
+      )}
+
+      <div className='str-chat__attachment-preview-file-end'>
+        <div className='str-chat__attachment-preview-file-name' title={attachment.title}>
+          {attachment.title}
+        </div>
+        {/* undefined if loaded from a draft */}
+        {(typeof uploadState === 'undefined' || uploadState === 'finished') &&
+          !!attachment.asset_url && (
+            <a
+              aria-label={t('aria/Download attachment')}
+              className='str-chat__attachment-preview-file-download'
+              download
+              href={attachment.asset_url}
+              rel='noreferrer'
+              target='_blank'
+              title={t('Download attachment {{ name }}', { name: attachment.title })}
+            >
+              <DownloadIcon />
+            </a>
+          )}
+        {uploadState === 'uploading' && <LoadingIndicatorIcon size={17} />}
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/ImageAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/ImageAttachmentPreview.tsx
@@ -1,0 +1,77 @@
+import clsx from 'clsx';
+import React, { useCallback, useState } from 'react';
+// import { CloseIcon, LoadingIndicatorIcon, RetryIcon } from '../icons'; // TODO backend-wire-up
+const CloseIcon = () => null;
+const LoadingIndicatorIcon = (_props: any) => null;
+const RetryIcon = () => null;
+// import { BaseImage as DefaultBaseImage } from '../../Gallery'; // TODO backend-wire-up
+const DefaultBaseImage = (props: any) => <img {...props} />;
+// import { useComponentContext, useTranslationContext } from '../../../context'; // TODO backend-wire-up
+const useComponentContext = (_?: string) => ({ BaseImage: DefaultBaseImage });
+const useTranslationContext = (_?: string) => ({ t: (s: any) => s });
+// import type { LocalImageAttachment } from 'stream-chat'; // TODO backend-wire-up
+import type { LocalImageAttachment } from '../../../../../chat-shim';
+import type { UploadAttachmentPreviewProps } from './types';
+
+export type ImageAttachmentPreviewProps<CustomLocalMetadata = Record<string, unknown>> =
+  UploadAttachmentPreviewProps<LocalImageAttachment<CustomLocalMetadata>>;
+
+export const ImageAttachmentPreview = ({
+  attachment,
+  handleRetry,
+  removeAttachments,
+}: ImageAttachmentPreviewProps) => {
+  const { t } = useTranslationContext('ImagePreviewItem');
+  const { BaseImage = DefaultBaseImage } = useComponentContext('ImagePreview');
+  const [previewError, setPreviewError] = useState(false);
+
+  const { id, uploadState } = attachment.localMetadata ?? {};
+
+  const handleLoadError = useCallback(() => setPreviewError(true), []);
+  const assetUrl = attachment.image_url || attachment.localMetadata.previewUri;
+
+  return (
+    <div
+      className={clsx('str-chat__attachment-preview-image', {
+        'str-chat__attachment-preview-image--error': previewError,
+      })}
+      data-testid='attachment-preview-image'
+    >
+      <button
+        aria-label={t('aria/Remove attachment')}
+        className='str-chat__attachment-preview-delete'
+        data-testid='image-preview-item-delete-button'
+        disabled={uploadState === 'uploading'}
+        onClick={() => id && removeAttachments([id])}
+      >
+        <CloseIcon />
+      </button>
+
+      {['blocked', 'failed'].includes(uploadState) && (
+        <button
+          className='str-chat__attachment-preview-error str-chat__attachment-preview-error-image'
+          data-testid='image-preview-item-retry-button'
+          onClick={() => handleRetry(attachment)}
+        >
+          <RetryIcon />
+        </button>
+      )}
+
+      {uploadState === 'uploading' && (
+        <div className='str-chat__attachment-preview-image-loading'>
+          <LoadingIndicatorIcon size={17} />
+        </div>
+      )}
+
+      {assetUrl && (
+        <BaseImage
+          alt={attachment.fallback}
+          className='str-chat__attachment-preview-thumbnail'
+          onError={handleLoadError}
+          src={assetUrl}
+          title={attachment.fallback}
+        />
+      )}
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+// import { isLocalUploadAttachment } from 'stream-chat'; // TODO backend-wire-up
+import { isLocalUploadAttachment } from '../../../../../chat-shim';
+// import { CloseIcon, DownloadIcon, LoadingIndicatorIcon, RetryIcon } from '../icons'; // TODO backend-wire-up
+const CloseIcon = () => null;
+const DownloadIcon = () => null;
+const LoadingIndicatorIcon = (_props: any) => null;
+const RetryIcon = () => null;
+// import { FileIcon } from '../../ReactFileUtilities'; // TODO backend-wire-up
+const FileIcon = (_props: any) => null;
+// import { useTranslationContext } from '../../../context'; // TODO backend-wire-up
+const useTranslationContext = (_?: string) => ({ t: (s: any) => s });
+// import type { AnyLocalAttachment, LocalUploadAttachment } from 'stream-chat'; // TODO backend-wire-up
+import type { AnyLocalAttachment, LocalUploadAttachment } from '../../../../../chat-shim';
+
+export type UnsupportedAttachmentPreviewProps<
+  CustomLocalMetadata = Record<string, unknown>,
+> = {
+  attachment: AnyLocalAttachment<CustomLocalMetadata>;
+  handleRetry: (
+    attachment: LocalUploadAttachment,
+  ) => void | Promise<LocalUploadAttachment | undefined>;
+  removeAttachments: (ids: string[]) => void;
+};
+
+export const UnsupportedAttachmentPreview = ({
+  attachment,
+  handleRetry,
+  removeAttachments,
+}: UnsupportedAttachmentPreviewProps) => {
+  const { t } = useTranslationContext('UnsupportedAttachmentPreview');
+  const title = attachment.title ?? t('Unsupported attachment');
+  return (
+    <div
+      className='str-chat__attachment-preview-unsupported'
+      data-testid='attachment-preview-unknown'
+    >
+      <div className='str-chat__attachment-preview-file-icon'>
+        <FileIcon filename={title} mimeType={attachment.mime_type} />
+      </div>
+
+      <button
+        aria-label={t('aria/Remove attachment')}
+        className='str-chat__attachment-preview-delete'
+        data-testid='file-preview-item-delete-button'
+        disabled={attachment.localMetadata?.uploadState === 'uploading'}
+        onClick={() =>
+          attachment.localMetadata?.id &&
+          removeAttachments([attachment.localMetadata?.id])
+        }
+      >
+        <CloseIcon />
+      </button>
+
+      {isLocalUploadAttachment(attachment) &&
+        ['blocked', 'failed'].includes(attachment.localMetadata?.uploadState) &&
+        !!handleRetry && (
+          <button
+            className='str-chat__attachment-preview-error str-chat__attachment-preview-error-file'
+            data-testid='file-preview-item-retry-button'
+            onClick={() => handleRetry(attachment)}
+          >
+            <RetryIcon />
+          </button>
+        )}
+
+      <div className='str-chat__attachment-preview-metadata'>
+        <div className='str-chat__attachment-preview-title' title={title}>
+          {title}
+        </div>
+        {attachment.localMetadata?.uploadState === 'finished' &&
+          !!attachment.asset_url && (
+            <a
+              className='str-chat__attachment-preview-file-download'
+              download
+              href={attachment.asset_url}
+              rel='noreferrer'
+              target='_blank'
+            >
+              <DownloadIcon />
+            </a>
+          )}
+        {attachment.localMetadata?.uploadState === 'uploading' && (
+          <LoadingIndicatorIcon size={17} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/VoiceRecordingPreview.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/VoiceRecordingPreview.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+// import { PlayButton } from '../../Attachment'; // TODO backend-wire-up
+const PlayButton = (_props: any) => null;
+// import { RecordingTimer } from '../../MediaRecorder'; // TODO backend-wire-up
+const RecordingTimer = (_props: any) => null;
+// import { CloseIcon, LoadingIndicatorIcon, RetryIcon } from '../icons'; // TODO backend-wire-up
+const CloseIcon = () => null;
+const LoadingIndicatorIcon = (_props: any) => null;
+const RetryIcon = () => null;
+// import { FileIcon } from '../../ReactFileUtilities'; // TODO backend-wire-up
+const FileIcon = (_props: any) => null;
+// import { useAudioController } from '../../Attachment/hooks/useAudioController'; // TODO backend-wire-up
+const useAudioController = (_: any) => ({
+  audioRef: { current: null } as any,
+  isPlaying: false,
+  secondsElapsed: 0,
+  togglePlay: () => {},
+});
+// import type { LocalVoiceRecordingAttachment } from 'stream-chat'; // TODO backend-wire-up
+import type { LocalVoiceRecordingAttachment } from '../../../../../chat-shim';
+import type { UploadAttachmentPreviewProps } from './types';
+// import { useTranslationContext } from '../../../context'; // TODO backend-wire-up
+const useTranslationContext = () => ({ t: (s: any) => s });
+
+export type VoiceRecordingPreviewProps<CustomLocalMetadata = Record<string, unknown>> =
+  UploadAttachmentPreviewProps<LocalVoiceRecordingAttachment<CustomLocalMetadata>>;
+
+export const VoiceRecordingPreview = ({
+  attachment,
+  handleRetry,
+  removeAttachments,
+}: VoiceRecordingPreviewProps) => {
+  const { t } = useTranslationContext();
+  const { audioRef, isPlaying, secondsElapsed, togglePlay } = useAudioController({
+    mimeType: attachment.mime_type,
+  });
+
+  return (
+    <div
+      className='str-chat__attachment-preview-voice-recording'
+      data-testid='attachment-preview-voice-recording'
+    >
+      <audio ref={audioRef}>
+        <source
+          data-testid='audio-source'
+          src={attachment.asset_url}
+          type={attachment.mime_type}
+        />
+      </audio>
+      <PlayButton isPlaying={isPlaying} onClick={togglePlay} />
+
+      <button
+        aria-label={t('aria/Remove attachment')}
+        className='str-chat__attachment-preview-delete'
+        data-testid='file-preview-item-delete-button'
+        disabled={attachment.localMetadata?.uploadState === 'uploading'}
+        onClick={() =>
+          attachment.localMetadata?.id && removeAttachments([attachment.localMetadata.id])
+        }
+      >
+        <CloseIcon />
+      </button>
+
+      {['blocked', 'failed'].includes(attachment.localMetadata?.uploadState) &&
+        !!handleRetry && (
+          <button
+            className='str-chat__attachment-preview-error str-chat__attachment-preview-error-file'
+            data-testid='file-preview-item-retry-button'
+            onClick={() => handleRetry(attachment)}
+          >
+            <RetryIcon />
+          </button>
+        )}
+
+      <div className='str-chat__attachment-preview-metadata'>
+        <div className='str-chat__attachment-preview-file-name' title={attachment.title}>
+          {attachment.title}
+        </div>
+        {typeof attachment.duration !== 'undefined' && (
+          <RecordingTimer durationSeconds={secondsElapsed || attachment.duration} />
+        )}
+        {attachment.localMetadata?.uploadState === 'uploading' && (
+          <LoadingIndicatorIcon size={17} />
+        )}
+      </div>
+      <div className='str-chat__attachment-preview-file-icon'>
+        <FileIcon filename={attachment.title} mimeType={attachment.mime_type} />
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/index.ts
@@ -1,0 +1,6 @@
+export * from './AttachmentPreviewList';
+export type { FileAttachmentPreviewProps } from './FileAttachmentPreview';
+export type { ImageAttachmentPreviewProps } from './ImageAttachmentPreview';
+export type { UploadAttachmentPreviewProps as AttachmentPreviewProps } from './types';
+export type { UnsupportedAttachmentPreviewProps } from './UnsupportedAttachmentPreview';
+export type { VoiceRecordingPreviewProps } from './VoiceRecordingPreview';

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/types.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/types.ts
@@ -1,0 +1,10 @@
+// import type { LocalUploadAttachment } from 'stream-chat'; // TODO backend-wire-up
+import type { LocalUploadAttachment } from '../../../../../chat-shim';
+
+export type UploadAttachmentPreviewProps<A extends LocalUploadAttachment> = {
+  attachment: A;
+  handleRetry: (
+    attachment: LocalUploadAttachment,
+  ) => void | Promise<LocalUploadAttachment | undefined>;
+  removeAttachments: (ids: string[]) => void;
+};


### PR DESCRIPTION
## Summary
- port AttachmentPreviewList components from stream-chat-react
- stub out missing dependencies per AGENTS instructions
- update AttachmentPreviewList test

## Testing
- `pnpm -r build` *(fails: stream-chat-react build script missing deps)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685de3215998832689dc66ca3a4b6bb3