### PR TITLE
Add ReactionSelectorWithButton component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ReactionSelectorWithButton.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ReactionSelectorWithButton.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ReactionSelectorWithButton } from '../src/components/Reactions/ReactionSelectorWithButton';
+
+test('renders without crashing', () => {
+  const Icon = () => <span />;
+  render(<ReactionSelectorWithButton ReactionIcon={Icon} />);
+});

--- a/libs/stream-chat-shim/src/components/Reactions/ReactionSelectorWithButton.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/ReactionSelectorWithButton.tsx
@@ -1,0 +1,55 @@
+import type { ElementRef } from 'react';
+import React, { useRef } from 'react';
+import { ReactionSelector as DefaultReactionSelector } from './ReactionSelector';
+import { DialogAnchor, useDialog, useDialogIsOpen } from '../Dialog';
+import {
+  useComponentContext,
+  useMessageContext,
+  useTranslationContext,
+} from '../../context';
+
+import type { IconProps } from '../../types/types';
+
+type ReactionSelectorWithButtonProps = {
+  /* Custom component rendering the icon used in a button invoking reactions selector for a given message. */
+  ReactionIcon: React.ComponentType<IconProps>;
+};
+
+/**
+ * Internal convenience component - not to be exported. It just groups the button and the dialog anchor and thus prevents
+ * cluttering the parent component.
+ */
+export const ReactionSelectorWithButton = ({
+  ReactionIcon,
+}: ReactionSelectorWithButtonProps) => {
+  const { t } = useTranslationContext('ReactionSelectorWithButton');
+  const { isMyMessage, message } = useMessageContext('MessageOptions');
+  const { ReactionSelector = DefaultReactionSelector } =
+    useComponentContext('MessageOptions');
+  const buttonRef = useRef<ElementRef<'button'>>(null);
+  const dialogId = `reaction-selector--${message.id}`;
+  const dialog = useDialog({ id: dialogId });
+  const dialogIsOpen = useDialogIsOpen(dialogId);
+  return (
+    <>
+      <DialogAnchor
+        id={dialogId}
+        placement={isMyMessage() ? 'top-end' : 'top-start'}
+        referenceElement={buttonRef.current}
+        trapFocus
+      >
+        <ReactionSelector />
+      </DialogAnchor>
+      <button
+        aria-expanded={dialogIsOpen}
+        aria-label={t('aria/Open Reaction Selector')}
+        className='str-chat__message-reactions-button'
+        data-testid='message-reaction-action'
+        onClick={() => dialog?.toggle()}
+        ref={buttonRef}
+      >
+        <ReactionIcon className='str-chat__message-action-icon' />
+      </button>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- port ReactionSelectorWithButton from stream-chat-react
- add basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e0a6b577c8326a0c311510018a004