### PR TITLE
Port renderText utilities

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageRenderText.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageRenderText.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { renderText } from '../src/components/Message/renderText/renderText';
+
+test('renders markdown text', () => {
+  const html = renderToStaticMarkup(renderText('**hi**') as React.ReactElement);
+  expect(html).toContain('strong');
+});

--- a/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/Mention.tsx
+++ b/libs/stream-chat-shim/src/components/Message/renderText/componentRenderers/Mention.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+
+import type { UserResponse } from 'stream-chat';
+
+export type MentionProps = PropsWithChildren<{
+  node: {
+    mentionedUser: UserResponse;
+  };
+}>;
+
+export const Mention = ({ children, node: { mentionedUser } }: MentionProps) => (
+  <span className='str-chat__message-mention' data-user-id={mentionedUser.id}>
+    {children}
+  </span>
+);

--- a/libs/stream-chat-shim/src/components/Message/renderText/index.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/index.ts
@@ -1,0 +1,5 @@
+export type { MentionProps } from './componentRenderers';
+export { escapeRegExp, matchMarkdownLinks, messageCodeBlocks } from './regex';
+export * from './rehypePlugins';
+export * from './remarkPlugins';
+export * from './renderText';

--- a/libs/stream-chat-shim/src/components/Message/renderText/regex.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/regex.ts
@@ -1,0 +1,26 @@
+export function escapeRegExp(text: string) {
+  return text.replace(/[-[\]{}()*+?.,/\\^$|#]/g, '\\$&');
+}
+
+export const detectHttp = /(http(s?):\/\/)?(www\.)?/;
+
+export const messageCodeBlocks = (message: string) => {
+  const codeRegex = /```[a-z]*\n[\s\S]*?\n```|`[a-z]*[\s\S]*?`/gm;
+  const matches = message.match(codeRegex);
+  return matches || [];
+};
+
+export const matchMarkdownLinks = (message: string) => {
+  const regexMdLinks = /\[([^[]+)\](\(.*\))/gm;
+  const matches = message.match(regexMdLinks);
+  const singleMatch = /\[([^[]+)\]\((.*)\)/;
+
+  const links = matches
+    ? matches.map((match) => {
+        const i = singleMatch.exec(match);
+        return i && [i[1], i[2]];
+      })
+    : [];
+
+  return links.flat();
+};

--- a/libs/stream-chat-shim/src/components/Message/renderText/rehypePlugins/emojiMarkdownPlugin.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/rehypePlugins/emojiMarkdownPlugin.ts
@@ -1,0 +1,15 @@
+import type { ReplaceFunction } from 'hast-util-find-and-replace';
+import { findAndReplace } from 'hast-util-find-and-replace';
+import { u } from 'unist-builder';
+import emojiRegex from 'emoji-regex';
+
+import type { Nodes } from 'hast-util-find-and-replace/lib';
+
+export const emojiMarkdownPlugin = () => {
+  const replace: ReplaceFunction = (match) =>
+    u('element', { properties: {}, tagName: 'emoji' }, [u('text', match)]);
+
+  const transform = (node: Nodes) => findAndReplace(node, [emojiRegex(), replace]);
+
+  return transform;
+};

--- a/libs/stream-chat-shim/src/components/Message/renderText/rehypePlugins/index.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/rehypePlugins/index.ts
@@ -1,0 +1,2 @@
+export * from './emojiMarkdownPlugin';
+export * from './mentionsMarkdownPlugin';

--- a/libs/stream-chat-shim/src/components/Message/renderText/rehypePlugins/mentionsMarkdownPlugin.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/rehypePlugins/mentionsMarkdownPlugin.ts
@@ -1,0 +1,68 @@
+import { escapeRegExp } from '../regex';
+import type { ReplaceFunction } from 'hast-util-find-and-replace';
+import { findAndReplace } from 'hast-util-find-and-replace';
+import { u } from 'unist-builder';
+import { visit } from 'unist-util-visit';
+
+import type { Nodes } from 'hast-util-find-and-replace/lib';
+import type { Element } from 'hast';
+import type { UserResponse } from 'stream-chat';
+
+export const mentionsMarkdownPlugin = (mentioned_users: UserResponse[]) => () => {
+  const mentioned_usernames = mentioned_users
+    .map((user) => user.name || user.id)
+    .filter(Boolean)
+    .map(escapeRegExp);
+
+  const mentionedUsersRegex = new RegExp(
+    mentioned_usernames.map((username) => `@${username}`).join('|'),
+    'g',
+  );
+
+  const replace: ReplaceFunction = (match) => {
+    const usernameOrId = match.replace('@', '');
+    const user = mentioned_users.find(
+      ({ id, name }) => name === usernameOrId || id === usernameOrId,
+    );
+    return u('element', { mentionedUser: user, properties: {}, tagName: 'mention' }, [
+      u('text', match),
+    ]);
+  };
+
+  const transform = (tree: Nodes) => {
+    if (!mentioned_usernames.length) return;
+
+    // handles special cases of mentions where user.name is an e-mail
+    // Remark GFM translates all e-mail-like text nodes to links creating
+    // two separate child nodes "@" and "your.name@as.email" instead of
+    // keeping it as one text node with value "@your.name@as.email"
+    // this piece finds these two separated nodes and merges them together
+    // before "replace" function takes over
+    visit(tree, (node, index, parent) => {
+      if (typeof index === 'undefined') return;
+      if (!parent) return;
+
+      const nextChild = parent.children.at(index + 1) as Element;
+      const nextChildHref = nextChild?.properties?.href as string | undefined;
+
+      if (
+        node.type === 'text' &&
+        // text value has to have @ sign at the end of the string
+        // and no other characters except whitespace can precede it
+        // valid cases:   "text @", "@", " @"
+        // invalid cases: "text@", "@text",
+        /.?\s?@$|^@$/.test(node.value) &&
+        nextChildHref?.startsWith('mailto:')
+      ) {
+        const newTextValue = node.value.replace(/@$/, '');
+        const username = nextChildHref.replace('mailto:', '');
+        parent.children[index] = u('text', newTextValue);
+        parent.children[index + 1] = u('text', `@${username}`);
+      }
+    });
+
+    findAndReplace(tree, [mentionedUsersRegex, replace]);
+  };
+
+  return transform;
+};

--- a/libs/stream-chat-shim/src/components/Message/renderText/remarkPlugins/htmlToTextPlugin.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/remarkPlugins/htmlToTextPlugin.ts
@@ -1,0 +1,15 @@
+import type { Visitor } from 'unist-util-visit';
+import { visit } from 'unist-util-visit';
+
+import type { Nodes } from 'hast-util-find-and-replace/lib';
+
+const visitor: Visitor = (node) => {
+  if (node.type !== 'html') return;
+
+  node.type = 'text';
+};
+const transform = (tree: Nodes) => {
+  visit(tree, visitor);
+};
+
+export const htmlToTextPlugin = () => transform;

--- a/libs/stream-chat-shim/src/components/Message/renderText/remarkPlugins/index.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/remarkPlugins/index.ts
@@ -1,0 +1,2 @@
+export * from './htmlToTextPlugin';
+export * from './keepLineBreaksPlugin';

--- a/libs/stream-chat-shim/src/components/Message/renderText/remarkPlugins/keepLineBreaksPlugin.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/remarkPlugins/keepLineBreaksPlugin.ts
@@ -1,0 +1,38 @@
+import type { Visitor } from 'unist-util-visit';
+import { visit } from 'unist-util-visit';
+import { u } from 'unist-builder';
+
+import type { Break } from 'mdast';
+import type { Nodes } from 'hast-util-find-and-replace/lib';
+
+const visitor: Visitor = (node, index, parent) => {
+  if (!(index && parent && node.position)) return;
+
+  const prevSibling = parent.children.at(index - 1);
+  if (!prevSibling?.position) return;
+
+  if (node.position.start.line === prevSibling.position.start.line) return;
+  const ownStartLine = node.position.start.line;
+  const prevEndLine = prevSibling.position.end.line;
+
+  // the -1 is adjustment for the single line break into which multiple line breaks are converted
+  const countTruncatedLineBreaks = ownStartLine - prevEndLine - 1;
+  if (countTruncatedLineBreaks < 1) return;
+
+  const lineBreaks = Array.from<unknown, Break>(
+    { length: countTruncatedLineBreaks },
+    () => u('break', { tagName: 'br' }),
+  );
+
+  parent.children = [
+    ...parent.children.slice(0, index),
+    ...lineBreaks,
+    ...parent.children.slice(index),
+  ];
+  return;
+};
+const transform = (tree: Nodes) => {
+  visit(tree, visitor);
+};
+
+export const keepLineBreaksPlugin = () => transform;

--- a/libs/stream-chat-shim/src/components/Message/renderText/renderText.tsx
+++ b/libs/stream-chat-shim/src/components/Message/renderText/renderText.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
+import { find } from 'linkifyjs';
+import uniqBy from 'lodash.uniqby';
+import remarkGfm from 'remark-gfm';
+import type { ComponentType } from 'react';
+import type { Options } from 'react-markdown/lib';
+import type { UserResponse } from 'stream-chat';
+import type { PluggableList } from 'unified'; // A subdependency of react-markdown. The type is not declared or re-exported from anywhere else
+
+import { Anchor, Emoji, Mention } from './componentRenderers';
+import { detectHttp, escapeRegExp, matchMarkdownLinks, messageCodeBlocks } from './regex';
+import { emojiMarkdownPlugin, mentionsMarkdownPlugin } from './rehypePlugins';
+import { htmlToTextPlugin, keepLineBreaksPlugin } from './remarkPlugins';
+import { ErrorBoundary } from '../../UtilityComponents';
+import type { MentionProps } from './componentRenderers';
+
+export type RenderTextPluginConfigurator = (
+  defaultPlugins: PluggableList,
+) => PluggableList;
+
+export const defaultAllowedTagNames: Array<
+  keyof JSX.IntrinsicElements | 'emoji' | 'mention'
+> = [
+  'html',
+  'text',
+  'br',
+  'p',
+  'em',
+  'strong',
+  'a',
+  'ol',
+  'ul',
+  'li',
+  'code',
+  'pre',
+  'blockquote',
+  'del',
+  'table',
+  'thead',
+  'tbody',
+  'th',
+  'tr',
+  'td',
+  'tfoot',
+  // custom types (tagNames)
+  'emoji',
+  'mention',
+];
+
+function formatUrlForDisplay(url: string) {
+  try {
+    return decodeURIComponent(url).replace(detectHttp, '');
+  } catch (e) {
+    return url;
+  }
+}
+
+function encodeDecode(url: string) {
+  try {
+    return encodeURI(decodeURIComponent(url));
+  } catch (error) {
+    return url;
+  }
+}
+
+const urlTransform = (uri: string) =>
+  uri.startsWith('app://') ? uri : defaultUrlTransform(uri);
+
+const getPluginsForward: RenderTextPluginConfigurator = (plugins: PluggableList) =>
+  plugins;
+
+export const markDownRenderers: RenderTextOptions['customMarkDownRenderers'] = {
+  a: Anchor,
+  emoji: Emoji,
+  mention: Mention,
+};
+
+export type RenderTextOptions = {
+  allowedTagNames?: Array<
+    keyof JSX.IntrinsicElements | 'emoji' | 'mention' | (string & {})
+  >;
+  customMarkDownRenderers?: Options['components'] &
+    Partial<{
+      emoji: ComponentType;
+      mention: ComponentType<MentionProps>;
+    }>;
+  getRehypePlugins?: RenderTextPluginConfigurator;
+  getRemarkPlugins?: RenderTextPluginConfigurator;
+};
+
+export const renderText = (
+  text?: string,
+  mentionedUsers?: UserResponse[],
+  {
+    allowedTagNames = defaultAllowedTagNames,
+    customMarkDownRenderers,
+    getRehypePlugins = getPluginsForward,
+    getRemarkPlugins = getPluginsForward,
+  }: RenderTextOptions = {},
+) => {
+  // take the @ mentions and turn them into markdown?
+  // translate links
+  if (!text) return null;
+  if (text.trim().length === 1) return <>{text}</>;
+
+  let newText = text;
+  const markdownLinks = matchMarkdownLinks(newText);
+  const codeBlocks = messageCodeBlocks(newText);
+
+  // extract all valid links/emails within text and replace it with proper markup
+  uniqBy([...find(newText, 'email'), ...find(newText, 'url')], 'value').forEach(
+    ({ href, type, value }) => {
+      const linkIsInBlock = codeBlocks.some((block) => block?.includes(value));
+
+      // check if message is already  markdown
+      const noParsingNeeded =
+        markdownLinks &&
+        markdownLinks.filter((text) => {
+          const strippedHref = href?.replace(detectHttp, '');
+          const strippedText = text?.replace(detectHttp, '');
+
+          if (!strippedHref || !strippedText) return false;
+
+          return (
+            strippedHref.includes(strippedText) || strippedText.includes(strippedHref)
+          );
+        });
+
+      if (noParsingNeeded.length > 0 || linkIsInBlock) return;
+
+      try {
+        // special case for mentions:
+        // it could happen that a user's name matches with an e-mail format pattern.
+        // in that case, we check whether the found e-mail is actually a mention
+        // by naively checking for an existence of @ sign in front of it.
+        if (type === 'email' && mentionedUsers) {
+          const emailMatchesWithName = mentionedUsers.some((u) => u.name === value);
+          if (emailMatchesWithName) {
+            newText = newText.replace(
+              new RegExp(escapeRegExp(value), 'g'),
+              (match, position) => {
+                const isMention = newText.charAt(position - 1) === '@';
+                // in case of mention, we leave the match in its original form,
+                // and we let `mentionsMarkdownPlugin` to do its job
+                return isMention ? match : `[${match}](${encodeDecode(href)})`;
+              },
+            );
+
+            return;
+          }
+        }
+
+        const displayLink = type === 'email' ? value : formatUrlForDisplay(href);
+
+        newText = newText.replace(
+          new RegExp(escapeRegExp(value), 'g'),
+          `[${displayLink}](${encodeDecode(href)})`,
+        );
+      } catch (e) {
+        void e;
+      }
+    },
+  );
+
+  const remarkPlugins: PluggableList = [
+    htmlToTextPlugin,
+    keepLineBreaksPlugin,
+    [remarkGfm, { singleTilde: false }],
+  ];
+  const rehypePlugins: PluggableList = [emojiMarkdownPlugin];
+
+  if (mentionedUsers?.length) {
+    rehypePlugins.push(mentionsMarkdownPlugin(mentionedUsers));
+  }
+
+  return (
+    <ErrorBoundary fallback={<>{text}</>}>
+      <ReactMarkdown
+        allowedElements={allowedTagNames}
+        components={{
+          ...markDownRenderers,
+          ...customMarkDownRenderers,
+        }}
+        rehypePlugins={getRehypePlugins(rehypePlugins)}
+        remarkPlugins={getRemarkPlugins(remarkPlugins)}
+        skipHtml
+        unwrapDisallowed
+        urlTransform={urlTransform}
+      >
+        {newText}
+      </ReactMarkdown>
+    </ErrorBoundary>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Message/renderText/types.ts
+++ b/libs/stream-chat-shim/src/components/Message/renderText/types.ts
@@ -1,0 +1,3 @@
+import type { Content, Root } from 'hast';
+
+export type HNode = Content | Root;


### PR DESCRIPTION
## Summary
- port `renderText` utilities and mention renderer from stream-chat-react
- add basic test for `renderText`

## Testing
- `pnpm -r run build` *(fails: i18next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685df52d07e483268437f0261d33daf9