### PR TITLE
Add Poll component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Poll.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Poll.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Poll } from '../src/components/Poll/Poll';
+
+test('renders without crashing', () => {
+  render(<Poll poll={{ id: '1' } as any} />);
+});

--- a/libs/stream-chat-shim/src/components/Poll/Poll.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/Poll.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { PollContent as DefaultPollContent } from './PollContent';
+import { QuotedPoll as DefaultQuotedPoll } from './QuotedPoll';
+import { PollProvider, useComponentContext } from '../../context';
+import type { Poll as PollClass } from 'stream-chat';
+
+export const Poll = ({ isQuoted, poll }: { poll: PollClass; isQuoted?: boolean }) => {
+  const { PollContent = DefaultPollContent, QuotedPoll = DefaultQuotedPoll } =
+    useComponentContext();
+  return poll ? (
+    <PollProvider poll={poll}>{isQuoted ? <QuotedPoll /> : <PollContent />}</PollProvider>
+  ) : null;
+};


### PR DESCRIPTION
## Summary
- port `Poll` component from stream-chat-react
- add a basic render test for `Poll`

## Testing
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find name 'LinkPreviewsManagerState')*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685e025202a0832685613c6704cd586a