### PR TITLE
Add ModalHeader shim component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ModalHeader.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ModalHeader.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ModalHeader } from '../src/components/Modal/ModalHeader';
+
+test('renders without crashing', () => {
+  render(<ModalHeader title='Test Title' />);
+});

--- a/libs/stream-chat-shim/src/components/Modal/ModalHeader.tsx
+++ b/libs/stream-chat-shim/src/components/Modal/ModalHeader.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export type ModalHeaderProps = {
+  title: string;
+  className?: string;
+  close?: () => void;
+  goBack?: () => void;
+};
+
+export const ModalHeader = ({ className, close, goBack, title }: ModalHeaderProps) => (
+  <div className={clsx('str-chat__modal-header', className)}>
+    {goBack && (
+      <button className='str-chat__modal-header__go-back-button' onClick={goBack} />
+    )}
+    <div className='str-chat__modal-header__title'>{title}</div>
+    {close && <button className='str-chat__modal-header__close-button' onClick={close} />}
+  </div>
+);


### PR DESCRIPTION
## Summary
- port `ModalHeader` component from stream-chat-react
- add ModalHeader unit test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: missing `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685e023854fc8326904b89011e90caeb