### PR TITLE
Port NullComponent

### DIFF
--- a/libs/stream-chat-shim/__tests__/NullComponent.test.tsx
+++ b/libs/stream-chat-shim/__tests__/NullComponent.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { NullComponent } from '../src/components/UtilityComponents';
+
+test('renders without crashing', () => {
+  render(<NullComponent />);
+});

--- a/libs/stream-chat-shim/src/components/UtilityComponents/ErrorBoundary.tsx
+++ b/libs/stream-chat-shim/src/components/UtilityComponents/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import { Component } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+type ErrorBoundaryProps = PropsWithChildren<{ fallback?: ReactNode }>;
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boolean }> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, information: unknown) {
+    console.error(error, information);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/libs/stream-chat-shim/src/components/UtilityComponents/NullComponent.tsx
+++ b/libs/stream-chat-shim/src/components/UtilityComponents/NullComponent.tsx
@@ -1,0 +1,1 @@
+export const NullComponent = () => null;

--- a/libs/stream-chat-shim/src/components/UtilityComponents/index.ts
+++ b/libs/stream-chat-shim/src/components/UtilityComponents/index.ts
@@ -1,0 +1,2 @@
+export * from './NullComponent';
+export * from './ErrorBoundary';

--- a/libs/stream-chat-shim/src/components/UtilityComponents/useStableId.ts
+++ b/libs/stream-chat-shim/src/components/UtilityComponents/useStableId.ts
@@ -1,0 +1,13 @@
+import { nanoid } from 'nanoid';
+import { useMemo } from 'react';
+
+/**
+ * The ID is generated using the `nanoid` library and is memoized to ensure
+ * that it remains the same across renders unless the key changes.
+ */
+export const useStableId = (key?: string) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const id = useMemo(() => nanoid(), [key]);
+
+  return id;
+};


### PR DESCRIPTION
## Summary
- port UtilityComponents from stream-chat-react
- add sanity test for NullComponent

## Testing
- `pnpm -r --if-present build` *(fails: stream-chat-react build dependencies not installed)*
- `pnpm -F frontend tsc --noEmit` *(fails: no tsc script defined)*
- `pnpm test` *(fails: turbo json parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f8982608326ab566194ba698dd4