### PR TITLE
Port MessageNotification component

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageNotification.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageNotification.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageNotification } from '../src/components/MessageList/MessageNotification';
+
+test('renders without crashing', () => {
+  render(<MessageNotification onClick={() => {}} />);
+});

--- a/libs/stream-chat-shim/src/components/MessageList/MessageNotification.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/MessageNotification.tsx
@@ -1,0 +1,36 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+
+export type MessageNotificationProps = PropsWithChildren<{
+  /** button click event handler */
+  onClick: React.MouseEventHandler;
+  /** signals whether the message list is considered (below a threshold) to be scrolled to the bottom. Prop used only by [ScrollToBottomButton](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/ScrollToBottomButton.tsx) */
+  isMessageListScrolledToBottom?: boolean;
+  /** Whether or not to show notification. Prop used only by [MessageNotification](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/MessageNotification.tsx)  */
+  showNotification?: boolean;
+  /** informs the component whether it is rendered inside a thread message list */
+  threadList?: boolean;
+  /** */
+  unreadCount?: number;
+}>;
+
+const UnMemoizedMessageNotification = (props: MessageNotificationProps) => {
+  const { children, onClick, showNotification = true } = props;
+
+  if (!showNotification) return null;
+
+  return (
+    <button
+      aria-live='polite'
+      className={`str-chat__message-notification`}
+      data-testid='message-notification'
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const MessageNotification = React.memo(
+  UnMemoizedMessageNotification,
+) as typeof UnMemoizedMessageNotification;


### PR DESCRIPTION
## Summary
- port `MessageNotification` from stream-chat-react
- add sanity test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa3c00d883268b49eb5182f6d778