### PR TITLE
Port EditMessageForm component

### DIFF
--- a/libs/stream-chat-shim/__tests__/EditMessageForm.test.tsx
+++ b/libs/stream-chat-shim/__tests__/EditMessageForm.test.tsx
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react';
+import { EditMessageForm } from '../src/components/MessageInput/EditMessageForm';
+
+test('renders without crashing', () => {
+  render(<EditMessageForm />);
+});

--- a/libs/stream-chat-shim/src/components/MessageInput/EditMessageForm.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/EditMessageForm.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useEffect } from 'react';
+import { MessageInput } from './MessageInput';
+import { MessageInputFlat } from './MessageInputFlat';
+import { Modal } from '../Modal';
+import {
+  useComponentContext,
+  useMessageContext,
+  useMessageInputContext,
+  useTranslationContext,
+} from '../../context';
+import { useMessageComposer, useMessageComposerHasSendableData } from './hooks';
+
+import type { MessageUIComponentProps } from '../Message';
+
+const EditMessageFormSendButton = () => {
+  const { t } = useTranslationContext();
+  const hasSendableData = useMessageComposerHasSendableData();
+  return (
+    <button
+      className='str-chat__edit-message-send'
+      data-testid='send-button-edit-form'
+      disabled={!hasSendableData}
+      type='submit'
+    >
+      {t('Send')}
+    </button>
+  );
+};
+
+export const EditMessageForm = () => {
+  const { t } = useTranslationContext('EditMessageForm');
+  const messageComposer = useMessageComposer();
+  const { clearEditingState, handleSubmit } = useMessageInputContext('EditMessageForm');
+
+  const cancel = useCallback(() => {
+    clearEditingState?.();
+    messageComposer.restore();
+  }, [clearEditingState, messageComposer]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') cancel();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [cancel]);
+
+  return (
+    <form
+      autoComplete='off'
+      className='str-chat__edit-message-form'
+      onSubmit={handleSubmit}
+    >
+      <MessageInputFlat />
+      <div className='str-chat__edit-message-form-options'>
+        <button
+          className='str-chat__edit-message-cancel'
+          data-testid='cancel-button'
+          onClick={cancel}
+        >
+          {t('Cancel')}
+        </button>
+        <EditMessageFormSendButton />
+      </div>
+    </form>
+  );
+};
+
+export const EditMessageModal = ({
+  additionalMessageInputProps,
+}: Pick<MessageUIComponentProps, 'additionalMessageInputProps'>) => {
+  const { EditMessageInput = EditMessageForm } = useComponentContext();
+  const { clearEditingState } = useMessageContext();
+  const messageComposer = useMessageComposer();
+  const onEditModalClose = useCallback(() => {
+    clearEditingState();
+    messageComposer.restore();
+  }, [clearEditingState, messageComposer]);
+
+  return (
+    <Modal
+      className='str-chat__edit-message-modal'
+      onClose={onEditModalClose}
+      open={true}
+    >
+      <MessageInput
+        clearEditingState={clearEditingState}
+        hideSendButton
+        Input={EditMessageInput}
+        {...additionalMessageInputProps}
+      />
+    </Modal>
+  );
+};


### PR DESCRIPTION
## Summary
- port `EditMessageForm` from stream-ui
- add a basic test

## Testing
- `pnpm -r run build` *(fails: Module not found 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685de382502083268a7e928ca18fa9a3