### PR TITLE
Add SendButton component

### DIFF
--- a/libs/stream-chat-shim/__tests__/SendButton.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SendButton.test.tsx
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react';
+import { SendButton } from '../src/components/MessageInput/SendButton';
+
+test('renders without crashing', () => {
+  render(<SendButton sendMessage={() => {}} />);
+});

--- a/libs/stream-chat-shim/src/components/MessageInput/SendButton.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/SendButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { SendIcon } from './icons';
+// import { useMessageComposerHasSendableData } from './hooks'; // TODO backend-wire-up
+const useMessageComposerHasSendableData = () => true;
+// import type { UpdatedMessage } from 'stream-chat'; // TODO backend-wire-up
+type UpdatedMessage = any;
+
+export type SendButtonProps = {
+  sendMessage: (
+    event: React.BaseSyntheticEvent,
+    customMessageData?: Omit<UpdatedMessage, 'mentioned_users'>,
+  ) => void;
+} & React.ComponentProps<'button'>;
+
+export const SendButton = ({ sendMessage, ...rest }: SendButtonProps) => {
+  const hasSendableData = useMessageComposerHasSendableData();
+  return (
+    <button
+      aria-label='Send'
+      className='str-chat__send-button'
+      data-testid='send-button'
+      disabled={!hasSendableData}
+      onClick={sendMessage}
+      type='button'
+      {...rest}
+    >
+      <SendIcon />
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- port SendButton from Stream upstream
- add SendButton smoke test

## Testing
- `pnpm -r run build` *(fails: Module not found: Can't resolve 'stream-chat-react')*
- `pnpm --filter frontend exec tsc --noEmit` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685df93922b4832685b5897921232908