### PR TITLE
Add MessageInput icon test

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageInput_icons.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageInput_icons.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  LoadingIndicatorIcon,
+  UploadIcon,
+  CloseIcon,
+  RetryIcon,
+  DownloadIcon,
+  LinkIcon,
+  SendIcon,
+  MicIcon,
+  BinIcon,
+  PauseIcon,
+  PlayIcon,
+  CheckSignIcon,
+} from '../src/components/MessageInput/icons';
+
+test('renders message input icons without crashing', () => {
+  render(
+    <>
+      <LoadingIndicatorIcon />
+      <UploadIcon />
+      <CloseIcon />
+      <RetryIcon />
+      <DownloadIcon />
+      <LinkIcon />
+      <SendIcon />
+      <MicIcon />
+      <BinIcon />
+      <PauseIcon />
+      <PlayIcon />
+      <CheckSignIcon />
+    </>,
+  );
+});


### PR DESCRIPTION
## Summary
- add render test for MessageInput icons

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df982342c8326a79a4fc3f97b1893