### PR TITLE
Port SpriteImage component

### DIFF
--- a/libs/stream-chat-shim/__tests__/SpriteImage.test.tsx
+++ b/libs/stream-chat-shim/__tests__/SpriteImage.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SpriteImage } from '../src/components/Reactions/SpriteImage';
+
+test('renders without crashing', () => {
+  render(<SpriteImage columns={1} position={[0, 0]} rows={1} spriteUrl='' />);
+});

--- a/libs/stream-chat-shim/src/components/Reactions/SpriteImage.tsx
+++ b/libs/stream-chat-shim/src/components/Reactions/SpriteImage.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+
+import { getImageDimensions } from './utils/utils';
+
+export type SpriteImageProps = {
+  columns: number;
+  position: [number, number];
+  rows: number;
+  spriteUrl: string;
+  fallback?: React.ReactNode;
+  height?: number;
+  style?: React.CSSProperties;
+  width?: number;
+};
+
+export const SpriteImage = ({
+  columns,
+  fallback,
+  height,
+  position,
+  rows,
+  spriteUrl,
+  style,
+  width,
+}: SpriteImageProps) => {
+  const [[spriteWidth, spriteHeight], setSpriteDimensions] = useState([0, 0]);
+
+  useEffect(() => {
+    getImageDimensions(spriteUrl).then(setSpriteDimensions).catch(console.error);
+  }, [spriteUrl]);
+
+  const [x, y] = position;
+
+  if (!spriteHeight || !spriteWidth) return <>{fallback}</>;
+
+  return (
+    <div
+      data-testid='sprite-image'
+      style={
+        {
+          ...style,
+          '--str-chat__sprite-image-resize-ratio':
+            'var(--str-chat__sprite-image-resize-ratio-x, var(--str-chat__sprite-image-resize-ratio-y, 1))',
+          '--str-chat__sprite-image-resize-ratio-x':
+            'calc(var(--str-chat__sprite-image-width) / var(--str-chat__sprite-item-width))',
+          '--str-chat__sprite-image-resize-ratio-y':
+            'calc(var(--str-chat__sprite-image-height) / var(--str-chat__sprite-item-height))',
+          '--str-chat__sprite-item-height': `${spriteHeight / rows}`,
+          '--str-chat__sprite-item-width': `${spriteWidth / columns}`,
+          ...(Number.isFinite(height)
+            ? { '--str-chat__sprite-image-height': `${height}px` }
+            : {}),
+          ...(Number.isFinite(width)
+            ? { '--str-chat__sprite-image-width': `${width}px` }
+            : {}),
+          backgroundImage: `url('${spriteUrl}')`,
+          backgroundPosition: `${x * (100 / (columns - 1))}% ${y * (100 / (rows - 1))}%`,
+          backgroundSize: `${columns * 100}% ${rows * 100}%`,
+          height:
+            'var(--str-chat__sprite-image-height, calc(var(--str-chat__sprite-item-height) * var(--str-chat__sprite-image-resize-ratio)))',
+          width:
+            'var(--str-chat__sprite-image-width, calc(var(--str-chat__sprite-item-width) * var(--str-chat__sprite-image-resize-ratio)))',
+        } as React.CSSProperties
+      }
+    />
+  );
+};

--- a/libs/stream-chat-shim/src/components/Reactions/index.ts
+++ b/libs/stream-chat-shim/src/components/Reactions/index.ts
@@ -1,0 +1,2 @@
+export * from './SpriteImage';
+// TODO backend-wire-up: export other Reactions components when ported

--- a/libs/stream-chat-shim/src/components/Reactions/utils/utils.ts
+++ b/libs/stream-chat-shim/src/components/Reactions/utils/utils.ts
@@ -1,0 +1,29 @@
+import type { ForwardedRef, MutableRefObject } from 'react';
+
+export const isMutableRef = <T>(
+  ref: ForwardedRef<T> | null,
+): ref is MutableRefObject<T> => {
+  if (ref) {
+    return (ref as MutableRefObject<T>).current !== undefined;
+  }
+  return false;
+};
+
+export const getImageDimensions = (source: string) =>
+  new Promise<[number, number]>((resolve, reject) => {
+    const image = new Image();
+
+    image.addEventListener(
+      'load',
+      () => {
+        resolve([image.width, image.height]);
+      },
+      { once: true },
+    );
+
+    image.addEventListener('error', () => reject(`Couldn't load image from ${source}`), {
+      once: true,
+    });
+
+    image.src = source;
+  });


### PR DESCRIPTION
## Summary
- port `SpriteImage` component from stream-ui
- expose it in `Reactions` index
- add supporting utils
- add smoke test

## Testing
- `pnpm -r build` *(fails: Can't resolve 'stream-chat-react')*
- `pnpm exec tsc -p frontend --noEmit` *(fails with TS errors)*
- `pnpm test` *(fails to parse turbo json)*
- `npx jest libs/stream-chat-shim/__tests__/SpriteImage.test.tsx` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685e0a94e92c832681bf395abbf2cabc