### PR TITLE
Remove StreamChat usage from AIStateIndicator hook

### DIFF
--- a/libs/stream-chat-shim/src/components/AIStateIndicator/hooks/useAIState.ts
+++ b/libs/stream-chat-shim/src/components/AIStateIndicator/hooks/useAIState.ts
@@ -22,20 +22,13 @@ export const useAIState = (channel?: Channel): { aiState: AIState } => {
       return;
     }
 
-    const indicatorChangedListener = channel.on('ai_indicator.update', (event: Event) => {
-      const { cid } = event;
-      const state = event.ai_state as AIState;
-      if (channel.cid === cid) {
-        setAiState(state);
-      }
-    });
+    const indicatorChangedListener = /* TODO backend-wire-up: on */ {
+      unsubscribe: () => {},
+    } as any;
 
-    const indicatorClearedListener = channel.on('ai_indicator.clear', (event) => {
-      const { cid } = event;
-      if (channel.cid === cid) {
-        setAiState(AIStates.Idle);
-      }
-    });
+    const indicatorClearedListener = /* TODO backend-wire-up: on */ {
+      unsubscribe: () => {},
+    } as any;
 
     return () => {
       indicatorChangedListener.unsubscribe();


### PR DESCRIPTION
## Summary
- stub out Channel event calls in AIStateIndicator hook per AGENTS

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e9896791c8326a9464c33691c3abd