### PR TITLE
Add StopAIGenerationButton placeholder

### DIFF
--- a/libs/stream-chat-shim/__tests__/StopAIGenerationButton.test.tsx
+++ b/libs/stream-chat-shim/__tests__/StopAIGenerationButton.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { StopAIGenerationButton } from '../src/components/MessageInput/StopAIGenerationButton'
+
+test('renders placeholder', () => {
+  const { getByTestId } = render(<StopAIGenerationButton />)
+  expect(getByTestId('stop-ai-generation-button')).toBeTruthy()
+})

--- a/libs/stream-chat-shim/src/components/MessageInput/StopAIGenerationButton.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/StopAIGenerationButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { CloseIcon } from './icons'
+
+export type StopAIGenerationButtonProps = React.ComponentProps<'button'>
+
+/**
+ * Placeholder implementation of the StopAIGenerationButton component.
+ */
+export const StopAIGenerationButton = ({ children, ...rest }: StopAIGenerationButtonProps) => (
+  <button
+    aria-label='Stop AI generation'
+    className='str-chat__stop-ai-generation-button'
+    data-testid='stop-ai-generation-button'
+    type='button'
+    {...rest}
+  >
+    {children || <CloseIcon />}
+  </button>
+)
+
+export default StopAIGenerationButton

--- a/libs/stream-chat-shim/src/components/MessageInput/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/index.ts
@@ -17,4 +17,5 @@ export * from './MessageInput';
 export * from './MessageInputFlat';
 export * from './QuotedMessagePreview';
 export * from './SendButton';
+export * from './StopAIGenerationButton';
 export { WithDragAndDropUpload } from './WithDragAndDropUpload';


### PR DESCRIPTION
## Summary
- add `StopAIGenerationButton` placeholder component
- export it from MessageInput index
- add a simple render test

## Testing
- `pnpm run build` *(fails: Missing script)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685df95371688326885d55186d799bc2