### PR TITLE
Port ThreadStart component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadStart.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadStart.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadStart } from '../src/components/Thread/ThreadStart';
+
+test('renders without crashing', () => {
+  render(<ThreadStart />);
+});

--- a/libs/stream-chat-shim/src/components/Thread/ThreadStart.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/ThreadStart.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { useChannelStateContext } from '../../context/ChannelStateContext';
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export const ThreadStart = () => {
+  const { thread } = useChannelStateContext('ThreadStart');
+  const { t } = useTranslationContext('ThreadStart');
+
+  if (!thread?.reply_count) return null;
+
+  return (
+    <div className='str-chat__thread-start'>
+      {t('replyCount', { count: thread.reply_count })}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port `ThreadStart` component from stream-chat-react
- add basic render test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No `tsc` script)*

------
https://chatgpt.com/codex/tasks/task_e_685e0ed8623c8326ae1b9174dcd06171