### PR TITLE
Port ReactionSelector component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ReactionSelector.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ReactionSelector.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ReactionSelector } from '../src/components/Reactions/ReactionSelector';
+
+test('renders without crashing', () => {
+  render(<ReactionSelector />);
+});

--- a/libs/stream-chat-shim/src/components/Reactions/ReactionSelector.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/ReactionSelector.tsx
@@ -1,0 +1,242 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+import { Avatar as DefaultAvatar } from '../Avatar';
+import { useDialog } from '../Dialog';
+import { defaultReactionOptions } from './reactionOptions';
+import { isMutableRef } from './utils/utils';
+
+// import { useComponentContext } from '../../context/ComponentContext'; // TODO backend-wire-up
+const useComponentContext = () => ({} as any); // temporary shim
+// import { useMessageContext } from '../../context/MessageContext'; // TODO backend-wire-up
+const useMessageContext = () =>
+  ({
+    closeReactionSelectorOnClick: false,
+    handleReaction: async () => {},
+    message: { id: 'placeholder' },
+  } as any); // temporary shim
+
+import type { ReactionGroupResponse, ReactionResponse } from 'chat-shim';
+import type { AvatarProps } from '../Avatar';
+
+import type { ReactionOptions } from './reactionOptions';
+
+export type ReactionSelectorProps = {
+  /** Custom UI component to display user avatar, defaults to and accepts same props as: [Avatar](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Avatar/Avatar.tsx) */
+  Avatar?: React.ElementType<AvatarProps>;
+  /** If true, shows the user's avatar with the reaction */
+  detailedView?: boolean;
+  /** Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`) */
+  handleReaction?: (
+    reactionType: string,
+    event: React.BaseSyntheticEvent,
+  ) => Promise<void>;
+  /** An array of the reaction objects to display in the list */
+  latest_reactions?: ReactionResponse[];
+  /** An array of the own reaction objects to distinguish own reactions visually */
+  own_reactions?: ReactionResponse[];
+  /**
+   * An object that keeps track of the count of each type of reaction on a message
+   * @deprecated This override value is no longer taken into account. Use `reaction_groups` to override reaction counts instead.
+   * */
+  reaction_counts?: Record<string, number>;
+  /** An object containing summary for each reaction type on a message */
+  reaction_groups?: Record<string, ReactionGroupResponse>;
+  /**
+   * @deprecated
+   * A list of the currently supported reactions on a message
+   * */
+  reactionOptions?: ReactionOptions;
+  /** If true, adds a CSS class that reverses the horizontal positioning of the selector */
+  reverse?: boolean;
+};
+
+const UnMemoizedReactionSelector = (props: ReactionSelectorProps) => {
+  const {
+    Avatar: propAvatar,
+    detailedView = true,
+    handleReaction: propHandleReaction,
+    latest_reactions: propLatestReactions,
+    own_reactions: propOwnReactions,
+    reaction_groups: propReactionGroups,
+    reactionOptions: propReactionOptions,
+    reverse = false,
+  } = props;
+
+  const {
+    Avatar: contextAvatar,
+    reactionOptions: contextReactionOptions = defaultReactionOptions,
+  } = useComponentContext('ReactionSelector');
+  const {
+    closeReactionSelectorOnClick,
+    handleReaction: contextHandleReaction,
+    message,
+  } = useMessageContext('ReactionSelector');
+  const dialogId = `reaction-selector--${message.id}`;
+  const dialog = useDialog({ id: dialogId });
+  const reactionOptions = propReactionOptions ?? contextReactionOptions;
+
+  const Avatar = propAvatar || contextAvatar || DefaultAvatar;
+  const handleReaction = propHandleReaction || contextHandleReaction;
+  const latestReactions = propLatestReactions || message?.latest_reactions || [];
+  const ownReactions = propOwnReactions || message?.own_reactions || [];
+  const reactionGroups = propReactionGroups || message?.reaction_groups || {};
+
+  const [tooltipReactionType, setTooltipReactionType] = useState<string | null>(null);
+  const [tooltipPositions, setTooltipPositions] = useState<{
+    arrow: number;
+    tooltip: number;
+  } | null>(null);
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+
+  const showTooltip = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>, reactionType: string) => {
+      targetRef.current = event.currentTarget;
+      setTooltipReactionType(reactionType);
+    },
+    [],
+  );
+
+  const hideTooltip = useCallback(() => {
+    setTooltipReactionType(null);
+    setTooltipPositions(null);
+  }, []);
+
+  useEffect(() => {
+    if (!tooltipReactionType || !rootRef.current) return;
+    const tooltip = tooltipRef.current?.getBoundingClientRect();
+    const target = targetRef.current?.getBoundingClientRect();
+
+    const container = isMutableRef(rootRef)
+      ? rootRef.current?.getBoundingClientRect()
+      : null;
+
+    if (!tooltip || !target || !container) return;
+
+    const tooltipPosition =
+      tooltip.width === container.width || tooltip.x < container.x
+        ? 0
+        : target.left + target.width / 2 - container.left - tooltip.width / 2;
+
+    const arrowPosition = target.x - tooltip.x + target.width / 2 - tooltipPosition;
+
+    setTooltipPositions({
+      arrow: arrowPosition,
+      tooltip: tooltipPosition,
+    });
+  }, [tooltipReactionType, rootRef]);
+
+  const getUsersPerReactionType = (type: string | null) =>
+    latestReactions
+      .map((reaction) => {
+        if (reaction.type === type) {
+          return reaction.user?.name || reaction.user?.id;
+        }
+        return null;
+      })
+      .filter(Boolean);
+
+  const iHaveReactedWithReaction = (reactionType: string) =>
+    ownReactions.find((reaction) => reaction.type === reactionType);
+
+  const getLatestUserForReactionType = (type: string | null) =>
+    latestReactions.find((reaction) => reaction.type === type && !!reaction.user)?.user ||
+    undefined;
+
+  return (
+    <div
+      className={clsx(
+        'str-chat__reaction-selector str-chat__message-reaction-selector str-chat-react__message-reaction-selector',
+        {
+          'str-chat__reaction-selector--reverse': reverse,
+        },
+      )}
+      data-testid='reaction-selector'
+      ref={rootRef}
+    >
+      {!!tooltipReactionType && detailedView && (
+        <div
+          className='str-chat__reaction-selector-tooltip'
+          ref={tooltipRef}
+          style={{
+            left: tooltipPositions?.tooltip,
+            visibility: tooltipPositions ? 'visible' : 'hidden',
+          }}
+        >
+          <div className='arrow' style={{ left: tooltipPositions?.arrow }} />
+          {getUsersPerReactionType(tooltipReactionType)?.map((user, i, users) => (
+            <span className='latest-user-username' key={`key-${i}-${user}`}>
+              {`${user}${i < users.length - 1 ? ', ' : ''}`}
+            </span>
+          ))}
+        </div>
+      )}
+      <ul className='str-chat__message-reactions-list str-chat__message-reactions-options'>
+        {reactionOptions.map(({ Component, name: reactionName, type: reactionType }) => {
+          const latestUser = getLatestUserForReactionType(reactionType);
+          const count = reactionGroups[reactionType]?.count ?? 0;
+          return (
+            <li key={reactionType}>
+              <button
+                aria-label={`Select Reaction: ${reactionName || reactionType}`}
+                className={clsx(
+                  'str-chat__message-reactions-list-item str-chat__message-reactions-option',
+                  {
+                    'str-chat__message-reactions-option-selected':
+                      iHaveReactedWithReaction(reactionType),
+                  },
+                )}
+                data-testid='select-reaction-button'
+                data-text={reactionType}
+                onClick={(event) => {
+                  handleReaction(reactionType, event);
+                  if (closeReactionSelectorOnClick) {
+                    dialog.close();
+                  }
+                }}
+              >
+                {!!count && detailedView && (
+                  <div
+                    className='latest-user str-chat__message-reactions-last-user'
+                    onClick={hideTooltip}
+                    onMouseEnter={(e) => showTooltip(e, reactionType)}
+                    onMouseLeave={hideTooltip}
+                  >
+                    {latestUser ? (
+                      <Avatar
+                        image={latestUser.image}
+                        name={latestUser.name}
+                        size={20}
+                        user={latestUser}
+                      />
+                    ) : (
+                      <div className='latest-user-not-found' />
+                    )}
+                  </div>
+                )}
+                <span className='str-chat__message-reaction-emoji'>
+                  <Component />
+                </span>
+                {Boolean(count) && detailedView && (
+                  <span className='str-chat__message-reactions-list-item__count'>
+                    {count || ''}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+/**
+ * Component that allows a user to select a reaction.
+ */
+export const ReactionSelector = React.memo(
+  UnMemoizedReactionSelector,
+) as typeof UnMemoizedReactionSelector;

--- a/libs/stream-chat-shim/src/components/Reactions/SpriteImage.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/SpriteImage.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+
+import { getImageDimensions } from './utils/utils';
+
+export type SpriteImageProps = {
+  columns: number;
+  position: [number, number];
+  rows: number;
+  spriteUrl: string;
+  fallback?: React.ReactNode;
+  height?: number;
+  style?: React.CSSProperties;
+  width?: number;
+};
+
+export const SpriteImage = ({
+  columns,
+  fallback,
+  height,
+  position,
+  rows,
+  spriteUrl,
+  style,
+  width,
+}: SpriteImageProps) => {
+  const [[spriteWidth, spriteHeight], setSpriteDimensions] = useState([0, 0]);
+
+  useEffect(() => {
+    getImageDimensions(spriteUrl).then(setSpriteDimensions).catch(console.error);
+  }, [spriteUrl]);
+
+  const [x, y] = position;
+
+  if (!spriteHeight || !spriteWidth) return <>{fallback}</>;
+
+  return (
+    <div
+      data-testid='sprite-image'
+      style={
+        {
+          ...style,
+          '--str-chat__sprite-image-resize-ratio':
+            'var(--str-chat__sprite-image-resize-ratio-x, var(--str-chat__sprite-image-resize-ratio-y, 1))',
+          '--str-chat__sprite-image-resize-ratio-x':
+            'calc(var(--str-chat__sprite-image-width) / var(--str-chat__sprite-item-width))',
+          '--str-chat__sprite-image-resize-ratio-y':
+            'calc(var(--str-chat__sprite-image-height) / var(--str-chat__sprite-item-height))',
+          '--str-chat__sprite-item-height': `${spriteHeight / rows}`,
+          '--str-chat__sprite-item-width': `${spriteWidth / columns}`,
+          ...(Number.isFinite(height)
+            ? { '--str-chat__sprite-image-height': `${height}px` }
+            : {}),
+          ...(Number.isFinite(width)
+            ? { '--str-chat__sprite-image-width': `${width}px` }
+            : {}),
+          backgroundImage: `url('${spriteUrl}')`,
+          backgroundPosition: `${x * (100 / (columns - 1))}% ${y * (100 / (rows - 1))}%`,
+          backgroundSize: `${columns * 100}% ${rows * 100}%`,
+          height:
+            'var(--str-chat__sprite-image-height, calc(var(--str-chat__sprite-item-height) * var(--str-chat__sprite-image-resize-ratio)))',
+          width:
+            'var(--str-chat__sprite-image-width, calc(var(--str-chat__sprite-item-width) * var(--str-chat__sprite-image-resize-ratio)))',
+        } as React.CSSProperties
+      }
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/Reactions/StreamEmoji.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/StreamEmoji.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import type { SpriteImageProps } from './SpriteImage';
+import { SpriteImage } from './SpriteImage';
+
+import type { Readable } from '../../types/types';
+
+const StreamSpriteEmojiPositions = {
+  angry: [1, 1],
+  haha: [1, 0],
+  like: [0, 0],
+  love: [1, 2],
+  sad: [0, 1],
+  wow: [0, 2],
+};
+
+type StreamEmojiType = keyof typeof StreamSpriteEmojiPositions;
+
+const STREAM_SPRITE_URL = 'https://getstream.imgix.net/images/emoji-sprite.png';
+
+export const StreamEmoji = ({
+  fallback,
+  type,
+}: Readable<{ type: StreamEmojiType } & Pick<SpriteImageProps, 'fallback'>>) => {
+  const position = StreamSpriteEmojiPositions[type] as [number, number];
+  return (
+    <SpriteImage
+      columns={2}
+      fallback={fallback}
+      position={position}
+      rows={3}
+      spriteUrl={STREAM_SPRITE_URL}
+      style={
+        {
+          '--str-chat__sprite-image-height': 'var(--str-chat__stream-emoji-size, 18px)',
+        } as React.CSSProperties
+      }
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/Reactions/index.ts
+++ b/libs/stream-chat-shim/src/components/Reactions/index.ts
@@ -1,0 +1,7 @@
+export * from './ReactionSelector';
+export * from './ReactionsList';
+export * from './ReactionsListModal';
+export * from './SimpleReactionsList';
+export * from './SpriteImage';
+export * from './StreamEmoji';
+export * from './reactionOptions';

--- a/libs/stream-chat-shim/src/components/Reactions/reactionOptions.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/reactionOptions.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable sort-keys */
+
+import React from 'react';
+
+import { StreamEmoji } from './StreamEmoji';
+
+export type ReactionOptions = Array<{
+  Component: React.ComponentType;
+  type: string;
+  name?: string;
+}>;
+
+export const defaultReactionOptions: ReactionOptions = [
+  {
+    type: 'haha',
+    Component: () => <StreamEmoji fallback='😂' type='haha' />,
+    name: 'Joy',
+  },
+  {
+    type: 'like',
+    Component: () => <StreamEmoji fallback='👍' type='like' />,
+    name: 'Thumbs up',
+  },
+  {
+    type: 'love',
+    Component: () => <StreamEmoji fallback='❤️' type='love' />,
+    name: 'Heart',
+  },
+  { type: 'sad', Component: () => <StreamEmoji fallback='😔' type='sad' />, name: 'Sad' },
+  {
+    type: 'wow',
+    Component: () => <StreamEmoji fallback='😲' type='wow' />,
+    name: 'Astonished',
+  },
+];

--- a/libs/stream-chat-shim/src/components/Reactions/utils/utils.ts
+++ b/libs/stream-chat-shim/src/components/Reactions/utils/utils.ts
@@ -1,0 +1,29 @@
+import type { ForwardedRef, MutableRefObject } from 'react';
+
+export const isMutableRef = <T>(
+  ref: ForwardedRef<T> | null,
+): ref is MutableRefObject<T> => {
+  if (ref) {
+    return (ref as MutableRefObject<T>).current !== undefined;
+  }
+  return false;
+};
+
+export const getImageDimensions = (source: string) =>
+  new Promise<[number, number]>((resolve, reject) => {
+    const image = new Image();
+
+    image.addEventListener(
+      'load',
+      () => {
+        resolve([image.width, image.height]);
+      },
+      { once: true },
+    );
+
+    image.addEventListener('error', () => reject(`Couldn't load image from ${source}`), {
+      once: true,
+    });
+
+    image.src = source;
+  });


### PR DESCRIPTION
## Summary
- port `ReactionSelector` component and related helpers from the upstream stream UI
- include barrel file and simple test
- stub context hooks for now

## Testing
- `pnpm build` *(fails: `Command "build" not found`)*
- `pnpm -F frontend tsc --noEmit` *(fails: `None of the selected packages has a "tsc" script`)*
- `pnpm test` *(fails: `turbo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e0a5520808326b94fd2bb8abd916c