### PR TITLE
Port PollOptionWithVotesHeader component

### DIFF
--- a/libs/stream-chat-shim/__tests__/PollOptionWithVotesHeader.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PollOptionWithVotesHeader.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { PollOptionWithVotesHeader } from '../src/PollOptionWithVotesHeader'
+import { PollOptionWithVotesHeader } from '../src/components/Poll/PollActions/PollResults/PollOptionWithVotesHeader'
 
-test('renders placeholder', () => {
+test('renders without crashing', () => {
   const { getByTestId } = render(
     <PollOptionWithVotesHeader option={{ id: '1', text: 'Opt' } as any} />
   )

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/PollResults/PollOptionWithVotesHeader.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/PollResults/PollOptionWithVotesHeader.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useStateStore } from '../../../../store';
+import { usePollContext, useTranslationContext } from '../../../../context';
+import type { PollOption, PollState } from 'chat-shim';
+
+type PollStateSelectorReturnValue = {
+  maxVotedOptionIds: string[];
+  vote_counts_by_option: Record<string, number>;
+};
+const pollStateSelector = (nextValue: PollState): PollStateSelectorReturnValue => ({
+  maxVotedOptionIds: nextValue.maxVotedOptionIds,
+  vote_counts_by_option: nextValue.vote_counts_by_option,
+});
+
+export type PollResultOptionVoteCounterProps = {
+  optionId: string;
+};
+
+export const PollResultOptionVoteCounter = ({
+  optionId,
+}: PollResultOptionVoteCounterProps) => {
+  const { t } = useTranslationContext();
+  const { poll } = usePollContext();
+  const { maxVotedOptionIds, vote_counts_by_option } = useStateStore(
+    poll.state,
+    pollStateSelector,
+  );
+
+  return (
+    <div className='str-chat__poll-result-option-vote-counter'>
+      {maxVotedOptionIds.length === 1 && maxVotedOptionIds[0] === optionId && (
+        <div className='str-chat__poll-result-winning-option-icon' />
+      )}
+      <span className='str-chat__poll-result-option-vote-count'>
+        {t('{{count}} votes', { count: vote_counts_by_option[optionId] ?? 0 })}
+      </span>
+    </div>
+  );
+};
+
+export type PollOptionWithVotesHeaderProps = {
+  option: PollOption;
+};
+
+export const PollOptionWithVotesHeader = ({ option }: PollOptionWithVotesHeaderProps) => (
+  <div className='str-chat__poll-option__header'>
+    <div className='str-chat__poll-option__option-text'>{option.text}</div>
+    <PollResultOptionVoteCounter optionId={option.id} />
+  </div>
+);


### PR DESCRIPTION
## Summary
- port `PollOptionWithVotesHeader` component from Stream upstream
- adjust associated test to load the new component

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685e02d154488326b19dc3afc700e1b3