### PR TITLE
Port ThreadListItemUI component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadListItemUI.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadListItemUI.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ThreadListItemUI } from '../src/ThreadListItemUI';
+import { ThreadListItemUI } from '../src/components/Threads/ThreadList/ThreadListItemUI';
 
-test('renders placeholder', () => {
-  const { getByTestId } = render(<ThreadListItemUI />);
-  expect(getByTestId('thread-list-item-ui-placeholder')).toBeTruthy();
+test('renders without crashing', () => {
+  render(<ThreadListItemUI />);
 });

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListItemUI.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListItemUI.tsx
@@ -1,0 +1,149 @@
+import React, { useCallback } from 'react';
+import clsx from 'clsx';
+
+// import type { LocalMessage, ThreadState } from 'stream-chat'; // TODO backend-wire-up
+import type { LocalMessage, ThreadState } from 'chat-shim';
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { Timestamp } from '../../Message/Timestamp';
+import { Avatar } from '../../Avatar';
+import { Icon } from '../icons';
+// import { UnreadCountBadge } from '../UnreadCountBadge'; // TODO backend-wire-up
+const UnreadCountBadge = (props: any) => <div {...props} />; // temporary shim
+
+// import { useChannelPreviewInfo } from '../../ChannelPreview'; // TODO backend-wire-up
+const useChannelPreviewInfo = (_: any) => ({ displayTitle: '' }); // temporary shim
+// import { useChatContext } from '../../../context'; // TODO backend-wire-up
+const useChatContext = () => ({ client: {} as any });
+import { useThreadsViewContext } from '../../ChatView';
+// import { useThreadListItemContext } from './ThreadListItem'; // TODO backend-wire-up
+const useThreadListItemContext = () => ({} as any);
+// import { useStateStore } from '../../../store'; // TODO backend-wire-up
+const useStateStore = (_store: any, selector: any) => selector({});
+
+export type ThreadListItemUIProps = ComponentPropsWithoutRef<'button'>;
+
+/**
+ * TODO:
+ * - maybe hover state? ask design
+ */
+
+export const attachmentTypeIconMap = {
+  audio: '🔈',
+  file: '📄',
+  image: '📷',
+  video: '🎥',
+  voiceRecording: '🎙️',
+} as const;
+
+// TODO: translations
+const getTitleFromMessage = ({
+  currentUserId,
+  message,
+}: {
+  currentUserId?: string;
+  message?: LocalMessage;
+}) => {
+  const attachment = message?.attachments?.at(0);
+
+  let attachmentIcon = '';
+
+  if (attachment) {
+    attachmentIcon +=
+      attachmentTypeIconMap[
+        (attachment.type as keyof typeof attachmentTypeIconMap) ?? 'file'
+      ] ?? attachmentTypeIconMap.file;
+  }
+
+  const messageBelongsToCurrentUser = message?.user?.id === currentUserId;
+
+  if (message?.deleted_at && message.parent_id)
+    return clsx(messageBelongsToCurrentUser && 'You:', 'This reply was deleted.');
+
+  if (message?.deleted_at && !message.parent_id)
+    return clsx(messageBelongsToCurrentUser && 'You:', 'The source message was deleted.');
+
+  if (attachment?.type === 'voiceRecording')
+    return clsx(attachmentIcon, messageBelongsToCurrentUser && 'You:', 'Voice message');
+
+  return clsx(
+    attachmentIcon,
+    messageBelongsToCurrentUser && 'You:',
+    message?.text || attachment?.fallback || 'N/A',
+  );
+};
+
+export const ThreadListItemUI = (props: ThreadListItemUIProps) => {
+  const { client } = useChatContext();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const thread = useThreadListItemContext()!;
+
+  const selector = useCallback(
+    (nextValue: ThreadState) => ({
+      channel: nextValue.channel,
+      deletedAt: nextValue.deletedAt,
+      latestReply: nextValue.replies.at(-1),
+      ownUnreadMessageCount:
+        (client.userID && nextValue.read[client.userID]?.unreadMessageCount) || 0,
+      parentMessage: nextValue.parentMessage,
+    }),
+    [client],
+  );
+
+  const { channel, deletedAt, latestReply, ownUnreadMessageCount, parentMessage } =
+    useStateStore(thread.state, selector);
+
+  const { displayTitle: channelDisplayTitle } = useChannelPreviewInfo({ channel });
+
+  const { activeThread, setActiveThread } = useThreadsViewContext();
+
+  const avatarProps = deletedAt ? null : latestReply?.user;
+
+  return (
+    <button
+      aria-selected={activeThread === thread}
+      className='str-chat__thread-list-item'
+      data-thread-id={thread.id}
+      onClick={() => setActiveThread(thread)}
+      role='option'
+      {...props}
+    >
+      <div className='str-chat__thread-list-item__channel'>
+        <Icon.MessageBubble />
+        <div className='str-chat__thread-list-item__channel-text'>
+          {channelDisplayTitle}
+        </div>
+      </div>
+      <div className='str-chat__thread-list-item__parent-message'>
+        <div className='str-chat__thread-list-item__parent-message-text'>
+          {/* TODO: use thread.title instead? */}
+          replied to: {getTitleFromMessage({ message: parentMessage })}
+        </div>
+        {!deletedAt && <UnreadCountBadge count={ownUnreadMessageCount} />}
+      </div>
+      <div className='str-chat__thread-list-item__latest-reply'>
+        <Avatar {...avatarProps} />
+        <div className='str-chat__thread-list-item__latest-reply-details'>
+          {!deletedAt && (
+            <div className='str-chat__thread-list-item__latest-reply-created-by'>
+              {latestReply?.user?.name || latestReply?.user?.id || 'Unknown sender'}
+            </div>
+          )}
+          <div className='str-chat__thread-list-item__latest-reply-text-and-timestamp'>
+            <div className='str-chat__thread-list-item__latest-reply-text'>
+              {deletedAt
+                ? 'This thread was deleted'
+                : getTitleFromMessage({
+                    currentUserId: client.user?.id,
+                    message: latestReply,
+                  })}
+            </div>
+            <div className='str-chat__thread-list-item__latest-reply-timestamp'>
+              <Timestamp timestamp={deletedAt ?? latestReply?.created_at} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/index.ts
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/index.ts
@@ -1,0 +1,3 @@
+// export * from './ThreadList'; // TODO backend-wire-up
+// export * from './ThreadListItem'; // TODO backend-wire-up
+export * from './ThreadListItemUI';

--- a/libs/stream-chat-shim/src/components/Threads/index.ts
+++ b/libs/stream-chat-shim/src/components/Threads/index.ts
@@ -1,0 +1,2 @@
+// export * from './ThreadContext'; // TODO backend-wire-up
+// export * from './ThreadList'; // TODO backend-wire-up


### PR DESCRIPTION
## Summary
- port `ThreadListItemUI` from Stream upstream
- add placeholder stubs for missing dependencies
- expose through ThreadList index files
- update tests for the real component

## Testing
- `pnpm -r run build` *(fails: next not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: cannot find type definitions)*
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f2468d8832696553ac43b53c6f0