### PR TITLE
Window cleanup

### DIFF
--- a/libs/stream-chat-shim/src/components/Window/Window.tsx
+++ b/libs/stream-chat-shim/src/components/Window/Window.tsx
@@ -2,7 +2,8 @@ import React, { PropsWithChildren } from 'react';
 import clsx from 'clsx';
 
 import { useChannelStateContext } from '../../context/ChannelStateContext';
-import type { LocalMessage } from 'stream-chat';
+// import type { LocalMessage } from 'stream-chat'; // TODO backend-wire-up
+type LocalMessage = any;
 
 export type WindowProps = {
   /** optional prop to force addition of class str-chat__main-panel--thread-open to the Window root element */


### PR DESCRIPTION
## Summary
- excise stream-chat import from Window component

## Testing
- `pnpm --recursive build` *(fails: Can't resolve 'stream-chat-react')*
- `pnpm --filter frontend exec tsc --noEmit` *(fails: command failed with exit code 2)*


------
https://chatgpt.com/codex/tasks/task_e_685e0ff7ecb88326971974de6ede2dd5