### PR TITLE
Port Tooltip component

### DIFF
--- a/libs/stream-chat-shim/__tests__/Tooltip.test.tsx
+++ b/libs/stream-chat-shim/__tests__/Tooltip.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Tooltip } from '../src/components/Tooltip/Tooltip';
+
+test('renders without crashing', () => {
+  render(<Tooltip />);
+});

--- a/libs/stream-chat-shim/src/components/Tooltip/Tooltip.tsx
+++ b/libs/stream-chat-shim/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,55 @@
+import type { ComponentProps } from 'react';
+import React, { useState } from 'react';
+import type { PopperProps } from 'react-popper';
+import { usePopper } from 'react-popper';
+
+export const Tooltip = ({ children, ...rest }: ComponentProps<'div'>) => (
+  <div className='str-chat__tooltip' {...rest}>
+    {children}
+  </div>
+);
+
+export type PopperTooltipProps<T extends HTMLElement> = React.PropsWithChildren<{
+  /** Reference element to which the tooltip should attach to */
+  referenceElement: T | null;
+  /** Popper's modifier (offset) property - [xAxis offset, yAxis offset], default [0, 10] */
+  offset?: [number, number];
+  /** Popper's placement property defining default position of the tooltip, default 'top' */
+  placement?: PopperProps<unknown>['placement'];
+  /** Tells component whether to render its contents */
+  visible?: boolean;
+}>;
+
+export const PopperTooltip = <T extends HTMLElement>({
+  children,
+  offset = [0, 10],
+  placement = 'top',
+  referenceElement,
+  visible = false,
+}: PopperTooltipProps<T>) => {
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const { attributes, styles } = usePopper(referenceElement, popperElement, {
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset,
+        },
+      },
+    ],
+    placement,
+  });
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className='str-chat__tooltip'
+      ref={setPopperElement}
+      style={styles.popper}
+      {...attributes.popper}
+    >
+      {children}
+    </div>
+  );
+};

--- a/libs/stream-chat-shim/src/components/Tooltip/hooks/index.ts
+++ b/libs/stream-chat-shim/src/components/Tooltip/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useEnterLeaveHandlers';

--- a/libs/stream-chat-shim/src/components/Tooltip/hooks/useEnterLeaveHandlers.ts
+++ b/libs/stream-chat-shim/src/components/Tooltip/hooks/useEnterLeaveHandlers.ts
@@ -1,0 +1,27 @@
+import type React from 'react';
+import { useCallback, useState } from 'react';
+
+export const useEnterLeaveHandlers = <T extends HTMLElement>({
+  onMouseEnter,
+  onMouseLeave,
+}: Partial<Record<'onMouseEnter' | 'onMouseLeave', React.MouseEventHandler<T>>> = {}) => {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+
+  const handleEnter: React.MouseEventHandler<T> = useCallback(
+    (e) => {
+      setTooltipVisible(true);
+      onMouseEnter?.(e);
+    },
+    [onMouseEnter],
+  );
+
+  const handleLeave: React.MouseEventHandler<T> = useCallback(
+    (e) => {
+      setTooltipVisible(false);
+      onMouseLeave?.(e);
+    },
+    [onMouseLeave],
+  );
+
+  return { handleEnter, handleLeave, tooltipVisible };
+};

--- a/libs/stream-chat-shim/src/components/Tooltip/index.ts
+++ b/libs/stream-chat-shim/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './Tooltip';


### PR DESCRIPTION
## Summary
- port Tooltip component and hooks from stream-ui
- add Tooltip test

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: None of the selected packages has a "tsc" script)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f6402ec8326875d7f97c3f9052e