### PR TITLE
Stub StreamChat SDK calls in ChannelList components

### DIFF
--- a/libs/stream-chat-shim/src/components/ChannelList/ChannelList.js
+++ b/libs/stream-chat-shim/src/components/ChannelList/ChannelList.js
@@ -182,11 +182,11 @@ useConnectionRecoveredListener(forceUpdate);
             setActiveChannel();
         }
     };
-    client.on('channel.deleted', handleEvent);
-    client.on('channel.hidden', handleEvent);
+    /* TODO backend-wire-up: client.on */
+    /* TODO backend-wire-up: client.on */
     return function () {
-        client.off('channel.deleted', handleEvent);
-        client.off('channel.hidden', handleEvent);
+        /* TODO backend-wire-up: client.off */
+        /* TODO backend-wire-up: client.off */
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
 }, [channel === null || channel === void 0 ? void 0 : channel.cid]);

--- a/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
@@ -247,9 +247,7 @@ const UnMemoizedChannelList = (props: ChannelListProps) => {
       );
 
       if (!customActiveChannelObject) {
-        [customActiveChannelObject] = await client.queryChannels({
-          id: customActiveChannel,
-        });
+        [customActiveChannelObject] = await /* TODO backend-wire-up: client.queryChannels */ Promise.resolve([]);
       }
 
       if (customActiveChannelObject) {
@@ -339,12 +337,12 @@ const UnMemoizedChannelList = (props: ChannelListProps) => {
       }
     };
 
-    client.on('channel.deleted', handleEvent);
-    client.on('channel.hidden', handleEvent);
+    /* TODO backend-wire-up: client.on */
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('channel.deleted', handleEvent);
-      client.off('channel.hidden', handleEvent);
+      /* TODO backend-wire-up: client.off */
+      /* TODO backend-wire-up: client.off */
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel?.cid]);

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelDeletedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelDeletedListener.ts
@@ -30,10 +30,10 @@ export const useChannelDeletedListener = (
       }
     };
 
