### PR TITLE
Remove SDK usage in ChannelPreview

### DIFF
--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
@@ -104,19 +104,21 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
       if (channel.cid === event.cid) setUnread(0);
     };
 
-    client.on('notification.mark_read', handleEvent);
-    return () => client.off('notification.mark_read', handleEvent);
+    /* TODO backend-wire-up: client.on */
+    return () => {
+      /* TODO backend-wire-up: client.off */
+    };
   }, [channel, client]);
 
   useEffect(() => {
     const handleEvent = (event: Event) => {
       if (channel.cid !== event.cid) return;
       if (event.user?.id !== client.user?.id) return;
-      setUnread(channel.countUnread());
+        setUnread(/* TODO backend-wire-up: channel.countUnread */ 0);
     };
-    channel.on('notification.mark_unread', handleEvent);
+    /* TODO backend-wire-up: channel.on */
     return () => {
-      channel.off('notification.mark_unread', handleEvent);
+      /* TODO backend-wire-up: channel.off */
     };
   }, [channel, client]);
 
@@ -126,7 +128,7 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
         if (muted) {
           setUnread(0);
         } else {
-          setUnread(channel.countUnread());
+            setUnread(/* TODO backend-wire-up: channel.countUnread */ 0);
         }
       }, 400),
     [channel, muted],
@@ -142,18 +144,18 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
       refreshUnreadCount();
     };
 
-    channel.on('message.new', handleEvent);
-    channel.on('message.updated', handleEvent);
-    channel.on('message.deleted', handleEvent);
-    channel.on('message.undeleted', handleEvent);
-    channel.on('channel.truncated', handleEvent);
+      /* TODO backend-wire-up: channel.on */
+      /* TODO backend-wire-up: channel.on */
+      /* TODO backend-wire-up: channel.on */
+      /* TODO backend-wire-up: channel.on */
+      /* TODO backend-wire-up: channel.on */
 
     return () => {
-      channel.off('message.new', handleEvent);
-      channel.off('message.updated', handleEvent);
-      channel.off('message.deleted', handleEvent);
-      channel.off('message.undeleted', handleEvent);
-      channel.off('channel.truncated', handleEvent);
+        /* TODO backend-wire-up: channel.off */
+        /* TODO backend-wire-up: channel.off */
+        /* TODO backend-wire-up: channel.off */
+        /* TODO backend-wire-up: channel.off */
+        /* TODO backend-wire-up: channel.off */
     };
   }, [channel, refreshUnreadCount, channelUpdateCount]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
