### PR TITLE
Port Thread component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Thread.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Thread.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Thread } from '../src/components/Thread/Thread';
+
+test('renders without crashing', () => {
+  render(<Thread />);
+});

--- a/libs/stream-chat-shim/src/components/Thread/LegacyThreadContext.ts
+++ b/libs/stream-chat-shim/src/components/Thread/LegacyThreadContext.ts
@@ -1,0 +1,9 @@
+import React, { useContext } from 'react';
+/* TODO backend-wire-up: LocalMessage import excised */
+type LocalMessage = any;
+
+export const LegacyThreadContext = React.createContext<{
+  legacyThread: LocalMessage | undefined;
+}>({ legacyThread: undefined });
+
+export const useLegacyThreadContext = () => useContext(LegacyThreadContext);

--- a/libs/stream-chat-shim/src/components/Thread/Thread.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/Thread.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect } from 'react';
+import clsx from 'clsx';
+
+import { LegacyThreadContext } from './LegacyThreadContext';
+import { MESSAGE_ACTIONS } from '../Message';
+import type { MessageInputProps } from '../MessageInput';
+import { MessageInput, MessageInputFlat } from '../MessageInput';
+import type { MessageListProps, VirtualizedMessageListProps } from '../MessageList';
+import { MessageList, VirtualizedMessageList } from '../MessageList';
+import { ThreadHeader as DefaultThreadHeader } from './ThreadHeader';
+import { ThreadHead as DefaultThreadHead } from '../Thread/ThreadHead';
+
+import {
+  useChannelActionContext,
+  useChannelStateContext,
+  useChatContext,
+  useComponentContext,
+} from '../../context';
+import { useThreadContext } from '../Threads';
+import { useStateStore } from '../../store';
+
+import type { MessageProps, MessageUIComponentProps } from '../Message/types';
+import type { MessageActionsArray } from '../Message/utils';
+/* TODO backend-wire-up: ThreadState import excised */
+type ThreadState = any;
+
+export type ThreadProps = {
+  /** Additional props for `MessageInput` component: [available props](https://getstream.io/chat/docs/sdk/react/message-input-components/message_input/#props) */
+  additionalMessageInputProps?: MessageInputProps;
+  /** Additional props for `MessageList` component: [available props](https://getstream.io/chat/docs/sdk/react/core-components/message_list/#props) */
+  additionalMessageListProps?: MessageListProps;
+  /** Additional props for `Message` component of the parent message: [available props](https://getstream.io/chat/docs/sdk/react/message-components/message/#props) */
+  additionalParentMessageProps?: Partial<MessageProps>;
+  /** Additional props for `VirtualizedMessageList` component: [available props](https://getstream.io/chat/docs/sdk/react/core-components/virtualized_list/#props) */
+  additionalVirtualizedMessageListProps?: VirtualizedMessageListProps;
+  /** If true, focuses the `MessageInput` component on opening a thread */
+  autoFocus?: boolean;
+  /** Injects date separator components into `Thread`, defaults to `false`. To be passed to the underlying `MessageList` or `VirtualizedMessageList` components */
+  enableDateSeparator?: boolean;
+  /** Custom thread input UI component used to override the default `Input` value stored in `ComponentContext` or the [MessageInputSmall](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageInput/MessageInputSmall.tsx) default */
+  Input?: React.ComponentType;
+  /** Custom thread message UI component used to override the default `Message` value stored in `ComponentContext` */
+  Message?: React.ComponentType<MessageUIComponentProps>;
+  /** Array of allowed message actions (ex: ['edit', 'delete', 'flag', 'mute', 'pin', 'quote', 'react', 'reply']). To disable all actions, provide an empty array. */
+  messageActions?: MessageActionsArray;
+  /** If true, render the `VirtualizedMessageList` instead of the standard `MessageList` component */
+  virtualized?: boolean;
+};
+
+/**
+ * The Thread component renders a parent Message with a list of replies
+ */
+export const Thread = (props: ThreadProps) => {
+  const { channel, channelConfig, thread } = useChannelStateContext('Thread');
+  const threadInstance = useThreadContext();
+
+  if (!thread && !threadInstance) return null;
+  if (channelConfig?.replies === false) return null;
+
+  // the wrapper ensures a key variable is set and the component recreates on thread switch
+  return (
+    // FIXME: TS is having trouble here as at least one of the two would always be defined
+    <ThreadInner
+      {...props}
+      key={`thread-${(thread ?? threadInstance)?.id}-${channel?.cid}`}
+    />
+  );
+};
+
+const selector = (nextValue: ThreadState) => ({
+  isLoadingNext: nextValue.pagination.isLoadingNext,
+  isLoadingPrev: nextValue.pagination.isLoadingPrev,
+  parentMessage: nextValue.parentMessage,
+  replies: nextValue.replies,
+});
+
+const ThreadInner = (props: ThreadProps & { key: string }) => {
+  const {
+    additionalMessageInputProps,
+    additionalMessageListProps,
+    additionalParentMessageProps,
+    additionalVirtualizedMessageListProps,
+    autoFocus = true,
+    enableDateSeparator = false,
+    Input: PropInput,
+    Message: PropMessage,
+    messageActions = Object.keys(MESSAGE_ACTIONS),
+    virtualized,
+  } = props;
+
+  const threadInstance = useThreadContext();
+
+  const {
+    thread,
+    threadHasMore,
+    threadLoadingMore,
+    threadMessages = [],
+    threadSuppressAutoscroll,
+  } = useChannelStateContext('Thread');
+  const { closeThread, loadMoreThread } = useChannelActionContext('Thread');
+  const { customClasses } = useChatContext('Thread');
+  const {
+    Message: ContextMessage,
+    ThreadHead = DefaultThreadHead,
+    ThreadHeader = DefaultThreadHeader,
+    ThreadInput: ContextInput,
+    VirtualMessage,
+  } = useComponentContext('Thread');
+
+  const { isLoadingNext, isLoadingPrev, parentMessage, replies } =
+    useStateStore(threadInstance?.state, selector) ?? {};
+
+  const ThreadInput =
+    PropInput ?? additionalMessageInputProps?.Input ?? ContextInput ?? MessageInputFlat;
+
+  const ThreadMessage = PropMessage || additionalMessageListProps?.Message;
+  const FallbackMessage = virtualized && VirtualMessage ? VirtualMessage : ContextMessage;
+  const MessageUIComponent = ThreadMessage || FallbackMessage;
+
+  const ThreadMessageList = virtualized ? VirtualizedMessageList : MessageList;
+
+  useEffect(() => {
+    if (threadInstance) return;
+
+    if ((thread?.reply_count ?? 0) > 0) {
+      // FIXME: integrators can customize channel query options but cannot customize channel.getReplies() options
+      loadMoreThread();
+    }
+  }, [thread, loadMoreThread, threadInstance]);
+
+  const threadProps: Pick<
+    VirtualizedMessageListProps,
+    | 'hasMoreNewer'
+    | 'loadMoreNewer'
+    | 'loadingMoreNewer'
+    | 'hasMore'
+    | 'loadMore'
+    | 'loadingMore'
+    | 'messages'
+  > = threadInstance
+    ? {
+        loadingMore: isLoadingPrev,
+        loadingMoreNewer: isLoadingNext,
+        loadMore: threadInstance.loadPrevPage,
+        loadMoreNewer: threadInstance.loadNextPage,
+        messages: replies,
+      }
+    : {
+        hasMore: threadHasMore,
+        loadingMore: threadLoadingMore,
+        loadMore: loadMoreThread,
+        messages: threadMessages,
+      };
+
+  const messageAsThread = thread ?? parentMessage;
+
+  if (!messageAsThread) return null;
+
+  const threadClass =
+    customClasses?.thread ||
+    clsx('str-chat__thread-container str-chat__thread', {
+      'str-chat__thread--virtualized': virtualized,
+    });
+
+  const head = (
+    <ThreadHead
+      key={messageAsThread.id}
+      message={messageAsThread}
+      Message={MessageUIComponent}
+      {...additionalParentMessageProps}
+    />
+  );
+
+  return (
+    // Thread component needs a context which we can use for message composer
+    <LegacyThreadContext.Provider
+      value={{
+        legacyThread: thread ?? undefined,
+      }}
+    >
+      <div className={threadClass}>
+        <ThreadHeader closeThread={closeThread} thread={messageAsThread} />
+        <ThreadMessageList
+          disableDateSeparator={!enableDateSeparator}
+          head={head}
+          Message={MessageUIComponent}
+          messageActions={messageActions}
+          suppressAutoscroll={threadSuppressAutoscroll}
+          threadList
+          {...threadProps}
+          {...(virtualized
+            ? additionalVirtualizedMessageListProps
+            : additionalMessageListProps)}
+        />
+        <MessageInput
+          focus={autoFocus}
+          Input={ThreadInput}
+          isThreadInput
+          parent={thread ?? parentMessage}
+          {...additionalMessageInputProps}
+        />
+      </div>
+    </LegacyThreadContext.Provider>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/ThreadHead.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadHead.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import type { MessageProps } from '../Message';
+import { Message } from '../Message';
+import { ThreadStart as DefaultThreadStart } from './ThreadStart';
+
+import { useComponentContext } from '../../context';
+
+export const ThreadHead = (props: MessageProps) => {
+  const { ThreadStart = DefaultThreadStart } = useComponentContext('ThreadHead');
+  return (
+    <div className='str-chat__parent-message-li'>
+      <Message initialMessage threadList {...props} />
+      <ThreadStart />
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/ThreadHeader.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadHeader.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { useChannelPreviewInfo } from '../ChannelPreview/hooks/useChannelPreviewInfo';
+import { CloseIcon } from './icons';
+
+import { useChannelStateContext } from '../../context/ChannelStateContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+
+import type { ChannelPreviewInfoParams } from '../ChannelPreview/hooks/useChannelPreviewInfo';
+/* TODO backend-wire-up: LocalMessage import excised */
+type LocalMessage = any;
+
+export type ThreadHeaderProps = {
+  /** Callback for closing the thread */
+  closeThread: (event?: React.BaseSyntheticEvent) => void;
+  /** The thread parent message */
+  thread: LocalMessage;
+};
+
+export const ThreadHeader = (
+  props: ThreadHeaderProps &
+    Pick<ChannelPreviewInfoParams, 'overrideImage' | 'overrideTitle'>,
+) => {
+  const { closeThread, overrideImage, overrideTitle } = props;
+
+  const { t } = useTranslationContext('ThreadHeader');
+  const { channel } = useChannelStateContext('');
+  const { displayTitle } = useChannelPreviewInfo({
+    channel,
+    overrideImage,
+    overrideTitle,
+  });
+
+  return (
+    <div className='str-chat__thread-header'>
+      <div className='str-chat__thread-header-details'>
+        <div className='str-chat__thread-header-title'>{t('Thread')}</div>
+        <div className='str-chat__thread-header-subtitle'>{displayTitle}</div>
+      </div>
+      <button
+        aria-label={t('aria/Close thread')}
+        className='str-chat__close-thread-button'
+        data-testid='close-button'
+        onClick={closeThread}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/ThreadStart.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadStart.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { useChannelStateContext } from '../../context/ChannelStateContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export const ThreadStart = () => {
+  const { thread } = useChannelStateContext('ThreadStart');
+  const { t } = useTranslationContext('ThreadStart');
+
+  if (!thread?.reply_count) return null;
+
+  return (
+    <div className='str-chat__thread-start'>
+      {t('replyCount', { count: thread.reply_count })}
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/icons.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/icons.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export const CloseIcon = ({ title }: { title?: string }) => {
+  const { t } = useTranslationContext('CloseIcon');
+
+  return (
+    <svg
+      data-testid='close-no-outline'
+      fill='none'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title ?? t('Close')}</title>
+      <path
+        d='M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z'
+        fill='black'
+      />
+    </svg>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/index.ts
+++ b/libs/stream-chat-shim/src/components/Thread/index.ts
@@ -1,0 +1,4 @@
+export * from './Thread';
+export * from './ThreadHeader';
+export { ThreadStart } from './ThreadStart';
+export { useLegacyThreadContext } from './LegacyThreadContext';


### PR DESCRIPTION
## Summary
- port Thread component from stream-chat-react and adjust for chat-shim
- include auxiliary thread components and exports
- add a basic test for the Thread shim

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No tsc script)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0eae26f88326a247bfc2ac4e1f1a