### PR TITLE
Add EmoticonItem component

### DIFF
--- a/libs/stream-chat-shim/__tests__/EmoticonItem.test.tsx
+++ b/libs/stream-chat-shim/__tests__/EmoticonItem.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EmoticonItem } from '../src/components/TextareaComposer/SuggestionList/EmoticonItem';
+
+test('renders emoticon', () => {
+  const entity = {
+    name: 'smile',
+    native: '😄',
+    tokenizedDisplayName: { token: 'smile', parts: ['sm', 'ile'] },
+  } as any;
+  const { container } = render(<EmoticonItem entity={entity} />);
+  expect(container.textContent).toContain('😄');
+});

--- a/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/EmoticonItem.tsx
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/EmoticonItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export type EmoticonItemProps = {
+  entity: {
+    /** Name for emoticon */
+    name: string;
+    /** Native value or actual emoticon */
+    native: string;
+    /** The parts of the Name property of the entity (or id if no name) that can be matched to the user input value.
+     * Default is bold for matches, but can be overwritten in css.
+     * */
+    tokenizedDisplayName: { token: string; parts: string[] };
+  };
+};
+
+export const EmoticonItem = (props: EmoticonItemProps) => {
+  const { entity } = props;
+  const hasEntity = Object.keys(entity).length;
+  if (!hasEntity) return null;
+
+  const { parts, token } = entity.tokenizedDisplayName ?? ({} as EmoticonItemProps);
+
+  const renderName = () =>
+    parts?.map((part, i) =>
+      part.toLowerCase() === token ? (
+        <span className='str-chat__emoji-item--highlight' key={`part-${i}`}>
+          {part}
+        </span>
+      ) : (
+        <span className='str-chat__emoji-item--part' key={`part-${i}`}>
+          {part}
+        </span>
+      ),
+    ) ?? null;
+
+  return (
+    <div className='str-chat__emoji-item'>
+      <span className='str-chat__emoji-item--entity'>{entity.native}</span>
+      <span className='str-chat__emoji-item--name'>{renderName()}</span>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/index.ts
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/index.ts
@@ -1,0 +1,5 @@
+export * from './CommandItem';
+export * from './EmoticonItem';
+export * from './SuggestionList';
+export * from './SuggestionListItem';
+export * from './UserItem';

--- a/libs/stream-chat-shim/src/components/TextareaComposer/index.ts
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/index.ts
@@ -1,0 +1,2 @@
+export * from './SuggestionList';
+export * from './TextareaComposer';


### PR DESCRIPTION
## Summary
- port `EmoticonItem` from `stream-chat-react`
- expose `SuggestionList` members via an index file
- add a basic render test for `EmoticonItem`

## Testing
- `pnpm -r run build` *(fails: Module not found: Can't resolve 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails: tsc errors)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685e0d2c7a488326be07495dee9d07e4