### PR TITLE
Add unstub sweep script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "typescript": "5"
   },
   "scripts": {
-    "test": "turbo run test && jest"
+    "test": "turbo run test && jest",
+    "unstub": "tsx scripts/unstub-stream-ui.ts"
   },
   "dependencies": {
     "emoji-dictionary": "1.0.12",
@@ -26,5 +27,5 @@
     "overrides": {
       "stream-chat-react": "13.2.1"
     }
-  }  
+  }
 }

--- a/scripts/unstub-stream-ui.ts
+++ b/scripts/unstub-stream-ui.ts
@@ -1,0 +1,51 @@
+import fg from 'fast-glob';
+import fs from 'fs/promises';
+import path from 'path';
+import cp from 'child_process';
+
+const SHIM_SRC = path.resolve(__dirname, '../libs/stream-chat-shim/src');
+const UI_SRC = path.resolve(__dirname, '../libs/stream-ui/src');
+
+async function processFile(shimFile: string) {
+  let txt = await fs.readFile(shimFile, 'utf8');
+  if (!txt.includes('TODO backend-wire-up')) return;
+  const rel = path.relative(SHIM_SRC, shimFile);
+  const uiFile = path.join(UI_SRC, rel);
+  let imports: string[] = [];
+  try {
+    const upstream = await fs.readFile(uiFile, 'utf8');
+    imports = upstream
+      .split(/\r?\n/)
+      .filter((l) => l.trim().startsWith('import') &&
+        /(stream-chat(?:-react)?)/.test(l));
+  } catch {
+    // no upstream file
+  }
+  const lines = txt.split(/\r?\n/);
+  const cleaned: string[] = [];
+  for (const line of lines) {
+    if (line.includes('TODO backend-wire-up')) continue;
+    if (/^class \w+Controller/.test(line.trim())) continue;
+    cleaned.push(line);
+  }
+  if (imports.length) {
+    const firstNonImport = cleaned.findIndex((l) => !l.startsWith('import'));
+    const idx = firstNonImport === -1 ? cleaned.length : firstNonImport;
+    cleaned.splice(idx, 0, ...imports);
+  }
+  await fs.writeFile(shimFile, cleaned.join('\n'));
+  console.log('patched', rel);
+}
+
+async function main() {
+  for (const file of fg.sync('**/*.{ts,tsx}', { cwd: SHIM_SRC, absolute: true })) {
+    await processFile(file);
+  }
+  try {
+    cp.execSync('pnpm build && pnpm -F frontend tsc --noEmit', { stdio: 'inherit' });
+  } catch {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- implement `unstub-stream-ui.ts` to copy real import lines and remove stubs
- expose as `pnpm run unstub` in package.json

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm test` *(fails: turbo json parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685e713275988326b0d109ef57e8c6fb