### PR TITLE
Remove StreamChat SDK calls from Message components

### DIFF
--- a/libs/stream-chat-shim/src/components/Message/MessageSimple.js
+++ b/libs/stream-chat-shim/src/components/Message/MessageSimple.js
@@ -84,7 +84,8 @@ var MessageSimpleWithContext = function (props) {
         'str-chat__virtual-message__wrapper--first': firstOfGroup,
         'str-chat__virtual-message__wrapper--group': groupedByUser,
     });
-    var poll = message.poll_id && client.polls.fromState(message.poll_id);
+    var poll = message.poll_id &&
+        /* TODO backend-wire-up: polls.fromState */ undefined;
     return (<>
       {editing && (<MessageInput_1.EditMessageModal additionalMessageInputProps={additionalMessageInputProps}/>)}
       {isBounceDialogOpen && (<MessageBounceModal_1.MessageBounceModal MessageBouncePrompt={MessageBouncePrompt} onClose={function () { return setIsBounceDialogOpen(false); }} open={isBounceDialogOpen}/>)}

--- a/libs/stream-chat-shim/src/components/Message/MessageSimple.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageSimple.tsx
@@ -145,7 +145,8 @@ const MessageSimpleWithContext = (props: MessageSimpleWithContextProps) => {
     },
   );
 
