### PR TITLE
Port PollOptionSelector component

### DIFF
--- a/libs/stream-chat-shim/__tests__/PollOptionSelector.test.tsx
+++ b/libs/stream-chat-shim/__tests__/PollOptionSelector.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { PollOptionSelector } from '../src/PollOptionSelector';
+import { PollOptionSelector } from '../src/components/Poll/PollOptionSelector';
 
-test('renders placeholder', () => {
-  const { getByTestId } = render(
-    <PollOptionSelector option={{} as any} />,
-  );
-  expect(getByTestId('poll-option-selector-placeholder')).toBeTruthy();
+test('renders without crashing', () => {
+  render(<PollOptionSelector option={{ id: '1', poll_id: '', text: '' }} />);
 });

--- a/libs/stream-chat-shim/src/components/Poll/PollOptionSelector.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollOptionSelector.tsx
@@ -1,0 +1,159 @@
+import clsx from 'clsx';
+import debounce from 'lodash.debounce';
+import React, { useMemo } from 'react';
+// import { isVoteAnswer } from 'stream-chat'; // TODO backend-wire-up
+import { isVoteAnswer } from 'chat-shim';
+import { Avatar } from '../Avatar';
+// import {
+//   useChannelStateContext,
+//   useMessageContext,
+//   usePollContext,
+//   useTranslationContext,
+// } from '../../context'; // TODO backend-wire-up
+const useChannelStateContext = (_?: string) => ({ channelCapabilities: {} });
+const useMessageContext = () => ({ message: { id: '' } });
+const usePollContext = () => ({ poll: { state: {} as PollState } });
+const useTranslationContext = () => ({ t: (s: string, _?: any) => s });
+// import { useStateStore } from '../../store'; // TODO backend-wire-up
+const useStateStore = (_store: any, _selector: any) => ({
+  is_closed: false,
+  latest_votes_by_option: {} as Record<string, PollVote[]>,
+  maxVotedOptionIds: [] as string[],
+  ownVotesByOptionId: {} as Record<string, PollVote>,
+  vote_counts_by_option: {} as Record<string, number>,
+  voting_visibility: undefined as VotingVisibility | undefined,
+});
+// import type { PollOption, PollState, PollVote, VotingVisibility } from 'stream-chat'; // TODO backend-wire-up
+import type { PollOption, PollState, PollVote, VotingVisibility } from 'chat-shim';
+
+export type AmountBarProps = {
+  amount: number;
+  className?: string;
+};
+
+export const AmountBar = ({ amount, className }: AmountBarProps) => (
+  <div
+    className={clsx('str-chat__amount-bar', className)}
+    data-testid='amount-bar'
+    role='progressbar'
+    style={{
+      '--str-chat__amount-bar-fulfillment': amount + '%',
+    } as React.CSSProperties}
+  />
+);
+
+export type CheckmarkProps = { checked?: boolean };
+
+export const Checkmark = ({ checked }: CheckmarkProps) => (
+  <div className={clsx('str-chat__checkmark', { 'str-chat__checkmark--checked': checked })} />
+);
+
+type PollStateSelectorReturnValue = {
+  is_closed: boolean | undefined;
+  latest_votes_by_option: Record<string, PollVote[]>;
+  maxVotedOptionIds: string[];
+  ownVotesByOptionId: Record<string, PollVote>;
+  vote_counts_by_option: Record<string, number>;
+  voting_visibility: VotingVisibility | undefined;
+};
+const pollStateSelector = (nextValue: PollState): PollStateSelectorReturnValue => ({
+  is_closed: nextValue.is_closed,
+  latest_votes_by_option: nextValue.latest_votes_by_option,
+  maxVotedOptionIds: nextValue.maxVotedOptionIds,
+  ownVotesByOptionId: nextValue.ownVotesByOptionId,
+  vote_counts_by_option: nextValue.vote_counts_by_option,
+  voting_visibility: nextValue.voting_visibility,
+});
+
+export type PollOptionSelectorProps = {
+  option: PollOption;
+  displayAvatarCount?: number;
+  voteCountVerbose?: boolean;
+};
+
+export const PollOptionSelector = ({
+  displayAvatarCount,
+  option,
+  voteCountVerbose,
+}: PollOptionSelectorProps) => {
+  const { t } = useTranslationContext();
+  const { channelCapabilities = {} } = useChannelStateContext('PollOptionsShortlist');
+  const { message } = useMessageContext();
+
+  const { poll } = usePollContext();
+  const {
+    is_closed,
+    latest_votes_by_option,
+    maxVotedOptionIds,
+    ownVotesByOptionId,
+    vote_counts_by_option,
+    voting_visibility,
+  } = useStateStore(poll.state, pollStateSelector);
+  const canCastVote = channelCapabilities['cast-poll-vote'] && !is_closed;
+  const winningOptionCount = maxVotedOptionIds[0]
+    ? vote_counts_by_option[maxVotedOptionIds[0]]
+    : 0;
+
+  const toggleVote = useMemo(
+    () =>
+      debounce(() => {
+        if (!canCastVote) return;
+        const haveVotedForTheOption = !!ownVotesByOptionId[option.id];
+        return haveVotedForTheOption
+          ? poll.removeVote(ownVotesByOptionId[option.id].id, message.id)
+          : poll.castVote(option.id, message.id);
+      }, 100),
+    [canCastVote, message.id, option.id, ownVotesByOptionId, poll],
+  );
+
+  return (
+    <div
+      className={clsx('str-chat__poll-option', {
+        'str-chat__poll-option--votable': canCastVote,
+      })}
+      key={`base-poll-option-${option.id}`}
+      onClick={toggleVote}
+    >
+      {canCastVote && <Checkmark checked={!!ownVotesByOptionId[option.id]} />}
+      <div className='str-chat__poll-option-data'>
+        <p className='str-chat__poll-option-text'>{option.text}</p>
+        {displayAvatarCount && voting_visibility === 'public' && (
+          <div className='str-chat__poll-option-voters'>
+            {latest_votes_by_option?.[option.id] &&
+              (latest_votes_by_option[option.id] as PollVote[])
+                .filter((vote) => !!vote.user && !isVoteAnswer(vote))
+                .slice(0, displayAvatarCount)
+                .map(({ user }) => (
+                  <Avatar
+                    image={user?.image}
+                    key={`poll-option-${option.id}-avatar-${user?.id}`}
+                    name={user?.name}
+                  />
+                ))}
+          </div>
+        )}
+        <div className='str-chat__poll-option-vote-count'>
+          {voteCountVerbose
+            ? t('{{count}} votes', {
+                count: vote_counts_by_option[option.id] ?? 0,
+              })
+            : vote_counts_by_option[option.id] ?? 0}
+        </div>
+      </div>
+      <AmountBar
+        amount={
+          (winningOptionCount &&
+            (vote_counts_by_option[option.id] ?? 0) / winningOptionCount) * 100
+        }
+        className={clsx('str-chat__poll-option__votes-bar', {
+          'str-chat__poll-option__votes-bar--winner':
+            is_closed &&
+            maxVotedOptionIds.length === 1 &&
+            maxVotedOptionIds[0] === option.id,
+        })}
+      />
+    </div>
+  );
+};
+
+export default PollOptionSelector;

--- a/libs/stream-chat-shim/src/components/Poll/index.ts
+++ b/libs/stream-chat-shim/src/components/Poll/index.ts
@@ -1,3 +1,4 @@
 
 export * from './PollOptionList';
+export * from './PollOptionSelector';
 // TODO backend-wire-up: export other Poll components when ported


### PR DESCRIPTION
## Summary
- port `PollOptionSelector` from upstream into the shim
- update index barrel to export it
- adjust tests for the new component

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e09190d9c832695ef7fb212c068a0