### PR TITLE
Add ThreadListEmptyPlaceholder component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadListEmptyPlaceholder.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadListEmptyPlaceholder.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadListEmptyPlaceholder } from '../src/components/Threads/ThreadList/ThreadListEmptyPlaceholder';
+
+test('renders without crashing', () => {
+  render(<ThreadListEmptyPlaceholder />);
+});

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListEmptyPlaceholder.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListEmptyPlaceholder.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Icon } from '../icons';
+
+export const ThreadListEmptyPlaceholder = () => (
+  <div className='str-chat__thread-list-empty-placeholder'>
+    <Icon.MessageBubble />
+    {/* TODO: translate */}
+    No threads here yet...
+  </div>
+);


### PR DESCRIPTION
## Summary
- port ThreadListEmptyPlaceholder from stream-chat-react
- add a simple render test

## Testing
- `pnpm -r build` *(fails: module not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: type errors)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f056abc83268d2788b68aa3e7e1