-  const poll = message.poll_id && client.polls.fromState(message.poll_id);
+  const poll = message.poll_id &&
+    /* TODO backend-wire-up: polls.fromState */ undefined;
 
   return (
     <>

--- a/libs/stream-chat-shim/src/components/Message/MessageThreadReplyInChannelButtonIndicator.js
+++ b/libs/stream-chat-shim/src/components/Message/MessageThreadReplyInChannelButtonIndicator.js
@@ -48,7 +48,10 @@ var MessageThreadReplyInChannelButtonIndicator = function () {
     var message = (0, context_1.useMessageContext)().message;
     var parentMessageRef = (0, react_1.useRef)(undefined);
     var querySearchParent = function () {
-        return Promise.resolve({ results: [] })
+        return Promise.resolve({
+            /* TODO backend-wire-up: search */
+            results: []
+        })
             .then(function (_a) {
             var results = _a.results;
             if (!results.length) {
@@ -57,17 +60,7 @@ var MessageThreadReplyInChannelButtonIndicator = function () {
             parentMessageRef.current = formatMessage(results[0].message);
         })
             .catch(function (error) {
-            client.notifications.addError({
-                message: t('Thread has not been found'),
-                options: {
-                    originalError: error,
-                    type: 'api:message:search:not-found',
-                },
-                origin: {
-                    context: { threadReply: message },
-                    emitter: 'MessageThreadReplyInChannelButtonIndicator',
-                },
-            });
+            /* TODO backend-wire-up: addError */
         });
     };
     (0, react_1.useEffect)(function () {
@@ -75,7 +68,7 @@ var MessageThreadReplyInChannelButtonIndicator = function () {
             parentMessageRef.current === null ||
             !message.parent_id)
             return;
-        var localMessage = channel.state.findMessage(message.parent_id);
+        var localMessage = undefined; /* TODO backend-wire-up: findMessage */
         if (localMessage) {
             parentMessageRef.current = localMessage;
             return;

--- a/libs/stream-chat-shim/src/components/Message/MessageThreadReplyInChannelButtonIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageThreadReplyInChannelButtonIndicator.tsx
@@ -18,9 +18,10 @@ export const MessageThreadReplyInChannelButtonIndicator = () => {
   const parentMessageRef = useRef<LocalMessage | null | undefined>(undefined);
 
   const querySearchParent = () =>
-    channel
-      .getClient()
-      .search({ cid: channel.cid }, { id: message.parent_id })
+    Promise.resolve({
+      /* TODO backend-wire-up: search */
+      results: [],
+    })
       .then(({ results }) => {
         if (!results.length) {
           throw new Error('Thread has not been found');
@@ -28,17 +29,7 @@ export const MessageThreadReplyInChannelButtonIndicator = () => {
         parentMessageRef.current = formatMessage(results[0].message);
       })
       .catch((error: Error) => {
-        client.notifications.addError({
-          message: t('Thread has not been found'),
-          options: {
-            originalError: error,
-            type: 'api:message:search:not-found',
-          },
-          origin: {
-            context: { threadReply: message },
-            emitter: 'MessageThreadReplyInChannelButtonIndicator',
-          },
-        });
+        /* TODO backend-wire-up: addError */
       });
 
   useEffect(() => {
@@ -48,7 +39,8 @@ export const MessageThreadReplyInChannelButtonIndicator = () => {
       !message.parent_id
     )
       return;
-    const localMessage = channel.state.findMessage(message.parent_id);
+    const localMessage = undefined as unknown as LocalMessage; //
+    /* TODO backend-wire-up: findMessage */
     if (localMessage) {
       parentMessageRef.current = localMessage;
       return;

--- a/libs/stream-chat-shim/src/components/Message/QuotedMessage.js
+++ b/libs/stream-chat-shim/src/components/Message/QuotedMessage.js
@@ -24,7 +24,7 @@ var QuotedMessage = function (_a) {
     var Avatar = ContextAvatar || Avatar_1.Avatar;
     var quoted_message = message.quoted_message;
     var poll = (quoted_message === null || quoted_message === void 0 ? void 0 : quoted_message.poll_id) &&
-    ;
+        /* TODO backend-wire-up: polls.fromState */ undefined;
     var quotedMessageDeleted = (quoted_message === null || quoted_message === void 0 ? void 0 : quoted_message.deleted_at) || (quoted_message === null || quoted_message === void 0 ? void 0 : quoted_message.type) === 'deleted';
     var quotedMessageText = quotedMessageDeleted
         ? t('This message was deleted...')

--- a/libs/stream-chat-shim/src/components/Message/QuotedMessage.tsx
+++ b/libs/stream-chat-shim/src/components/Message/QuotedMessage.tsx
@@ -33,7 +33,9 @@ export const QuotedMessage = ({ renderText: propsRenderText }: QuotedMessageProp
 
   const { quoted_message } = message;
 
-  const poll = quoted_message?.poll_id && client.polls.fromState(quoted_message.poll_id);
+  const poll =
+    quoted_message?.poll_id &&
+    /* TODO backend-wire-up: polls.fromState */ undefined;
   const quotedMessageDeleted =
     quoted_message?.deleted_at || quoted_message?.type === 'deleted';
 

--- a/libs/stream-chat-shim/src/components/Message/hooks/useActionHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useActionHandler.ts
@@ -38,7 +38,9 @@ export function useActionHandler(message?: LocalMessage): ActionHandlerReturnTyp
     }
 
     if (messageID) {
-      const data = await channel.sendAction(messageID, formData);
+      const data = await Promise.resolve(
+        /* TODO backend-wire-up: sendAction */ undefined,
+      );
 
       if (data?.message) {
         updateMessage(data.message);

--- a/libs/stream-chat-shim/src/components/Message/hooks/useFlagHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useFlagHandler.ts
@@ -37,7 +37,9 @@ export const useFlagHandler = (
     }
 
     try {
-      await client.flagMessage(message.id);
+      await Promise.resolve(
+        /* TODO backend-wire-up: flagMessage */ undefined,
+      );
 
       const successMessage =
         getSuccessNotification &&

--- a/libs/stream-chat-shim/src/components/Message/hooks/useMarkUnreadHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useMarkUnreadHandler.ts
@@ -27,7 +27,9 @@ export const useMarkUnreadHandler = (
     }
 
     try {
-      await channel.markUnread({ message_id: message.id });
+      await Promise.resolve(
+        /* TODO backend-wire-up: markUnread */ undefined,
+      );
       if (!notify) return;
       const successMessage =
         getSuccessNotification &&

--- a/libs/stream-chat-shim/src/components/Message/hooks/useMuteHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useMuteHandler.ts
@@ -37,7 +37,9 @@ export const useMuteHandler = (
 
     if (!isUserMuted(message, mutes)) {
       try {
-        await client.muteUser(message.user.id);
+        await Promise.resolve(
+          /* TODO backend-wire-up: muteUser */ undefined,
+        );
 
         const successMessage =
           getSuccessNotification &&
@@ -59,7 +61,9 @@ export const useMuteHandler = (
       }
     } else {
       try {
-        await client.unmuteUser(message.user.id);
+        await Promise.resolve(
+          /* TODO backend-wire-up: unmuteUser */ undefined,
+        );
 
         const fallbackMessage = t(`{{ user }} has been unmuted`, {
           user: message.user.name || message.user.id,

--- a/libs/stream-chat-shim/src/components/Message/hooks/usePinHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/usePinHandler.ts
@@ -71,7 +71,9 @@ export const usePinHandler = (
 
         updateMessage(optimisticMessage);
 
-        await client.pinMessage(message);
+        await Promise.resolve(
+          /* TODO backend-wire-up: pinMessage */ undefined,
+        );
       } catch (e) {
         const errorMessage =
           getErrorNotification && validateAndGetMessage(getErrorNotification, [message]);
@@ -91,7 +93,9 @@ export const usePinHandler = (
 
         updateMessage(optimisticMessage);
 
-        await client.unpinMessage(message);
+        await Promise.resolve(
+          /* TODO backend-wire-up: unpinMessage */ undefined,
+        );
       } catch (e) {
         const errorMessage =
           getErrorNotification && validateAndGetMessage(getErrorNotification, [message]);

--- a/libs/stream-chat-shim/src/components/Message/hooks/useReactionHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useReactionHandler.ts
@@ -88,8 +88,12 @@ export const useReactionHandler = (message?: LocalMessage) => {
       thread?.upsertReplyLocally({ message: tempMessage });
 
       const messageResponse = add
-        ? await channel.sendReaction(id, { type } as Reaction)
-        : await channel.deleteReaction(id, type);
+        ? await Promise.resolve(
+            /* TODO backend-wire-up: sendReaction */ { message: tempMessage },
+          )
+        : await Promise.resolve(
+            /* TODO backend-wire-up: deleteReaction */ { message: tempMessage },
+          );
 
       // seems useless as we're expecting WS event to come in and replace this anyway
       updateMessage(messageResponse.message);

--- a/libs/stream-chat-shim/src/components/Message/hooks/useReactionsFetcher.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useReactionsFetcher.ts
@@ -45,12 +45,11 @@ async function fetchMessageReactions(
   let hasNext = true;
 
   while (hasNext && reactions.length < MAX_MESSAGE_REACTIONS_TO_FETCH) {
-    const response = await client.queryReactions(
-      messageId,
-      reactionType ? { type: reactionType } : {},
-      sort,
-      { limit, next },
-    );
+    const response = await Promise.resolve({
+      /* TODO backend-wire-up: queryReactions */
+      next: undefined,
+      reactions: [],
+    });
 
     reactions.push(...response.reactions);
     next = response.next;


### PR DESCRIPTION
## Summary
- replace StreamChat calls with backend-wire-up placeholders in Message components

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9b2ebb108326a2235dbb8008cbde