### PR TITLE
Add ThreadHead component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadHead.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadHead.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ThreadHead } from '../src/components/Thread/ThreadHead';
+
+ test('renders without crashing', () => {
+  render(<ThreadHead />);
+});

--- a/libs/stream-chat-shim/src/components/Thread/ThreadHead.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadHead.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import type { MessageProps } from '../Message';
+import { Message } from '../Message';
+import { ThreadStart as DefaultThreadStart } from './ThreadStart';
+
+import { useComponentContext } from '../../context';
+
+export const ThreadHead = (props: MessageProps) => {
+  const { ThreadStart = DefaultThreadStart } = useComponentContext('ThreadHead');
+  return (
+    <div className='str-chat__parent-message-li'>
+      <Message initialMessage threadList {...props} />
+      <ThreadStart />
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/ThreadStart.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadStart.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { useChannelStateContext } from '../../context/ChannelStateContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export const ThreadStart = () => {
+  const { thread } = useChannelStateContext('ThreadStart');
+  const { t } = useTranslationContext('ThreadStart');
+
+  if (!thread?.reply_count) return null;
+
+  return (
+    <div className='str-chat__thread-start'>
+      {t('replyCount', { count: thread.reply_count })}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port ThreadHead and ThreadStart from stream-chat-react
- add basic render test

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685e0ebc64fc8326bc20aefa9eb46ae0