-    client.on('channel.deleted', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('channel.deleted', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelHiddenListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelHiddenListener.ts
@@ -29,10 +29,10 @@ export const useChannelHiddenListener = (
       }
     };
 
-    client.on('channel.hidden', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('channel.hidden', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelListShape.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelListShape.ts
@@ -110,7 +110,7 @@ export const useChannelListShapeDefaults = () => {
       if (!channelType || !channelId) return;
 
       setChannels((currentChannels) => {
-        const targetChannel = client.channel(channelType, channelId);
+        const targetChannel = /* TODO backend-wire-up: client.channel */ {} as any;
         const targetChannelIndex = currentChannels.indexOf(targetChannel);
         const targetChannelExistsWithinList = targetChannelIndex >= 0;
 
@@ -280,7 +280,7 @@ export const useChannelListShapeDefaults = () => {
       const pinnedAtSort = extractSortValue({ atIndex: 0, sort, targetKey: 'pinned_at' });
 
       setChannels((currentChannels) => {
-        const targetChannel = client.channel(channelType, channelId);
+        const targetChannel = /* TODO backend-wire-up: client.channel */ {} as any;
         // assumes that channel instances are not changing
         const targetChannelIndex = currentChannels.indexOf(targetChannel);
         const targetChannelExistsWithinList = targetChannelIndex >= 0;
@@ -644,7 +644,7 @@ export const useChannelListShape = (handler: (e: Event) => void) => {
   const { client } = useChatContext();
 
   useEffect(() => {
-    const subscription = client.on('all', handler);
+    const subscription = /* TODO backend-wire-up: client.on */ { unsubscribe: () => {} };
 
     return subscription.unsubscribe;
   }, [client, handler]);

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelTruncatedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelTruncatedListener.ts
@@ -26,10 +26,10 @@ export const useChannelTruncatedListener = (
       }
     };
 
-    client.on('channel.truncated', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('channel.truncated', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, customHandler, forceUpdate, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
@@ -44,10 +44,10 @@ export const useChannelUpdatedListener = (
       }
     };
 
-    client.on('channel.updated', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('channel.updated', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, customHandler, forceUpdate, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelVisibleListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelVisibleListener.ts
@@ -30,10 +30,10 @@ export const useChannelVisibleListener = (
       }
     };
 
-    client.on('channel.visible', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('channel.visible', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useConnectionRecoveredListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useConnectionRecoveredListener.ts
@@ -12,10 +12,10 @@ export const useConnectionRecoveredListener = (forceUpdate?: () => void) => {
       }
     };
 
-    client.on('connection.recovered', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('connection.recovered', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, forceUpdate]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
@@ -32,7 +32,7 @@ export const useMessageNewListener = (
             allowNewMessagesFromUnfilteredChannels &&
             event.channel_type
           ) {
-            const channel = client.channel(event.channel_type, event.channel_id);
+            const channel = /* TODO backend-wire-up: client.channel */ {} as any;
             return uniqBy([channel, ...channels], 'cid');
           }
 
@@ -43,10 +43,10 @@ export const useMessageNewListener = (
       }
     };
 
-    client.on('message.new', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('message.new', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [
     allowNewMessagesFromUnfilteredChannels,

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationAddedToChannelListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationAddedToChannelListener.ts
@@ -38,10 +38,10 @@ export const useNotificationAddedToChannelListener = (
       }
     };
 
-    client.on('notification.added_to_channel', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('notification.added_to_channel', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [allowNewMessagesFromUnfilteredChannels, client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationMessageNewListener.ts
@@ -31,10 +31,10 @@ export const useNotificationMessageNewListener = (
       }
     };
 
-    client.on('notification.message_new', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('notification.message_new', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [allowNewMessagesFromUnfilteredChannels, client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
@@ -24,10 +24,10 @@ export const useNotificationRemovedFromChannelListener = (
       }
     };
 
-    client.on('notification.removed_from_channel', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('notification.removed_from_channel', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -89,11 +89,7 @@ export const usePaginatedChannels = (
           ...options,
         };
 
-        const channelQueryResponse = await client.queryChannels(
-          filters,
-          sort || {},
-          newOptions,
-        );
+        const channelQueryResponse = await /* TODO backend-wire-up: client.queryChannels */ Promise.resolve([]);
 
         const newChannels =
           queryType === 'reload'
@@ -141,7 +137,7 @@ export const usePaginatedChannels = (
 
   useEffect(() => {
     if (client.recoverStateOnReconnect) return;
-    const { unsubscribe } = client.on('connection.recovered', throttleRecover);
+    const { unsubscribe } = /* TODO backend-wire-up: client.on */ { unsubscribe: () => {} };
 
     return () => {
       unsubscribe();

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useSelectedChannelState.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useSelectedChannelState.ts
@@ -28,10 +28,8 @@ export function useSelectedChannelState<O>({
     (onStoreChange: (value: O) => void) => {
       if (!channel) return noop;
 
-      const subscriptions = stateChangeEventKeys.map((et) =>
-        channel.on(et, () => {
-          onStoreChange(selector(channel));
-        }),
+      const subscriptions = stateChangeEventKeys.map(
+        () => /* TODO backend-wire-up: channel.on */ { unsubscribe: () => {} },
       );
 
       return () => subscriptions.forEach((subscription) => subscription.unsubscribe());

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useUserPresenceChangedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useUserPresenceChangedListener.ts
@@ -27,10 +27,10 @@ export const useUserPresenceChangedListener = (
       });
     };
 
-    client.on('user.presence.changed', handleEvent);
+    /* TODO backend-wire-up: client.on */
 
     return () => {
-      client.off('user.presence.changed', handleEvent);
+      /* TODO backend-wire-up: client.off */
     };
   }, [client, setChannels]);
 };


### PR DESCRIPTION
## Summary
- replace StreamChat client calls in ChannelList components with backend TODOs

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e99295f488326a9ff77e3d2583949