### PR TITLE
Port UnreadCountBadge component

### DIFF
--- a/libs/stream-chat-shim/__tests__/UnreadCountBadge.test.tsx
+++ b/libs/stream-chat-shim/__tests__/UnreadCountBadge.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { UnreadCountBadge } from '../src/components/Threads/UnreadCountBadge';
+
+test('renders without crashing', () => {
+  render(<UnreadCountBadge count={1}>child</UnreadCountBadge>);
+});

--- a/libs/stream-chat-shim/src/components/Threads/UnreadCountBadge.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/UnreadCountBadge.tsx
@@ -1,0 +1,26 @@
+import clsx from 'clsx';
+import React from 'react';
+import type { PropsWithChildren } from 'react';
+
+export const UnreadCountBadge = ({
+  children,
+  count,
+  position,
+}: PropsWithChildren<{
+  count: number;
+  position?: 'top-right' | 'bottom-right' | 'bottom-left' | 'top-left';
+}>) => (
+  <div className='str-chat__unread-count-badge-container'>
+    {children}
+    {count > 0 && (
+      <div
+        className={clsx(
+          'str-chat__unread-count-badge',
+          position && `str-chat__unread-count-badge--${position}`,
+        )}
+      >
+        {count}
+      </div>
+    )}
+  </div>
+);


### PR DESCRIPTION
## Summary
- copy `UnreadCountBadge` from upstream stream-chat-react
- add Jest test for the new component

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: No "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f46d9f883268655148f49d55bab