### PR TITLE
Add test for StreamEmoji component

### DIFF
--- a/libs/stream-chat-shim/__tests__/StreamEmoji.test.tsx
+++ b/libs/stream-chat-shim/__tests__/StreamEmoji.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { StreamEmoji } from '../src/components/Reactions/StreamEmoji';
+
+test('renders without crashing', () => {
+  render(<StreamEmoji fallback='😀' type='like' />);
+});


### PR DESCRIPTION
## Summary
- add a sanity test for `StreamEmoji`

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e0a9e5394832687418ec73b7b4bdc