### PR TITLE
Add UnsupportedAttachmentPreview component

### DIFF
--- a/libs/stream-chat-shim/__tests__/UnsupportedAttachmentPreview.test.tsx
+++ b/libs/stream-chat-shim/__tests__/UnsupportedAttachmentPreview.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { UnsupportedAttachmentPreview } from '../src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview';
+
+test('renders without crashing', () => {
+  render(
+    <UnsupportedAttachmentPreview
+      attachment={{} as any}
+      handleRetry={() => undefined}
+      removeAttachments={() => undefined}
+    />,
+  );
+});

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { isLocalUploadAttachment } from 'chat-shim';
+import { CloseIcon, DownloadIcon, LoadingIndicatorIcon, RetryIcon } from '../icons';
+import { FileIcon } from '../../ReactFileUtilities';
+import { useTranslationContext } from '../../../context';
+/* TODO backend-wire-up: StreamChat types excised */
+type AnyLocalAttachment<CustomLocalMetadata = Record<string, unknown>> = any;
+type LocalUploadAttachment = any;
+
+export type UnsupportedAttachmentPreviewProps<
+  CustomLocalMetadata = Record<string, unknown>,
+> = {
+  attachment: AnyLocalAttachment<CustomLocalMetadata>;
+  handleRetry: (
+    attachment: LocalUploadAttachment,
+  ) => void | Promise<LocalUploadAttachment | undefined>;
+  removeAttachments: (ids: string[]) => void;
+};
+
+export const UnsupportedAttachmentPreview = ({
+  attachment,
+  handleRetry,
+  removeAttachments,
+}: UnsupportedAttachmentPreviewProps) => {
+  const { t } = useTranslationContext('UnsupportedAttachmentPreview');
+  const title = attachment.title ?? t('Unsupported attachment');
+  return (
+    <div
+      className='str-chat__attachment-preview-unsupported'
+      data-testid='attachment-preview-unknown'
+    >
+      <div className='str-chat__attachment-preview-file-icon'>
+        <FileIcon filename={title} mimeType={attachment.mime_type} />
+      </div>
+
+      <button
+        aria-label={t('aria/Remove attachment')}
+        className='str-chat__attachment-preview-delete'
+        data-testid='file-preview-item-delete-button'
+        disabled={attachment.localMetadata?.uploadState === 'uploading'}
+        onClick={() =>
+          attachment.localMetadata?.id &&
+          removeAttachments([attachment.localMetadata?.id])
+        }
+      >
+        <CloseIcon />
+      </button>
+
+      {isLocalUploadAttachment(attachment) &&
+        ['blocked', 'failed'].includes(attachment.localMetadata?.uploadState) &&
+        !!handleRetry && (
+          <button
+            className='str-chat__attachment-preview-error str-chat__attachment-preview-error-file'
+            data-testid='file-preview-item-retry-button'
+            onClick={() => handleRetry(attachment)}
+          >
+            <RetryIcon />
+          </button>
+        )}
+
+      <div className='str-chat__attachment-preview-metadata'>
+        <div className='str-chat__attachment-preview-title' title={title}>
+          {title}
+        </div>
+        {attachment.localMetadata?.uploadState === 'finished' &&
+          !!attachment.asset_url && (
+            <a
+              className='str-chat__attachment-preview-file-download'
+              download
+              href={attachment.asset_url}
+              rel='noreferrer'
+              target='_blank'
+            >
+              <DownloadIcon />
+            </a>
+          )}
+        {attachment.localMetadata?.uploadState === 'uploading' && (
+          <LoadingIndicatorIcon size={17} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/AttachmentPreviewList/index.ts
@@ -1,0 +1,6 @@
+export * from './AttachmentPreviewList';
+export type { FileAttachmentPreviewProps } from './FileAttachmentPreview';
+export type { ImageAttachmentPreviewProps } from './ImageAttachmentPreview';
+export type { UploadAttachmentPreviewProps as AttachmentPreviewProps } from './types';
+export type { UnsupportedAttachmentPreviewProps } from './UnsupportedAttachmentPreview';
+export type { VoiceRecordingPreviewProps } from './VoiceRecordingPreview';


### PR DESCRIPTION
## Summary
- port `UnsupportedAttachmentPreview` from `stream-chat-react`
- expose it in `AttachmentPreviewList` barrel
- test render of `UnsupportedAttachmentPreview`

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm test` *(fails: `turbo` not found)*
- `npx tsc --noEmit` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685de353a6588326b8040e7da0c76bac