@@ -28,9 +28,9 @@ export function ChannelPreviewActionButtons({
         onClick={(e) => {
           e.stopPropagation();
           if (membership.pinned_at) {
-            channel.unpin();
+            /* TODO backend-wire-up: channel.unpin */
           } else {
-            channel.pin();
+            /* TODO backend-wire-up: channel.pin */
           }
         }}
         title={membership.pinned_at ? t('Unpin') : t('Pin')}
@@ -47,9 +47,9 @@ export function ChannelPreviewActionButtons({
         onClick={(e) => {
           e.stopPropagation();
           if (membership.archived_at) {
-            channel.unarchive();
+            /* TODO backend-wire-up: channel.unarchive */
           } else {
-            channel.archive();
+            /* TODO backend-wire-up: channel.archive */
           }
         }}
         title={membership.archived_at ? t('Unarchive') : t('Archive')}

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useChannelPreviewInfo.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useChannelPreviewInfo.ts
@@ -40,9 +40,9 @@ export const useChannelPreviewInfo = (props: ChannelPreviewInfoParams) => {
 
     updateInfo();
 
-    client.on('user.updated', updateInfo);
+    /* TODO backend-wire-up: client.on */
     return () => {
-      client.off('user.updated', updateInfo);
+      /* TODO backend-wire-up: client.off */
     };
   }, [channel, channel.data, client, overrideImage, overrideTitle]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
@@ -7,13 +7,18 @@ import type { Channel } from 'chat-shim';
 export const useIsChannelMuted = (channel: Channel) => {
   const { client } = useChatContext('useIsChannelMuted');
 
-  const [muted, setMuted] = useState(channel.muteStatus());
+  const [muted, setMuted] = useState(
+    /* TODO backend-wire-up: channel.muteStatus */ false,
+  );
 
   useEffect(() => {
-    const handleEvent = () => setMuted(channel.muteStatus());
+    const handleEvent = () =>
+      setMuted(/* TODO backend-wire-up: channel.muteStatus */ false);
 
-    client.on('notification.channel_mutes_updated', handleEvent);
-    return () => client.off('notification.channel_mutes_updated', handleEvent);
+    /* TODO backend-wire-up: client.on */
+    return () => {
+      /* TODO backend-wire-up: client.off */
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [muted]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
@@ -62,10 +62,10 @@ export const useMessageDeliveryStatus = ({
       return setMessageDeliveryStatus(MessageDeliveryStatus.DELIVERED);
     };
 
-    channel.on('message.new', handleMessageNew);
+    /* TODO backend-wire-up: channel.on */
 
     return () => {
-      channel.off('message.new', handleMessageNew);
+      /* TODO backend-wire-up: channel.off */
     };
   }, [channel, client, isOwnMessage]);
 
@@ -75,10 +75,10 @@ export const useMessageDeliveryStatus = ({
       if (event.user?.id !== client.user?.id)
         setMessageDeliveryStatus(MessageDeliveryStatus.READ);
     };
-    channel.on('message.read', handleMarkRead);
+    /* TODO backend-wire-up: channel.on */
 
     return () => {
-      channel.off('message.read', handleMarkRead);
+      /* TODO backend-wire-up: channel.off */
     };
   }, [channel, client, lastMessage, isOwnMessage]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/utils.js
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/utils.js
@@ -32,7 +32,7 @@ var getLatestMessagePreview = function (channel, t, userLanguage, isMessageAIGen
     }
     if (poll) {
         if (!poll.vote_count) {
-            var createdBy = ((_b = poll.created_by) === null || _b === void 0 ? void 0 : _b.id) === channel.getClient().userID
+            var createdBy = ((_b = poll.created_by) === null || _b === void 0 ? void 0 : _b.id) === /* TODO backend-wire-up: channel.getClient */ ''
                 ? t('You')
                 : ((_d = (_c = poll.created_by) === null || _c === void 0 ? void 0 : _c.name) !== null && _d !== void 0 ? _d : t('Poll'));
             return t('📊 {{createdBy}} created: {{ pollName}}', {
@@ -46,7 +46,7 @@ var getLatestMessagePreview = function (channel, t, userLanguage, isMessageAIGen
             if (option && latestVote_1) {
                 return t('📊 {{votedBy}} voted: {{pollOptionText}}', {
                     pollOptionText: option.text,
-                    votedBy: ((_e = latestVote_1 === null || latestVote_1 === void 0 ? void 0 : latestVote_1.user) === null || _e === void 0 ? void 0 : _e.id) === channel.getClient().userID
+                    votedBy: ((_e = latestVote_1 === null || latestVote_1 === void 0 ? void 0 : latestVote_1.user) === null || _e === void 0 ? void 0 : _e.id) === /* TODO backend-wire-up: channel.getClient */ ''
                         ? t('You')
                         : ((_g = (_f = latestVote_1.user) === null || _f === void 0 ? void 0 : _f.name) !== null && _g !== void 0 ? _g : t('Poll')),
                 });

--- a/libs/stream-chat-shim/src/components/ChannelPreview/utils.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/utils.tsx
@@ -47,10 +47,11 @@ export const getLatestMessagePreview = (
 
   if (poll) {
     if (!poll.vote_count) {
-      const createdBy =
-        poll.created_by?.id === channel.getClient().userID
+        const createdBy =
+        poll.created_by?.id ===
+          /* TODO backend-wire-up: channel.getClient */ ''
           ? t('You')
-          : (poll.created_by?.name ?? t('Poll'));
+          : poll.created_by?.name ?? t('Poll');
       return t('📊 {{createdBy}} created: {{ pollName}}', {
         createdBy,
         pollName: poll.name,
@@ -65,10 +66,11 @@ export const getLatestMessagePreview = (
       if (option && latestVote) {
         return t('📊 {{votedBy}} voted: {{pollOptionText}}', {
           pollOptionText: option.text,
-          votedBy:
-            latestVote?.user?.id === channel.getClient().userID
-              ? t('You')
-              : (latestVote.user?.name ?? t('Poll')),
+            votedBy:
+              latestVote?.user?.id ===
+                /* TODO backend-wire-up: channel.getClient */ ''
+                ? t('You')
+                : latestVote.user?.name ?? t('Poll'),
         });
       }
     }


### PR DESCRIPTION
## Summary
- strip Stream Chat API calls from ChannelPreview components

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e994783648326aef41096462e6536