### PR TITLE
Port EmoticonItem

### DIFF
--- a/libs/stream-chat-shim/__tests__/EmoticonItem_component.test.tsx
+++ b/libs/stream-chat-shim/__tests__/EmoticonItem_component.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EmoticonItem } from '../src/components/TextareaComposer/SuggestionList/EmoticonItem';
+
+test('renders without crashing', () => {
+  const entity = { name: ':smile:', native: '😄', tokenizedDisplayName: { token: 'smile', parts: ['smile'] } } as any;
+  render(<EmoticonItem entity={entity} />);
+});

--- a/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/EmoticonItem.tsx
+++ b/libs/stream-chat-shim/src/components/TextareaComposer/SuggestionList/EmoticonItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export type EmoticonItemProps = {
+  entity: {
+    /** Name for emoticon */
+    name: string;
+    /** Native value or actual emoticon */
+    native: string;
+    /** The parts of the Name property of the entity (or id if no name) that can be matched to the user input value.
+     * Default is bold for matches, but can be overwritten in css.
+     * */
+    tokenizedDisplayName: { token: string; parts: string[] };
+  };
+};
+
+export const EmoticonItem = (props: EmoticonItemProps) => {
+  const { entity } = props;
+  const hasEntity = Object.keys(entity).length;
+  if (!hasEntity) return null;
+
+  const { parts, token } = entity.tokenizedDisplayName ?? ({} as EmoticonItemProps);
+
+  const renderName = () =>
+    parts?.map((part, i) =>
+      part.toLowerCase() === token ? (
+        <span className='str-chat__emoji-item--highlight' key={`part-${i}`}>
+          {part}
+        </span>
+      ) : (
+        <span className='str-chat__emoji-item--part' key={`part-${i}`}>
+          {part}
+        </span>
+      ),
+    ) ?? null;
+
+  return (
+    <div className='str-chat__emoji-item'>
+      <span className='str-chat__emoji-item--entity'>{entity.native}</span>
+      <span className='str-chat__emoji-item--name'>{renderName()}</span>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `EmoticonItem` from `stream-chat-react`
- add a minimal test that renders the component

## Testing
- `pnpm -r build` *(fails: Module not found 'stream-chat-react')*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*
- `npx jest` *(fails to run test suites)*

------
https://chatgpt.com/codex/tasks/task_e_685e0e514c688326a69801e156ee5349