### PR TITLE
Port ThreadHeader component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadHeader.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadHeader.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadHeader } from '../src/components/Thread/ThreadHeader';
+
+test('renders without crashing', () => {
+  render(
+    <ThreadHeader
+      closeThread={() => {}}
+      thread={{} as any}
+      overrideImage=''
+      overrideTitle=''
+    />
+  );
+});

--- a/libs/stream-chat-shim/src/components/Thread/ThreadHeader.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadHeader.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { useChannelPreviewInfo } from '../ChannelPreview/hooks/useChannelPreviewInfo';
+import { CloseIcon } from './icons';
+
+import { useChannelStateContext } from '../../context/ChannelStateContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+
+import type { ChannelPreviewInfoParams } from '../ChannelPreview/hooks/useChannelPreviewInfo';
+/* TODO backend-wire-up: LocalMessage import excised */
+// import type { LocalMessage } from 'stream-chat';
+type LocalMessage = any;
+
+export type ThreadHeaderProps = {
+  /** Callback for closing the thread */
+  closeThread: (event?: React.BaseSyntheticEvent) => void;
+  /** The thread parent message */
+  thread: LocalMessage;
+};
+
+export const ThreadHeader = (
+  props: ThreadHeaderProps &
+    Pick<ChannelPreviewInfoParams, 'overrideImage' | 'overrideTitle'>,
+) => {
+  const { closeThread, overrideImage, overrideTitle } = props;
+
+  const { t } = useTranslationContext('ThreadHeader');
+  const { channel } = useChannelStateContext('');
+  const { displayTitle } = useChannelPreviewInfo({
+    channel,
+    overrideImage,
+    overrideTitle,
+  });
+
+  return (
+    <div className='str-chat__thread-header'>
+      <div className='str-chat__thread-header-details'>
+        <div className='str-chat__thread-header-title'>{t('Thread')}</div>
+        <div className='str-chat__thread-header-subtitle'>{displayTitle}</div>
+      </div>
+      <button
+        aria-label={t('aria/Close thread')}
+        className='str-chat__close-thread-button'
+        data-testid='close-button'
+        onClick={closeThread}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/icons.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/icons.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export const CloseIcon = ({ title }: { title?: string }) => {
+  const { t } = useTranslationContext('CloseIcon');
+
+  return (
+    <svg
+      data-testid='close-no-outline'
+      fill='none'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title ?? t('Close')}</title>
+      <path
+        d='M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z'
+        fill='black'
+      />
+    </svg>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Thread/index.ts
+++ b/libs/stream-chat-shim/src/components/Thread/index.ts
@@ -1,0 +1,4 @@
+export * from './Thread';
+export * from './ThreadHeader';
+export { ThreadStart } from './ThreadStart';
+export { useLegacyThreadContext } from './LegacyThreadContext';


### PR DESCRIPTION
## Summary
- port `ThreadHeader` from stream-chat-react
- include supporting icons and barrel
- add a simple render test

## Testing
- `pnpm -r build` *(fails: stream-chat-react build script missing i18next)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script)*

------
https://chatgpt.com/codex/tasks/task_e_685e0ecd470c8326b7aa5e583d76671f