### PR TITLE
Port ThreadList from stream-chat-react

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadList.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadList.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadList } from '../src/components/Threads/ThreadList/ThreadList';
+
+test('renders without crashing', () => {
+  render(<ThreadList />);
+});

--- a/libs/stream-chat-shim/src/components/Threads/ThreadContext.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadContext.tsx
@@ -1,0 +1,22 @@
+import React, { createContext, useContext } from 'react';
+
+import { Channel } from '../../components';
+
+import type { PropsWithChildren } from 'react';
+// import type { Thread } from 'stream-chat'; // TODO backend-wire-up
+type Thread = any;
+
+export type ThreadContextValue = Thread | undefined;
+
+export const ThreadContext = createContext<ThreadContextValue>(undefined);
+
+export const useThreadContext = () => useContext(ThreadContext);
+
+export const ThreadProvider = ({
+  children,
+  thread,
+}: PropsWithChildren<{ thread?: Thread }>) => (
+  <ThreadContext.Provider value={thread}>
+    <Channel channel={thread?.channel}>{children}</Channel>
+  </ThreadContext.Provider>
+);

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect } from 'react';
+import type { ComputeItemKey, VirtuosoProps } from 'react-virtuoso';
+import { Virtuoso } from 'react-virtuoso';
+
+// import type { Thread, ThreadManagerState } from 'stream-chat'; // TODO backend-wire-up
+type Thread = any;
+type ThreadManagerState = any;
+
+import { ThreadListItem as DefaultThreadListItem } from './ThreadListItem';
+import { ThreadListEmptyPlaceholder as DefaultThreadListEmptyPlaceholder } from './ThreadListEmptyPlaceholder';
+import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner } from './ThreadListUnseenThreadsBanner';
+import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from './ThreadListLoadingIndicator';
+import { useChatContext, useComponentContext } from '../../../context';
+import { useStateStore } from '../../../store';
+
+const selector = (nextValue: ThreadManagerState) => ({ threads: nextValue.threads });
+
+const computeItemKey: ComputeItemKey<Thread, unknown> = (_, item) => item.id;
+
+type ThreadListProps = {
+  virtuosoProps?: VirtuosoProps<Thread, unknown>;
+};
+
+export const useThreadList = () => {
+  const { client } = useChatContext();
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        /* TODO backend-wire-up: client.threads.activate */
+      }
+      if (document.visibilityState === 'hidden') {
+        /* TODO backend-wire-up: client.threads.deactivate */
+      }
+    };
+
+    handleVisibilityChange();
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      /* TODO backend-wire-up: client.threads.deactivate */
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [client]);
+};
+
+export const ThreadList = ({ virtuosoProps }: ThreadListProps) => {
+  const { client } = useChatContext();
+  const {
+    ThreadListEmptyPlaceholder = DefaultThreadListEmptyPlaceholder,
+    ThreadListItem = DefaultThreadListItem,
+    ThreadListLoadingIndicator = DefaultThreadListLoadingIndicator,
+    ThreadListUnseenThreadsBanner = DefaultThreadListUnseenThreadsBanner,
+  } = useComponentContext();
+  const { threads } = useStateStore(client.threads.state, selector);
+
+  useThreadList();
+
+  return (
+    <div className='str-chat__thread-list-container'>
+      {/* TODO: allow re-load on stale ThreadManager state */}
+      <ThreadListUnseenThreadsBanner />
+      <Virtuoso
+        atBottomStateChange={(atBottom) =>
+          atBottom && /* TODO backend-wire-up: client.threads.loadNextPage */ null
+        }
+        className='str-chat__thread-list'
+        components={{
+          EmptyPlaceholder: ThreadListEmptyPlaceholder,
+          Footer: ThreadListLoadingIndicator,
+        }}
+        computeItemKey={computeItemKey}
+        data={threads}
+        itemContent={(_, thread) => <ThreadListItem thread={thread} />}
+        // TODO: handle visibility (for a button that scrolls to the unread thread)
+        // itemsRendered={(items) => console.log({ items })}
+        {...virtuosoProps}
+      />
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListEmptyPlaceholder.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListEmptyPlaceholder.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Icon } from '../icons';
+
+export const ThreadListEmptyPlaceholder = () => (
+  <div className='str-chat__thread-list-empty-placeholder'>
+    <Icon.MessageBubble />
+    {/* TODO: translate */}
+    No threads here yet...
+  </div>
+);

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListItem.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListItem.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, useContext } from 'react';
+
+// import type { Thread } from 'stream-chat'; // TODO backend-wire-up
+type Thread = any;
+
+import { useComponentContext } from '../../../context';
+import { ThreadListItemUI as DefaultThreadListItemUI } from './ThreadListItemUI';
+
+import type { ThreadListItemUIProps } from './ThreadListItemUI';
+
+export type ThreadListItemProps = {
+  thread: Thread;
+  threadListItemUIProps?: ThreadListItemUIProps;
+};
+
+const ThreadListItemContext = createContext<Thread | undefined>(undefined);
+
+export const useThreadListItemContext = () => useContext(ThreadListItemContext);
+
+export const ThreadListItem = ({
+  thread,
+  threadListItemUIProps,
+}: ThreadListItemProps) => {
+  const { ThreadListItemUI = DefaultThreadListItemUI } = useComponentContext();
+
+  return (
+    <ThreadListItemContext.Provider value={thread}>
+      <ThreadListItemUI {...threadListItemUIProps} />
+    </ThreadListItemContext.Provider>
+  );
+};
+
+// const App = () => {
+//   const route = useRouter();
+
+//   return (
+//     <Chat>
+//       {route === '/channels' && (
+//         <Channel>
+//           <MessageList />
+//           <Thread />
+//         </Channel>
+//       )}
+//       {route === '/threads' && (
+//         <Threads>
+//           <ThreadList />
+//           <ThreadProvider>
+//             <Thread />
+//           </ThreadProvider>
+//         </Threads>
+//       )}
+//     </Chat>
+//   );
+// };
+
+// pre-built layout
+
+{
+  /* 
+<Chat client={chatClient}>
+  <Views>
+    // has default
+    <ViewSelector onItemPointerDown={} />
+    <View.Chat>
+      <Channel>
+        <MessageList />
+        <MessageInput />
+      </Channel>
+    </View.Chat>
+    <View.Thread> <-- activeThread state
+      <ThreadList /> <-- uses context for click handler
+      <WrappedThread /> <-- ThreadProvider + Channel combo
+    </View.Thread>
+  </Views>
+</Chat>;
+*/
+}

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListItemUI.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListItemUI.tsx
@@ -1,0 +1,145 @@
+import React, { useCallback } from 'react';
+import clsx from 'clsx';
+
+// import type { LocalMessage, ThreadState } from 'stream-chat'; // TODO backend-wire-up
+type LocalMessage = any;
+type ThreadState = any;
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { Timestamp } from '../../Message/Timestamp';
+import { Avatar } from '../../Avatar';
+import { Icon } from '../icons';
+import { UnreadCountBadge } from '../UnreadCountBadge';
+
+import { useChannelPreviewInfo } from '../../ChannelPreview';
+import { useChatContext } from '../../../context';
+import { useThreadsViewContext } from '../../ChatView';
+import { useThreadListItemContext } from './ThreadListItem';
+import { useStateStore } from '../../../store';
+
+export type ThreadListItemUIProps = ComponentPropsWithoutRef<'button'>;
+
+/**
+ * TODO:
+ * - maybe hover state? ask design
+ */
+
+export const attachmentTypeIconMap = {
+  audio: '🔈',
+  file: '📄',
+  image: '📷',
+  video: '🎥',
+  voiceRecording: '🎙️',
+} as const;
+
+// TODO: translations
+const getTitleFromMessage = ({
+  currentUserId,
+  message,
+}: {
+  currentUserId?: string;
+  message?: LocalMessage;
+}) => {
+  const attachment = message?.attachments?.at(0);
+
+  let attachmentIcon = '';
+
+  if (attachment) {
+    attachmentIcon +=
+      attachmentTypeIconMap[
+        (attachment.type as keyof typeof attachmentTypeIconMap) ?? 'file'
+      ] ?? attachmentTypeIconMap.file;
+  }
+
+  const messageBelongsToCurrentUser = message?.user?.id === currentUserId;
+
+  if (message?.deleted_at && message.parent_id)
+    return clsx(messageBelongsToCurrentUser && 'You:', 'This reply was deleted.');
+
+  if (message?.deleted_at && !message.parent_id)
+    return clsx(messageBelongsToCurrentUser && 'You:', 'The source message was deleted.');
+
+  if (attachment?.type === 'voiceRecording')
+    return clsx(attachmentIcon, messageBelongsToCurrentUser && 'You:', 'Voice message');
+
+  return clsx(
+    attachmentIcon,
+    messageBelongsToCurrentUser && 'You:',
+    message?.text || attachment?.fallback || 'N/A',
+  );
+};
+
+export const ThreadListItemUI = (props: ThreadListItemUIProps) => {
+  const { client } = useChatContext();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const thread = useThreadListItemContext()!;
+
+  const selector = useCallback(
+    (nextValue: ThreadState) => ({
+      channel: nextValue.channel,
+      deletedAt: nextValue.deletedAt,
+      latestReply: nextValue.replies.at(-1),
+      ownUnreadMessageCount:
+        (client.userID && nextValue.read[client.userID]?.unreadMessageCount) || 0,
+      parentMessage: nextValue.parentMessage,
+    }),
+    [client],
+  );
+
+  const { channel, deletedAt, latestReply, ownUnreadMessageCount, parentMessage } =
+    useStateStore(thread.state, selector);
+
+  const { displayTitle: channelDisplayTitle } = useChannelPreviewInfo({ channel });
+
+  const { activeThread, setActiveThread } = useThreadsViewContext();
+
+  const avatarProps = deletedAt ? null : latestReply?.user;
+
+  return (
+    <button
+      aria-selected={activeThread === thread}
+      className='str-chat__thread-list-item'
+      data-thread-id={thread.id}
+      onClick={() => setActiveThread(thread)}
+      role='option'
+      {...props}
+    >
+      <div className='str-chat__thread-list-item__channel'>
+        <Icon.MessageBubble />
+        <div className='str-chat__thread-list-item__channel-text'>
+          {channelDisplayTitle}
+        </div>
+      </div>
+      <div className='str-chat__thread-list-item__parent-message'>
+        <div className='str-chat__thread-list-item__parent-message-text'>
+          {/* TODO: use thread.title instead? */}
+          replied to: {getTitleFromMessage({ message: parentMessage })}
+        </div>
+        {!deletedAt && <UnreadCountBadge count={ownUnreadMessageCount} />}
+      </div>
+      <div className='str-chat__thread-list-item__latest-reply'>
+        <Avatar {...avatarProps} />
+        <div className='str-chat__thread-list-item__latest-reply-details'>
+          {!deletedAt && (
+            <div className='str-chat__thread-list-item__latest-reply-created-by'>
+              {latestReply?.user?.name || latestReply?.user?.id || 'Unknown sender'}
+            </div>
+          )}
+          <div className='str-chat__thread-list-item__latest-reply-text-and-timestamp'>
+            <div className='str-chat__thread-list-item__latest-reply-text'>
+              {deletedAt
+                ? 'This thread was deleted'
+                : getTitleFromMessage({
+                    currentUserId: client.user?.id,
+                    message: latestReply,
+                  })}
+            </div>
+            <div className='str-chat__thread-list-item__latest-reply-timestamp'>
+              <Timestamp timestamp={deletedAt ?? latestReply?.created_at} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListLoadingIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListLoadingIndicator.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+// import type { ThreadManagerState } from 'stream-chat'; // TODO backend-wire-up
+type ThreadManagerState = any;
+
+import { LoadingIndicator as DefaultLoadingIndicator } from '../../Loading';
+import { useChatContext, useComponentContext } from '../../../context';
+import { useStateStore } from '../../../store';
+
+const selector = (nextValue: ThreadManagerState) => ({
+  isLoadingNext: nextValue.pagination.isLoadingNext,
+});
+
+export const ThreadListLoadingIndicator = () => {
+  const { LoadingIndicator = DefaultLoadingIndicator } = useComponentContext();
+  const { client } = useChatContext();
+  const { isLoadingNext } = useStateStore(client.threads.state, selector);
+
+  if (!isLoadingNext) return null;
+
+  return (
+    <div className='str-chat__thread-list-loading-indicator'>
+      <LoadingIndicator />
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+// import type { ThreadManagerState } from 'stream-chat'; // TODO backend-wire-up
+type ThreadManagerState = any;
+
+import { Icon } from '../icons';
+import { useChatContext } from '../../../context';
+import { useStateStore } from '../../../store';
+
+const selector = (nextValue: ThreadManagerState) => ({
+  unseenThreadIds: nextValue.unseenThreadIds,
+});
+
+export const ThreadListUnseenThreadsBanner = () => {
+  const { client } = useChatContext();
+  const { unseenThreadIds } = useStateStore(client.threads.state, selector);
+
+  if (!unseenThreadIds.length) return null;
+
+  return (
+    <div className='str-chat__unseen-threads-banner'>
+      {/* TODO: translate */}
+      {unseenThreadIds.length} unread threads
+      <button
+        className='str-chat__unseen-threads-banner__button'
+        onClick={() =>
+          /* TODO backend-wire-up: client.threads.reload */ undefined
+        }
+      >
+        <Icon.Reload />
+      </button>
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/index.ts
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/index.ts
@@ -1,0 +1,3 @@
+export * from './ThreadList';
+export * from './ThreadListItem';
+export * from './ThreadListItemUI';

--- a/libs/stream-chat-shim/src/components/Threads/hooks/useThreadManagerState.ts
+++ b/libs/stream-chat-shim/src/components/Threads/hooks/useThreadManagerState.ts
@@ -1,0 +1,13 @@
+// import type { ThreadManagerState } from 'stream-chat'; // TODO backend-wire-up
+type ThreadManagerState = any;
+
+import { useChatContext } from '../../../context';
+import { useStateStore } from '../../../store';
+
+export const useThreadManagerState = <T extends readonly unknown[]>(
+  selector: (nextValue: ThreadManagerState) => T,
+) => {
+  const { client } = useChatContext();
+
+  return useStateStore(client.threads.state, selector);
+};

--- a/libs/stream-chat-shim/src/components/Threads/hooks/useThreadState.ts
+++ b/libs/stream-chat-shim/src/components/Threads/hooks/useThreadState.ts
@@ -1,0 +1,17 @@
+// import type { ThreadState } from 'stream-chat'; // TODO backend-wire-up
+type ThreadState = any;
+import { useThreadListItemContext } from '../ThreadList';
+import { useThreadContext } from '../ThreadContext';
+import { useStateStore } from '../../../store/';
+
+/**
+ * @description returns thread state, prioritizes `ThreadListItemContext` falls back to `ThreadContext` if not former is not present
+ */
+export const useThreadState = <T extends readonly unknown[]>(
+  selector: (nextValue: ThreadState) => T,
+) => {
+  const listItemThread = useThreadListItemContext();
+  const thread = useThreadContext();
+
+  return useStateStore(listItemThread?.state ?? thread?.state, selector);
+};


### PR DESCRIPTION
## Summary
- port ThreadList and related components from upstream `stream-chat-react`
- add test for ThreadList
- stub out SaaS calls and imports per backend-wire-up guidelines

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo not found)*
- `pnpm exec jest` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0ef9915c8326b447752ab42a5d63