### PR TITLE
Add MessageListNotifications from stream-ui

### DIFF
--- a/libs/stream-chat-shim/__tests__/MessageListNotifications.test.tsx
+++ b/libs/stream-chat-shim/__tests__/MessageListNotifications.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MessageListNotifications } from '../src/components/MessageList/MessageListNotifications';
+import { MessageNotification } from '../src/components/MessageList/MessageNotification';
+
+describe('MessageListNotifications', () => {
+  test('renders without crashing', () => {
+    render(
+      <MessageListNotifications
+        hasNewMessages={false}
+        isMessageListScrolledToBottom={true}
+        isNotAtLatestMessageSet={false}
+        MessageNotification={MessageNotification}
+        notifications={[]}
+        scrollToBottom={() => {}}
+      />
+    );
+  });
+});

--- a/libs/stream-chat-shim/src/components/MessageList/MessageListNotifications.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/MessageListNotifications.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { ConnectionStatus } from './ConnectionStatus';
+import { CustomNotification } from './CustomNotification';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+import { useNotifications } from '../Notifications/hooks/useNotifications';
+import type { MessageNotificationProps } from './MessageNotification';
+import type { ChannelNotifications } from '../../context/ChannelStateContext';
+
+const ClientNotifications = () => {
+  const clientNotifications = useNotifications();
+  const { t } = useTranslationContext();
+
+  return (
+    <>
+      {clientNotifications.map((notification) => (
+        <CustomNotification
+          active={true}
+          key={notification.id}
+          type={notification.severity}
+        >
+          {t('translationBuilderTopic/notification', { notification })}
+        </CustomNotification>
+      ))}
+    </>
+  );
+};
+
+export type MessageListNotificationsProps = {
+  hasNewMessages: boolean;
+  isMessageListScrolledToBottom: boolean;
+  isNotAtLatestMessageSet: boolean;
+  MessageNotification: React.ComponentType<MessageNotificationProps>;
+  notifications: ChannelNotifications;
+  scrollToBottom: () => void;
+  threadList?: boolean;
+  unreadCount?: number;
+};
+
+export const MessageListNotifications = (props: MessageListNotificationsProps) => {
+  const {
+    hasNewMessages,
+    isMessageListScrolledToBottom,
+    isNotAtLatestMessageSet,
+    MessageNotification,
+    notifications,
+    scrollToBottom,
+    threadList,
+    unreadCount,
+  } = props;
+
+  const { t } = useTranslationContext('MessageListNotifications');
+
+  return (
+    <div className='str-chat__list-notifications'>
+      {notifications.map((notification) => (
+        <CustomNotification active={true} key={notification.id} type={notification.type}>
+          {notification.text}
+        </CustomNotification>
+      ))}
+      <ClientNotifications />
+      <ConnectionStatus />
+      <MessageNotification
+        isMessageListScrolledToBottom={isMessageListScrolledToBottom}
+        onClick={scrollToBottom}
+        showNotification={hasNewMessages || isNotAtLatestMessageSet}
+        threadList={threadList}
+        unreadCount={unreadCount}
+      >
+        {isNotAtLatestMessageSet ? t('Latest Messages') : t('New Messages!')}
+      </MessageNotification>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `MessageListNotifications` component from upstream
- add a basic render test

## Testing
- `pnpm build` *(fails: Missing script 'build')*
- `pnpm -F frontend tsc --noEmit` *(fails: No 'tsc' script)*

------
https://chatgpt.com/codex/tasks/task_e_685dfef639c48326be7553b1573cb6ff