### PR TITLE
Port CommandItem

### DIFF
--- a/libs/stream-chat-shim/__tests__/CommandItem_component.test.tsx
+++ b/libs/stream-chat-shim/__tests__/CommandItem_component.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CommandItem } from '../src/components/TextareaComposer/SuggestionList/CommandItem';
+
+test('renders without crashing', () => {
+  const entity = { name: '/test', args: '', description: 'desc' } as any;
+  render(<CommandItem entity={entity} />);
+});

--- a/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/CommandItem.tsx
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/CommandItem.tsx
@@ -1,0 +1,23 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+// import type { CommandResponse } from 'stream-chat'; // TODO backend-wire-up
+export type CommandResponse = any;
+
+export type CommandItemProps = {
+  entity: CommandResponse;
+};
+
+export const CommandItem = (props: PropsWithChildren<CommandItemProps>) => {
+  const { entity } = props;
+
+  return (
+    <div className='str-chat__slash-command'>
+      <span className='str-chat__slash-command-header'>
+        <strong>{entity.name}</strong> {entity.args}
+      </span>
+      <br />
+      <span className='str-chat__slash-command-description'>{entity.description}</span>
+    </div>
+  );
+};
+

--- a/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/index.ts
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/index.ts
@@ -1,0 +1,2 @@
+export * from './CommandItem';
+// TODO backend-wire-up: export other SuggestionList components when ported

--- a/libs/stream-chat-shim/src/components/TextareaComposer/index.ts
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/index.ts
@@ -1,0 +1,2 @@
+export * from './SuggestionList';
+// TODO backend-wire-up: export TextareaComposer when ported


### PR DESCRIPTION
## Summary
- port `CommandItem` from `stream-chat-react`
- create SuggestionList index and main TextareaComposer index
- add basic render test

## Testing
- `pnpm exec jest --runTestsByPath libs/stream-chat-shim/__tests__/CommandItem_component.test.tsx` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685e0accc13c83268f7f9510e1d5e00a