### PR TITLE
Port EndPollDialog component

### DIFF
--- a/libs/stream-chat-shim/__tests__/EndPollDialog.test.tsx
+++ b/libs/stream-chat-shim/__tests__/EndPollDialog.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { EndPollDialog } from '../src/components/Poll/PollActions/EndPollDialog';
+
+describe('EndPollDialog', () => {
+  test('renders without crashing', () => {
+    render(<EndPollDialog close={() => {}} />);
+  });
+});

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/EndPollDialog.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/EndPollDialog.tsx
@@ -1,0 +1,35 @@
+import { PromptDialog } from '../../Dialog/PromptDialog';
+import React from 'react';
+// import { usePollContext, useTranslationContext } from '../../../context'; // TODO backend-wire-up
+const usePollContext = () => ({ poll: { close: () => {} } } as any); // temporary shim
+const useTranslationContext = (_componentName?: string) => ({ t: (s: string) => s }); // temporary shim
+
+export type EndPollDialogProps = {
+  close: () => void;
+};
+
+export const EndPollDialog = ({ close }: EndPollDialogProps) => {
+  const { t } = useTranslationContext('SuggestPollOptionForm');
+  const { poll } = usePollContext();
+
+  return (
+    <PromptDialog
+      actions={[
+        {
+          children: t('Cancel'),
+          className: 'str-chat__dialog__controls-button--cancel',
+          onClick: close,
+        },
+        {
+          children: t('End'),
+          className:
+            'str-chat__dialog__controls-button--submit str-chat__dialog__controls-button--end-poll',
+          onClick: poll.close,
+        },
+      ]}
+      className='str-chat__modal__end-vote'
+      prompt={t('Nobody will be able to vote in this poll anymore.')}
+      title={t('End vote')}
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/PollResults/index.ts
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/PollResults/index.ts
@@ -1,0 +1,1 @@
+// export * from './PollResults'; // TODO backend-wire-up

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/index.ts
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/index.ts
@@ -1,0 +1,7 @@
+// export * from './AddCommentForm'; // TODO backend-wire-up
+export * from './EndPollDialog';
+// export * from './PollActions'; // TODO backend-wire-up
+// export * from './PollAnswerList'; // TODO backend-wire-up
+// export * from './PollOptionsFullList'; // TODO backend-wire-up
+// export * from './PollResults'; // TODO backend-wire-up
+// export * from './SuggestPollOptionForm'; // TODO backend-wire-up


### PR DESCRIPTION
## Summary
- port `EndPollDialog` from upstream
- add shim index files for Poll actions
- add a simple render test

## Testing
- `pnpm -r build` *(fails: next not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e026722dc8326841ad2e3bfc975d5