### PR TITLE
Port Modal component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Modal.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Modal.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Modal } from '../src/components/Modal/Modal';
+
+test('renders without crashing', () => {
+  render(<Modal open={false} />);
+});

--- a/libs/stream-chat-shim/src/components/Modal/Modal.tsx
+++ b/libs/stream-chat-shim/src/components/Modal/Modal.tsx
@@ -1,0 +1,75 @@
+import clsx from 'clsx';
+import type { PropsWithChildren } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { FocusScope } from '@react-aria/focus';
+
+import { CloseIconRound } from './icons';
+
+import { useTranslationContext } from '../../context';
+
+export type ModalProps = {
+  /** If true, modal is opened or visible. */
+  open: boolean;
+  /** Custom class to be applied to the modal root div */
+  className?: string;
+  /** Callback handler for closing of modal. */
+  onClose?: (
+    event: React.KeyboardEvent | React.MouseEvent<HTMLButtonElement | HTMLDivElement>,
+  ) => void;
+};
+
+export const Modal = ({
+  children,
+  className,
+  onClose,
+  open,
+}: PropsWithChildren<ModalProps>) => {
+  const { t } = useTranslationContext('Modal');
+
+  const innerRef = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
+    const target = event.target as HTMLButtonElement | HTMLDivElement;
+    if (!innerRef.current || !closeRef.current) return;
+
+    if (!innerRef.current.contains(target) || closeRef.current.contains(target))
+      onClose?.(event);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose?.(event as unknown as React.KeyboardEvent);
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={clsx('str-chat__modal str-chat__modal--open', className)}
+      onClick={handleClick}
+    >
+      <FocusScope autoFocus contain>
+        <button
+          className='str-chat__modal__close-button'
+          ref={closeRef}
+          title={t('Close')}
+        >
+          <CloseIconRound />
+        </button>
+        <div
+          className='str-chat__modal__inner str-chat-react__modal__inner'
+          ref={innerRef}
+        >
+          {children}
+        </div>
+      </FocusScope>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Modal/icons.tsx
+++ b/libs/stream-chat-shim/src/components/Modal/icons.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export const CloseIconRound = () => (
+  <svg
+    data-testid='close-icon-round'
+    fill='none'
+    height='28'
+    viewBox='0 0 28 28'
+    width='28'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <rect fill='#72767E' height='28' rx='14' width='28' />
+    <circle cx='14' cy='14' fill='#72767E' r='12' />
+    <path
+      clipRule='evenodd'
+      d='M28 14C28 21.732 21.732 28 14 28C6.26801 28 0 21.732 0 14C0 6.26801 6.26801 0 14 0C21.732 0 28 6.26801 28 14ZM26 14C26 20.6274 20.6274 26 14 26C7.37258 26 2 20.6274 2 14C2 7.37258 7.37258 2 14 2C20.6274 2 26 7.37258 26 14ZM19.59 7L21 8.41L15.41 14L21 19.59L19.59 21L14 15.41L8.41 21L7 19.59L12.59 14L7 8.41L8.41 7L14 12.59L19.59 7Z'
+      fill='white'
+      fillRule='evenodd'
+    />
+  </svg>
+);

--- a/libs/stream-chat-shim/src/components/Modal/index.ts
+++ b/libs/stream-chat-shim/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export * from './Modal';


### PR DESCRIPTION
## Summary
- port `Modal` component from `stream-chat-react`
- include icons and index barrel
- add basic render test

## Testing
- `pnpm -r --if-present build` *(fails: Module not found: can't resolve 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e022b3b548326b6213d108a234d96