### PR TITLE
Port useCooldownTimer hook

### DIFF
--- a/libs/stream-chat-shim/__tests__/components_MessageInput_hooks_useCooldownTimer.test.tsx
+++ b/libs/stream-chat-shim/__tests__/components_MessageInput_hooks_useCooldownTimer.test.tsx
@@ -1,0 +1,12 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCooldownTimer } from '../src/components/MessageInput/hooks/useCooldownTimer';
+
+test('useCooldownTimer exposes cooldown state', () => {
+  const { result } = renderHook(() => useCooldownTimer());
+  expect(result.current.cooldownInterval).toBe(0);
+  expect(result.current.cooldownRemaining).toBeUndefined();
+  act(() => {
+    result.current.setCooldownRemaining(5);
+  });
+  expect(result.current.cooldownRemaining).toBe(5);
+});

--- a/libs/stream-chat-shim/src/components/MessageInput/hooks/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/hooks/index.ts
@@ -1,0 +1,6 @@
+export * from './useAttachmentManagerState';
+export * from './useCanCreatePoll';
+export * from './useCooldownTimer';
+export * from './useMessageInputControls';
+export * from './useMessageComposer';
+export * from './useMessageComposerHasSendableData';

--- a/libs/stream-chat-shim/src/components/MessageInput/hooks/useCooldownTimer.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/hooks/useCooldownTimer.tsx
@@ -1,0 +1,66 @@
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+/* TODO backend-wire-up: StreamChat import excised */
+import type { ChannelResponse } from 'stream-chat';
+
+import { useChannelStateContext, useChatContext } from '../../../context';
+
+export type CooldownTimerState = {
+  cooldownInterval: number;
+  setCooldownRemaining: React.Dispatch<React.SetStateAction<number | undefined>>;
+  cooldownRemaining?: number;
+};
+
+export const useCooldownTimer = (): CooldownTimerState => {
+  const { client, latestMessageDatesByChannels } = useChatContext('useCooldownTimer');
+  const { channel, messages = [] } = useChannelStateContext('useCooldownTimer');
+  const [cooldownRemaining, setCooldownRemaining] = useState<number>();
+
+  const { cooldown: cooldownInterval = 0, own_capabilities } = (channel.data ||
+    {}) as ChannelResponse;
+
+  const skipCooldown = own_capabilities?.includes('skip-slow-mode');
+
+  const ownLatestMessageDate = useMemo(
+    () =>
+      latestMessageDatesByChannels[channel.cid] ??
+      [...messages]
+        .sort(
+          (a, b) => (b.created_at as Date)?.getTime() - (a.created_at as Date)?.getTime(),
+        )
+        .find((v) => v.user?.id === client.user?.id)?.created_at,
+    [messages, client.user?.id, latestMessageDatesByChannels, channel.cid],
+  ) as Date;
+
+  useEffect(() => {
+    const timeSinceOwnLastMessage = ownLatestMessageDate
+      ? // prevent negative values
+        Math.max(0, (new Date().getTime() - ownLatestMessageDate.getTime()) / 1000)
+      : undefined;
+
+    const remaining =
+      !skipCooldown &&
+      typeof timeSinceOwnLastMessage !== 'undefined' &&
+      cooldownInterval > timeSinceOwnLastMessage
+        ? Math.round(cooldownInterval - timeSinceOwnLastMessage)
+        : 0;
+
+    setCooldownRemaining(remaining);
+
+    if (!remaining) return;
+
+    const timeout = setTimeout(() => {
+      setCooldownRemaining(0);
+    }, remaining * 1000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [cooldownInterval, ownLatestMessageDate, skipCooldown]);
+
+  return {
+    cooldownInterval,
+    cooldownRemaining,
+    setCooldownRemaining,
+  };
+};


### PR DESCRIPTION
## Summary
- port `useCooldownTimer` hook from Stream UI
- export hooks from `index.ts`
- add a render test

## Testing
- `pnpm -r build` *(fails: Can't resolve 'stream-chat-react')*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685df96c6628832691ce6dd361f1be94