### PR TITLE
Add UnreadMessagesSeparator component

### DIFF
--- a/libs/stream-chat-shim/__tests__/UnreadMessagesSeparator.test.tsx
+++ b/libs/stream-chat-shim/__tests__/UnreadMessagesSeparator.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { UnreadMessagesSeparator } from '../src/components/MessageList/UnreadMessagesSeparator';
+
+test('renders unread messages separator', () => {
+  render(<UnreadMessagesSeparator unreadCount={1} />);
+});

--- a/libs/stream-chat-shim/src/components/MessageList/UnreadMessagesSeparator.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/UnreadMessagesSeparator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslationContext } from '../../context';
+
+export const UNREAD_MESSAGE_SEPARATOR_CLASS = 'str-chat__unread-messages-separator';
+
+export type UnreadMessagesSeparatorProps = {
+  /**
+   * Configuration parameter to determine, whether the unread count is to be shown on the component. Disabled by default.
+   */
+  showCount?: boolean;
+  /**
+   * The count of unread messages to be displayed if enabled.
+   */
+  unreadCount?: number;
+};
+
+export const UnreadMessagesSeparator = ({
+  showCount,
+  unreadCount,
+}: UnreadMessagesSeparatorProps) => {
+  const { t } = useTranslationContext('UnreadMessagesSeparator');
+  return (
+    <div
+      className={UNREAD_MESSAGE_SEPARATOR_CLASS}
+      data-testid='unread-messages-separator'
+    >
+      {unreadCount && showCount
+        ? t('unreadMessagesSeparatorText', { count: unreadCount })
+        : t('Unread messages')}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `UnreadMessagesSeparator` from upstream
- add Jest test for the new component

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa60cd648326ab4fb3c9e678cf1c