### PR TITLE
Port Thread CloseIcon to chat shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/Thread_icons.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Thread_icons.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CloseIcon } from '../src/components/Thread/icons';
+
+test('renders thread icons without crashing', () => {
+  render(<CloseIcon />);
+});

--- a/libs/stream-chat-shim/src/components/Thread/icons.tsx
+++ b/libs/stream-chat-shim/src/components/Thread/icons.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { useTranslationContext } from '../../context/TranslationContext';
+
+export const CloseIcon = ({ title }: { title?: string }) => {
+  const { t } = useTranslationContext('CloseIcon');
+
+  return (
+    <svg
+      data-testid='close-no-outline'
+      fill='none'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title ?? t('Close')}</title>
+      <path
+        d='M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z'
+        fill='black'
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION
## Summary
- port `components/Thread/icons.tsx` to the shim
- add basic render test for the Thread icons

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*


------
https://chatgpt.com/codex/tasks/task_e_685e0ee4247c832685e231dbaad5d46f