### PR TITLE
Port ReactionsListModal component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ReactionsListModal.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ReactionsListModal.test.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ReactionsListModal } from '../src/ReactionsListModal';
+import { ReactionsListModal } from '../src/components/Reactions/ReactionsListModal';
 
 describe('ReactionsListModal', () => {
-  it('renders placeholder', () => {
-    const { getByTestId } = render(
-      <ReactionsListModal
-        open={true}
-        reactions={[]}
-        selectedReactionType="like"
-      />,
+  it('renders without crashing', () => {
+    render(
+      <ReactionsListModal open={true} reactions={[]} selectedReactionType="like" />,
     );
-    expect(getByTestId('reactions-list-modal-placeholder')).toBeTruthy();
   });
 });

--- a/libs/stream-chat-shim/src/components/Reactions/ReactionsListModal.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/ReactionsListModal.tsx
@@ -1,0 +1,137 @@
+import React, { useMemo } from 'react';
+import clsx from 'clsx';
+
+import type { ReactionDetailsComparator, ReactionSummary, ReactionType } from './types';
+
+import type { ModalProps } from '../Modal';
+import { Modal } from '../Modal';
+import { useFetchReactions } from './hooks/useFetchReactions';
+import { LoadingIndicator } from '../Loading';
+import { Avatar } from '../Avatar';
+// import type { MessageContextValue } from '../../context'; // TODO backend-wire-up
+type MessageContextValue = any;
+// import { useMessageContext } from '../../context'; // TODO backend-wire-up
+const useMessageContext = (_?: string) => ({} as any);
+// import type { ReactionSort } from 'stream-chat'; // TODO backend-wire-up
+import type { ReactionSort } from 'chat-shim';
+
+export type ReactionsListModalProps = ModalProps &
+  Partial<Pick<MessageContextValue, 'handleFetchReactions' | 'reactionDetailsSort'>> & {
+    reactions: ReactionSummary[];
+    selectedReactionType: ReactionType;
+    onSelectedReactionTypeChange?: (reactionType: ReactionType) => void;
+    sort?: ReactionSort;
+    /** @deprecated use `sort` instead */
+    sortReactionDetails?: ReactionDetailsComparator;
+  };
+
+const defaultReactionDetailsSort = { created_at: -1 } as const;
+
+export function ReactionsListModal({
+  handleFetchReactions,
+  onSelectedReactionTypeChange,
+  reactionDetailsSort: propReactionDetailsSort,
+  reactions,
+  selectedReactionType,
+  sortReactionDetails: propSortReactionDetails,
+  ...modalProps
+}: ReactionsListModalProps) {
+  const selectedReaction = reactions.find(
+    ({ reactionType }) => reactionType === selectedReactionType,
+  );
+  const SelectedEmojiComponent = selectedReaction?.EmojiComponent ?? null;
+  const {
+    reactionDetailsSort: contextReactionDetailsSort,
+    sortReactionDetails: contextSortReactionDetails,
+  } = useMessageContext('ReactionsListModal');
+  const legacySortReactionDetails = propSortReactionDetails ?? contextSortReactionDetails;
+  const reactionDetailsSort =
+    propReactionDetailsSort ?? contextReactionDetailsSort ?? defaultReactionDetailsSort;
+  const { isLoading: areReactionsLoading, reactions: reactionDetails } =
+    useFetchReactions({
+      handleFetchReactions,
+      reactionType: selectedReactionType,
+      shouldFetch: modalProps.open,
+      sort: reactionDetailsSort,
+    });
+
+  const reactionDetailsWithLegacyFallback = useMemo(
+    () =>
+      legacySortReactionDetails
+        ? [...reactionDetails].sort(legacySortReactionDetails)
+        : reactionDetails,
+    [legacySortReactionDetails, reactionDetails],
+  );
+
+  return (
+    <Modal
+      {...modalProps}
+      className={clsx('str-chat__message-reactions-details-modal', modalProps.className)}
+    >
+      <div
+        className='str-chat__message-reactions-details'
+        data-testid='reactions-list-modal'
+      >
+        <div className='str-chat__message-reactions-details-reaction-types'>
+          {reactions.map(
+            ({ EmojiComponent, reactionCount, reactionType }) =>
+              EmojiComponent && (
+                <div
+                  className={clsx('str-chat__message-reactions-details-reaction-type', {
+                    'str-chat__message-reactions-details-reaction-type--selected':
+                      selectedReactionType === reactionType,
+                  })}
+                  data-testid={`reaction-details-selector-${reactionType}`}
+                  key={reactionType}
+                  onClick={() =>
+                    onSelectedReactionTypeChange?.(reactionType as ReactionType)
+                  }
+                >
+                  <span className='str-chat__message-reaction-emoji str-chat__message-reaction-emoji--with-fallback'>
+                    <EmojiComponent />
+                  </span>
+                  &nbsp;
+                  <span className='str-chat__message-reaction-count'>
+                    {reactionCount}
+                  </span>
+                </div>
+              ),
+          )}
+        </div>
+        {SelectedEmojiComponent && (
+          <div className='str-chat__message-reaction-emoji str-chat__message-reaction-emoji--with-fallback str-chat__message-reaction-emoji-big'>
+            <SelectedEmojiComponent />
+          </div>
+        )}
+        <div
+          className='str-chat__message-reactions-details-reacting-users'
+          data-testid='all-reacting-users'
+        >
+          {areReactionsLoading ? (
+            <LoadingIndicator />
+          ) : (
+            reactionDetailsWithLegacyFallback.map(({ user }) => (
+              <div
+                className='str-chat__message-reactions-details-reacting-user'
+                key={user?.id}
+              >
+                <Avatar
+                  className='stream-chat__avatar--reaction'
+                  data-testid='avatar'
+                  image={user?.image as string | undefined}
+                  name={user?.name || user?.id}
+                />
+                <span
+                  className='str-chat__user-item--name'
+                  data-testid='reaction-user-username'
+                >
+                  {user?.name || user?.id}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/libs/stream-chat-shim/src/components/Reactions/hooks/useFetchReactions.ts
+++ b/libs/stream-chat-shim/src/components/Reactions/hooks/useFetchReactions.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import type { ReactionResponse, ReactionSort } from 'chat-shim';
+// import type { MessageContextValue } from '../../../context'; // TODO backend-wire-up
+type MessageContextValue = any;
+// import { useMessageContext } from '../../../context'; // TODO backend-wire-up
+const useMessageContext = (_?: string) => ({} as any);
+
+import type { ReactionType } from '../types';
+
+export interface FetchReactionsOptions {
+  reactionType: ReactionType;
+  shouldFetch: boolean;
+  handleFetchReactions?: MessageContextValue['handleFetchReactions'];
+  sort?: ReactionSort;
+}
+
+export function useFetchReactions(options: FetchReactionsOptions) {
+  const { handleFetchReactions: contextHandleFetchReactions } =
+    useMessageContext('useFetchReactions');
+  const [reactions, setReactions] = useState<ReactionResponse[]>([]);
+  const {
+    handleFetchReactions: propHandleFetchReactions,
+    reactionType,
+    shouldFetch,
+    sort,
+  } = options;
+  const [isLoading, setIsLoading] = useState(shouldFetch);
+  const handleFetchReactions = propHandleFetchReactions ?? contextHandleFetchReactions;
+
+  useEffect(() => {
+    if (!shouldFetch) {
+      return;
+    }
+
+    let cancel = false;
+
+    (async () => {
+      try {
+        setIsLoading(true);
+        const reactions = await handleFetchReactions(reactionType, sort);
+
+        if (!cancel) {
+          setReactions(reactions);
+        }
+      } catch (e) {
+        if (!cancel) {
+          setReactions([]);
+        }
+      } finally {
+        if (!cancel) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancel = true;
+    };
+  }, [handleFetchReactions, reactionType, shouldFetch, sort]);
+
+  return { isLoading, reactions };
+}

--- a/libs/stream-chat-shim/src/components/Reactions/types.ts
+++ b/libs/stream-chat-shim/src/components/Reactions/types.ts
@@ -1,0 +1,23 @@
+import type { ComponentType } from 'react';
+// import type { ReactionResponse } from 'stream-chat'; // TODO backend-wire-up
+import type { ReactionResponse } from 'chat-shim';
+
+export interface ReactionSummary {
+  EmojiComponent: ComponentType | null;
+  firstReactionAt: Date | null;
+  isOwnReaction: boolean;
+  lastReactionAt: Date | null;
+  latestReactedUserNames: string[];
+  reactionCount: number;
+  reactionType: string;
+  unlistedReactedUserCount: number;
+}
+
+export type ReactionsComparator = (a: ReactionSummary, b: ReactionSummary) => number;
+
+export type ReactionDetailsComparator = (
+  a: ReactionResponse,
+  b: ReactionResponse,
+) => number;
+
+export type ReactionType = ReactionResponse['type'];


### PR DESCRIPTION
## Summary
- port `ReactionsListModal` from upstream stream-chat-react
- add supporting `useFetchReactions` hook and `types` definitions
- update unit test for `ReactionsListModal`

## Testing
- `pnpm -r build` *(fails: `next` not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `npx tsc --noEmit` *(fails: parse errors in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_685e0a81e04c83269894ef4d3f699e8c