### PR TITLE
Add ConnectionStatus component port

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageList_ConnectionStatus.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageList_ConnectionStatus.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConnectionStatus } from '../src/components/MessageList/ConnectionStatus';
+
+test('renders without crashing', () => {
+  render(<ConnectionStatus />);
+});

--- a/libs/stream-chat-shim/src/components/MessageList/ConnectionStatus.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/ConnectionStatus.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+
+import type { Event } from 'chat-shim';
+
+import { CustomNotification } from './CustomNotification';
+import { useChatContext, useTranslationContext } from '../../context';
+
+const UnMemoizedConnectionStatus = () => {
+  const { client } = useChatContext('ConnectionStatus');
+  const { t } = useTranslationContext('ConnectionStatus');
+
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    const connectionChanged = ({ online: onlineStatus = false }: Event) => {
+      if (online !== onlineStatus) {
+        setOnline(onlineStatus);
+      }
+    };
+
+    client.on('connection.changed', connectionChanged);
+    return () => client.off('connection.changed', connectionChanged);
+  }, [client, online]);
+
+  return (
+    <CustomNotification
+      active={!online}
+      className='str-chat__connection-status-notification'
+      type='error'
+    >
+      {t('Connection failure, reconnecting now...')}
+    </CustomNotification>
+  );
+};
+
+export const ConnectionStatus = React.memo(UnMemoizedConnectionStatus);


### PR DESCRIPTION
## Summary
- port MessageList/ConnectionStatus from stream-chat-react
- add a smoke test

## Testing
- `pnpm -r run build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685df99196a88326b43b7d41da5b9e50