### PR TITLE
Port ThreadListUnseenThreadsBanner component

### DIFF
--- a/libs/stream-chat-shim/__tests__/ThreadListUnseenThreadsBanner.test.tsx
+++ b/libs/stream-chat-shim/__tests__/ThreadListUnseenThreadsBanner.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThreadListUnseenThreadsBanner } from '../src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner';
+
+test('renders without crashing', () => {
+  render(<ThreadListUnseenThreadsBanner />);
+});

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+// import type { ThreadManagerState } from 'stream-chat'; // TODO backend-wire-up
+type ThreadManagerState = any; // temporary shim
+
+import { Icon } from '../icons';
+import { useChatContext } from '../../../context';
+import { useStateStore } from '../../../store';
+
+const selector = (nextValue: ThreadManagerState) => ({
+  unseenThreadIds: nextValue.unseenThreadIds,
+});
+
+export const ThreadListUnseenThreadsBanner = () => {
+  const { client } = useChatContext();
+  const { unseenThreadIds } = useStateStore(client.threads.state, selector);
+
+  if (!unseenThreadIds.length) return null;
+
+  return (
+    <div className='str-chat__unseen-threads-banner'>
+      {/* TODO: translate */}
+      {unseenThreadIds.length} unread threads
+      <button
+        className='str-chat__unseen-threads-banner__button'
+        onClick={() => {
+          /* TODO backend-wire-up: client.threads.reload */ Promise.resolve(undefined);
+        }}
+      >
+        <Icon.Reload />
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- port ThreadListUnseenThreadsBanner from stream-ui
- add basic render test

## Testing
- `pnpm -r build` *(fails: i18next not found)*
- `pnpm -F frontend exec tsc --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f3adf8c832681a981ff75c56f7d