### PR TITLE
Port ThreadContext

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadContext.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadContext.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadProvider } from '../src/components/Threads/ThreadContext';
+
+test('renders without crashing', () => {
+  render(<ThreadProvider />);
+});

--- a/libs/stream-chat-shim/src/components/Threads/ThreadContext.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadContext.tsx
@@ -1,0 +1,14 @@
+import React, { createContext, useContext, type PropsWithChildren } from 'react';
+import type { Thread } from 'chat-shim';
+
+export type ThreadContextValue = Thread | undefined;
+
+export const ThreadContext = createContext<ThreadContextValue>(undefined);
+
+export const useThreadContext = () => useContext(ThreadContext);
+
+export const ThreadProvider = ({ children, thread }: PropsWithChildren<{ thread?: Thread }>) => (
+  <ThreadContext.Provider value={thread}>{children}</ThreadContext.Provider>
+);
+
+export default ThreadContext;


### PR DESCRIPTION
## Summary
- add `ThreadContext` component
- include a render test for `ThreadProvider`

## Testing
- `pnpm -r --parallel build` *(fails: Module not found: 'stream-chat-react')*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find name 'LinkPreviewsManagerState')*

------
https://chatgpt.com/codex/tasks/task_e_685e0eef2bcc8326ab58fafca50fdb4a