### PR TITLE
Add MessageListMainPanel component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageListMainPanel.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageListMainPanel.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageListMainPanel } from '../src/components/MessageList/MessageListMainPanel';
+
+test('renders without crashing', () => {
+  render(<MessageListMainPanel />);
+});

--- a/libs/stream-chat-shim/src/components/MessageList/MessageListMainPanel.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/MessageListMainPanel.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import type { PropsWithChildrenOnly } from '../../types/types';
+
+export const MESSAGE_LIST_MAIN_PANEL_CLASS =
+  'str-chat__main-panel-inner str-chat__message-list-main-panel' as const;
+
+export const MessageListMainPanel = ({ children }: PropsWithChildrenOnly) => (
+  <div className={MESSAGE_LIST_MAIN_PANEL_CLASS}>{children}</div>
+);


### PR DESCRIPTION
## Summary
- port `MessageListMainPanel` from Stream UI
- add a basic render test

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa1f8f7883268936916d91e83976