### PR TITLE
Port ThreadListLoadingIndicator component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadListLoadingIndicatorComponent.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadListLoadingIndicatorComponent.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadListLoadingIndicator } from '../src/components/Threads/ThreadList/ThreadListLoadingIndicator';
+
+test('renders without crashing', () => {
+  render(<ThreadListLoadingIndicator />);
+});
+

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListLoadingIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListLoadingIndicator.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+// import type { ThreadManagerState } from 'stream-chat'; // TODO backend-wire-up
+type ThreadManagerState = any; // temporary shim
+
+import { LoadingIndicator as DefaultLoadingIndicator } from '../../Loading';
+// import { useChatContext, useComponentContext } from '../../../context'; // TODO backend-wire-up
+const useChatContext = () => ({ client: { threads: { state: {} } } } as any);
+const useComponentContext = () => ({ LoadingIndicator: DefaultLoadingIndicator } as any);
+// import { useStateStore } from '../../../store'; // TODO backend-wire-up
+const useStateStore = (_store: any, selector: any) => selector({ pagination: { isLoadingNext: false } });
+
+const selector = (nextValue: ThreadManagerState) => ({
+  isLoadingNext: nextValue.pagination.isLoadingNext,
+});
+
+export const ThreadListLoadingIndicator = () => {
+  const { LoadingIndicator = DefaultLoadingIndicator } = useComponentContext();
+  const { client } = useChatContext();
+  const { isLoadingNext } = useStateStore(client.threads.state, selector);
+
+  if (!isLoadingNext) return null;
+
+  return (
+    <div className='str-chat__thread-list-loading-indicator'>
+      <LoadingIndicator />
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- port `ThreadListLoadingIndicator` from stream-chat-react
- add basic test for the component

## Testing
- `pnpm build` *(fails: turbo_json_parse_error)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: Cannot find type definition file for 'jest', 'node', 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685e0f2ea2c08326a0b45373bc0e92bb