### PR TITLE
Add CustomNotification component

### DIFF
--- a/libs/stream-chat-shim/__tests__/CustomNotification.test.tsx
+++ b/libs/stream-chat-shim/__tests__/CustomNotification.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CustomNotification } from '../src/components/MessageList/CustomNotification';
+
+test('renders without crashing', () => {
+  render(
+    <CustomNotification active type="info" />
+  );
+});

--- a/libs/stream-chat-shim/src/components/MessageList/CustomNotification.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/CustomNotification.tsx
@@ -1,0 +1,36 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import clsx from 'clsx';
+
+export type CustomNotificationProps = {
+  type: string;
+  active?: boolean;
+  className?: string;
+};
+
+const UnMemoizedCustomNotification = (
+  props: PropsWithChildren<CustomNotificationProps>,
+) => {
+  const { active, children, className, type } = props;
+
+  if (!active) return null;
+
+  return (
+    <div
+      aria-live='polite'
+      className={clsx(
+        `str-chat__custom-notification notification-${type}`,
+        `str-chat__notification`,
+        `str-chat-react__notification`,
+        className,
+      )}
+      data-testid='custom-notification'
+    >
+      {children}
+    </div>
+  );
+};
+
+export const CustomNotification = React.memo(
+  UnMemoizedCustomNotification,
+) as typeof UnMemoizedCustomNotification;


### PR DESCRIPTION
## Summary
- port `CustomNotification` from stream-chat-react
- add a simple render test

## Testing
- `pnpm -r build` *(fails: module not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685df99eafd083268968a2c2ffadd1a2