### PR TITLE
Port LinkPreviewList

### DIFF
--- a/libs/stream-chat-shim/__tests__/LinkPreviewList.test.tsx
+++ b/libs/stream-chat-shim/__tests__/LinkPreviewList.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LinkPreviewList } from '../src/components/MessageInput/LinkPreviewList';
+
+test('renders without crashing', () => {
+  render(<LinkPreviewList />);
+});

--- a/libs/stream-chat-shim/src/components/MessageInput/LinkPreviewList.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/LinkPreviewList.tsx
@@ -1,0 +1,109 @@
+import clsx from 'clsx';
+import React, { useState } from 'react';
+import type {
+  LinkPreview,
+  LinkPreviewsManagerState,
+  MessageComposerState,
+} from 'chat-shim';
+import { LinkPreviewsManager } from 'chat-shim'; // TODO backend-wire-up
+import { useStateStore } from '../../store';
+import { PopperTooltip } from '../Tooltip';
+import { useEnterLeaveHandlers } from '../Tooltip/hooks';
+import { useMessageComposer } from './hooks';
+import { CloseIcon, LinkIcon } from './icons';
+
+const linkPreviewsManagerStateSelector = (state: LinkPreviewsManagerState) => ({
+  linkPreviews: Array.from(state.previews.values()).filter(
+    (preview) =>
+      LinkPreviewsManager.previewIsLoaded(preview) ||
+      LinkPreviewsManager.previewIsLoading(preview),
+  ),
+});
+
+const messageComposerStateSelector = (state: MessageComposerState) => ({
+  quotedMessage: state.quotedMessage,
+});
+
+export const LinkPreviewList = () => {
+  const messageComposer = useMessageComposer();
+  const { linkPreviewsManager } = messageComposer;
+  const { quotedMessage } = useStateStore(
+    messageComposer.state,
+    messageComposerStateSelector,
+  );
+  const { linkPreviews } = useStateStore(
+    linkPreviewsManager.state,
+    linkPreviewsManagerStateSelector,
+  );
+
+  const showLinkPreviews = linkPreviews.length > 0 && !quotedMessage;
+
+  if (!showLinkPreviews) return null;
+
+  return (
+    <div className='str-chat__link-preview-list'>
+      {linkPreviews.map((linkPreview) => (
+        <LinkPreviewCard key={linkPreview.og_scrape_url} linkPreview={linkPreview} />
+      ))}
+    </div>
+  );
+};
+
+type LinkPreviewProps = {
+  linkPreview: LinkPreview;
+};
+
+export const LinkPreviewCard = ({ linkPreview }: LinkPreviewProps) => {
+  const { linkPreviewsManager } = useMessageComposer();
+  const { handleEnter, handleLeave, tooltipVisible } =
+    useEnterLeaveHandlers<HTMLDivElement>();
+  const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null);
+
+  if (
+    !LinkPreviewsManager.previewIsLoaded(linkPreview) &&
+    !LinkPreviewsManager.previewIsLoading(linkPreview)
+  )
+    return null;
+
+  return (
+    <div
+      className={clsx('str-chat__link-preview-card', {
+        'str-chat__link-preview-card--loading':
+          LinkPreviewsManager.previewIsLoading(linkPreview),
+      })}
+      data-testid='link-preview-card'
+    >
+      <PopperTooltip
+        offset={[0, 5]}
+        referenceElement={referenceElement}
+        visible={tooltipVisible}
+      >
+        {linkPreview.og_scrape_url}
+      </PopperTooltip>
+      <div
+        className='str-chat__link-preview-card__icon-container'
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+        ref={setReferenceElement}
+      >
+        <LinkIcon />
+      </div>
+      <div className='str-chat__link-preview-card__content'>
+        <div className='str-chat__link-preview-card__content-title'>
+          {linkPreview.title}
+        </div>
+        <div className='str-chat__link-preview-card__content-description'>
+          {linkPreview.text}
+        </div>
+      </div>
+      <button
+        className='str-chat__link-preview-card__dismiss-button'
+        data-testid='link-preview-card-dismiss-btn'
+        onClick={() => linkPreviewsManager.dismissPreview(linkPreview.og_scrape_url)}
+        type='button'
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `LinkPreviewList` component from Stream library into chat-shim
- add simple render test for `LinkPreviewList`

## Testing
- `pnpm -r build` *(fails: Module not found 'stream-chat-react')*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685de38f05f88326b7c934e7991db58f