### PR TITLE
Add UnreadMessagesNotification component

### DIFF
--- a/libs/stream-chat-shim/__tests__/UnreadMessagesNotification.test.tsx
+++ b/libs/stream-chat-shim/__tests__/UnreadMessagesNotification.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { ChannelActionProvider } from '../src/⛔_legacy_ui/ChannelActionContext';
+import { UnreadMessagesNotification } from '../src/components/MessageList/UnreadMessagesNotification';
+
+describe('UnreadMessagesNotification', () => {
+  it('calls actions when buttons clicked', () => {
+    const jumpToFirstUnreadMessage = jest.fn();
+    const markRead = jest.fn();
+    const { getByText, getByTestId } = render(
+      <ChannelActionProvider jumpToFirstUnreadMessage={jumpToFirstUnreadMessage} markRead={markRead}>
+        <UnreadMessagesNotification showCount unreadCount={3} />
+      </ChannelActionProvider>
+    );
+
+    fireEvent.click(getByText('3 unread'));
+    expect(jumpToFirstUnreadMessage).toHaveBeenCalled();
+
+    fireEvent.click(getByTestId('unread-messages-notification').querySelector('button:last-child')!);
+    expect(markRead).toHaveBeenCalled();
+  });
+});

--- a/libs/stream-chat-shim/src/components/MessageList/UnreadMessagesNotification.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/UnreadMessagesNotification.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { CloseIcon } from './icons';
+import { useChannelActionContext, useTranslationContext } from '../../context';
+
+export type UnreadMessagesNotificationProps = {
+  /**
+   * Configuration parameter to determine the message page size, when jumping to the first unread message.
+   */
+  queryMessageLimit?: number;
+  /**
+   * Configuration parameter to determine, whether the unread count is to be shown on the component. Disabled by default.
+   */
+  showCount?: boolean;
+  /**
+   * The count of unread messages to be displayed if enabled.
+   */
+  unreadCount?: number;
+};
+
+export const UnreadMessagesNotification = ({
+  queryMessageLimit,
+  showCount,
+  unreadCount,
+}: UnreadMessagesNotificationProps) => {
+  const { jumpToFirstUnreadMessage, markRead } = useChannelActionContext(
+    'UnreadMessagesNotification',
+  );
+  const { t } = useTranslationContext('UnreadMessagesNotification');
+
+  return (
+    <div
+      className='str-chat__unread-messages-notification'
+      data-testid='unread-messages-notification'
+    >
+      <button onClick={() => jumpToFirstUnreadMessage(queryMessageLimit)}>
+        {unreadCount && showCount
+          ? t('{{count}} unread', { count: unreadCount ?? 0 })
+          : t('Unread messages')}
+      </button>
+      <button onClick={() => markRead()}>
+        <CloseIcon />
+      </button>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/MessageList/icons.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/icons.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface ArrowProps {
+  className?: string;
+  color?: string;
+}
+
+export const ArrowUp = ({ className, color }: ArrowProps) => (
+  <svg
+    className={className}
+    data-testid='arrow-up'
+    fill='none'
+    height='24'
+    viewBox='0 0 24 24'
+    width='24'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <path
+      d='M16.59 15.7051L12 11.1251L7.41 15.7051L6 14.2951L12 8.29508L18 14.2951L16.59 15.7051Z'
+      fill={color || 'var(--primary-color)'}
+    />
+  </svg>
+);
+
+export const ArrowDown = ({ className, color }: ArrowProps) => (
+  <svg
+    className={className}
+    data-testid='arrow-down'
+    fill='none'
+    height='24'
+    viewBox='0 0 24 24'
+    width='24'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <path
+      d='M7.41 8.29504L12 12.875L16.59 8.29504L18 9.70504L12 15.705L6 9.70504L7.41 8.29504Z'
+      fill={color || 'var(--primary-color)'}
+    />
+  </svg>
+);
+
+export const CloseIcon = () => (
+  <svg fill='currentColor' viewBox='0 0 14 13' xmlns='http://www.w3.org/2000/svg'>
+    <path d='M1.32227 12.3408C0.944336 11.9629 0.953125 11.3213 1.32227 10.9521L5.60254 6.66309L1.32227 2.38281C0.953125 2.01367 0.944336 1.37207 1.32227 0.994141C1.7002 0.616211 2.3418 0.625 2.71094 0.985352L7 5.27441L11.2803 0.994141C11.6494 0.625 12.291 0.616211 12.6689 0.994141C13.0469 1.37207 13.0381 2.01367 12.6689 2.38281L8.38867 6.66309L12.6689 10.9521C13.0381 11.3213 13.0469 11.9629 12.6689 12.3408C12.291 12.7188 11.6494 12.71 11.2803 12.3408L7 8.06055L2.71094 12.3408C2.3418 12.71 1.7002 12.7188 1.32227 12.3408Z' />
+  </svg>
+);

--- a/libs/stream-chat-shim/src/components/MessageList/index.ts
+++ b/libs/stream-chat-shim/src/components/MessageList/index.ts
@@ -1,0 +1,12 @@
+export * from './ConnectionStatus'; // TODO: export this under its own folder
+export * from './GiphyPreviewMessage';
+export * from './MessageList';
+export * from './MessageListNotifications';
+export * from './MessageNotification';
+export * from './ScrollToBottomButton';
+export * from './UnreadMessagesNotification';
+export * from './UnreadMessagesSeparator';
+export * from './VirtualizedMessageList';
+export * from './hooks';
+export * from './renderMessages';
+export * from './utils';


### PR DESCRIPTION
## Summary
- port UnreadMessagesNotification from stream-chat-react
- include MessageList icons and index barrel
- add tests for UnreadMessagesNotification

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa54762c83268af1f627c1f18661