### PR TITLE
Add QuotedPoll component

### DIFF
--- a/libs/stream-chat-shim/__tests__/components_Poll_QuotedPoll.test.tsx
+++ b/libs/stream-chat-shim/__tests__/components_Poll_QuotedPoll.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { QuotedPoll } from '../src/components/Poll/QuotedPoll';
+
+test('renders without crashing', () => {
+  render(<QuotedPoll />);
+});

--- a/libs/stream-chat-shim/src/components/Poll/QuotedPoll.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/QuotedPoll.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+import React from 'react';
+// import { usePollContext } from '../../context'; // TODO backend-wire-up
+const usePollContext = () => ({ poll: { state: {} as PollState } } as any);
+// import { useStateStore } from '../../store'; // TODO backend-wire-up
+const useStateStore = (_store: any, _selector: any) => ({
+  is_closed: false,
+  name: '',
+});
+import type { PollState } from 'chat-shim';
+
+type PollStateSelectorQuotedPollReturnValue = {
+  is_closed: boolean | undefined;
+  name: string;
+};
+const pollStateSelectorQuotedPoll = (
+  nextValue: PollState,
+): PollStateSelectorQuotedPollReturnValue => ({
+  is_closed: nextValue.is_closed,
+  name: nextValue.name,
+});
+
+export const QuotedPoll = () => {
+  const { poll } = usePollContext();
+  const { is_closed, name } = useStateStore(
+    poll.state,
+    pollStateSelectorQuotedPoll,
+  );
+
+  return (
+    <div
+      className={clsx('str-chat__quoted-poll-preview', {
+        'str-chat__quoted-poll-preview--closed': is_closed,
+      })}
+    >
+      <div className='str-chat__quoted-poll-preview__icon'>📊</div>
+      <div className='str-chat__quoted-poll-preview__name'>{name}</div>
+    </div>
+  );
+};
+
+export default QuotedPoll;


### PR DESCRIPTION
## Summary
- port QuotedPoll from Stream
- add a simple render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685e09358fd88326826982bc45c61a14