### PR TITLE
Port AddCommentForm component

### DIFF
--- a/libs/stream-chat-shim/__tests__/AddCommentForm.test.tsx
+++ b/libs/stream-chat-shim/__tests__/AddCommentForm.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AddCommentForm } from '../src/components/Poll/PollActions/AddCommentForm';
+
+test('renders without crashing', () => {
+  render(<AddCommentForm close={() => {}} messageId="1" />);
+});

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/AddCommentForm.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/AddCommentForm.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { FormDialog } from '../../Dialog/FormDialog';
+// import { useStateStore } from '../../../store'; // TODO backend-wire-up
+const useStateStore = (_store: any, selector: any) => selector({});
+import { usePollContext, useTranslationContext } from '../../../context';
+// import type { PollAnswer, PollState } from 'stream-chat'; // TODO backend-wire-up
+import type { PollAnswer, PollState } from 'chat-shim';
+
+type PollStateSelectorReturnValue = { ownAnswer: PollAnswer | undefined };
+const pollStateSelector = (nextValue: PollState): PollStateSelectorReturnValue => ({
+  ownAnswer: nextValue.ownAnswer,
+});
+
+export type AddCommentFormProps = {
+  close: () => void;
+  messageId: string;
+};
+
+export const AddCommentForm = ({ close, messageId }: AddCommentFormProps) => {
+  const { t } = useTranslationContext('AddCommentForm');
+
+  const { poll } = usePollContext();
+  const { ownAnswer } = useStateStore(poll.state, pollStateSelector);
+
+  return (
+    <FormDialog<{ comment: '' }>
+      className='str-chat__prompt-dialog str-chat__modal__poll-add-comment'
+      close={close}
+      fields={{
+        comment: {
+          element: 'input',
+          props: {
+            id: 'comment',
+            name: 'comment',
+            required: true,
+            type: 'text',
+            value: ownAnswer?.answer_text ?? '',
+          },
+        },
+      }}
+      onSubmit={async (value) => {
+        await /* TODO backend-wire-up: poll.addAnswer */ Promise.resolve(undefined);
+      }}
+      shouldDisableSubmitButton={(value) =>
+        !value.comment || value.comment === ownAnswer?.answer_text
+      }
+      title={ownAnswer ? t('Update your comment') : t('Add a comment')}
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/index.ts
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/index.ts
@@ -1,0 +1,7 @@
+export * from './AddCommentForm';
+export * from './EndPollDialog';
+export * from './PollActions';
+export * from './PollAnswerList';
+export * from './PollOptionsFullList';
+export * from './PollResults';
+export * from './SuggestPollOptionForm';


### PR DESCRIPTION
## Summary
- port `AddCommentForm` from `stream-chat-react`
- export from `PollActions` barrel
- add basic render test for `AddCommentForm`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e025d439883269d69b610459e151d