### PR TITLE
Port GiphyPreviewMessage

### DIFF
--- a/libs/stream-chat-shim/__tests__/GiphyPreviewMessage.test.tsx
+++ b/libs/stream-chat-shim/__tests__/GiphyPreviewMessage.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { GiphyPreviewMessage } from '../src/components/MessageList/GiphyPreviewMessage';
+
+test('renders giphy preview message', () => {
+  const { container } = render(<GiphyPreviewMessage message={{} as any} />);
+  expect(container.querySelector('.giphy-preview-message')).toBeTruthy();
+});

--- a/libs/stream-chat-shim/src/components/MessageList/GiphyPreviewMessage.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/GiphyPreviewMessage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { Message } from '../Message/Message';
+// import type { LocalMessage } from 'stream-chat'; // TODO backend-wire-up
+type LocalMessage = any;
+
+export type GiphyPreviewMessageProps = {
+  message: LocalMessage;
+};
+
+export const GiphyPreviewMessage = (props: GiphyPreviewMessageProps) => {
+  const { message } = props;
+
+  return (
+    <div className='giphy-preview-message'>
+      <Message message={message} />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `GiphyPreviewMessage` from upstream
- add a basic render test

## Testing
- `pnpm -r build` *(fails: Module not found 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685df9a9ea688326a54f1a20f7047e0e