### PR TITLE
Remove StreamChat calls in MessageActions

### DIFF
--- a/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.js
+++ b/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.js
@@ -48,7 +48,6 @@ var MESSAGE_ACTIONS = {
 };
 var UnMemoizedMessageActionsBox = function (props) {
     var className = props.className, getMessageActions = props.getMessageActions, handleDelete = props.handleDelete, handleEdit = props.handleEdit, handleFlag = props.handleFlag, handleMarkUnread = props.handleMarkUnread, handleMute = props.handleMute, handlePin = props.handlePin, isUserMuted = props.isUserMuted, mine = props.mine, open = props.open, restDivProps = __rest(props, ["className", "getMessageActions", "handleDelete", "handleEdit", "handleFlag", "handleMarkUnread", "handleMute", "handlePin", "isUserMuted", "mine", "open"]);
-    var client = useChatContext().client;
     var _a = useComponentContext('MessageActionsBox').CustomMessageActionsList, CustomMessageActionsList = _a === void 0 ? CustomMessageActionsList_1.CustomMessageActionsList : _a;
     var _b = useMessageContext('MessageActionsBox'), customMessageActions = _b.customMessageActions, message = _b.message, threadList = _b.threadList;
     var t = useTranslationContext('MessageActionsBox').t;
@@ -97,7 +96,12 @@ var UnMemoizedMessageActionsBox = function (props) {
           </button>)}
         {messageActions.indexOf(MESSAGE_ACTIONS.remindMe) > -1 && (<RemindMeSubmenu_1.RemindMeActionButton className={buttonClassName} isMine={mine}/>)}
         {messageActions.indexOf(MESSAGE_ACTIONS.saveForLater) > -1 && (<button aria-selected='false' className={buttonClassName} onClick={function () {
-                return reminder;
+                if (reminder) {
+                    /* TODO backend-wire-up: reminders.deleteReminder */
+                }
+                else {
+                    /* TODO backend-wire-up: reminders.createReminder */
+                }
             }} role='option'>
             {reminder ? t('Remove reminder') : t('Save for later')}
           </button>)}

--- a/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
@@ -6,7 +6,6 @@ import { RemindMeActionButton } from './RemindMeSubmenu';
 import { useMessageReminder } from '../Message';
 import { useMessageComposer } from '../MessageInput';
 import {
-  useChatContext,
   useComponentContext,
   useMessageContext,
   useTranslationContext,
@@ -48,7 +47,6 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
     ...restDivProps
   } = props;
 
-  const { client } = useChatContext();
   const { CustomMessageActionsList = DefaultCustomMessageActionsList } =
     useComponentContext('MessageActionsBox');
   const { customMessageActions, message, threadList } =
@@ -169,11 +167,13 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
           <button
             aria-selected='false'
             className={buttonClassName}
-            onClick={() =>
-              reminder
-                ? client.reminders.deleteReminder(reminder.id)
-                : client.reminders.createReminder({ messageId: message.id })
-            }
+            onClick={() => {
+              if (reminder) {
+                /* TODO backend-wire-up: reminders.deleteReminder */
+              } else {
+                /* TODO backend-wire-up: reminders.createReminder */
+              }
+            }}
             role='option'
           >
             {reminder ? t('Remove reminder') : t('Save for later')}

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.js
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.js
@@ -16,9 +16,11 @@ var RemindMeSubmenu = function () {
     var t = (0, context_1.useTranslationContext)().t;
     var client = (0, context_1.useChatContext)().client;
     var message = (0, context_1.useMessageContext)().message;
+    var scheduledOffsetsMs = [];
+    /* TODO backend-wire-up: reminders.scheduledOffsetsMs */
     return (<div aria-label={t('aria/Remind Me Options')} className='str-chat__message-actions-box__submenu' role='listbox'>
-      {client.reminders.scheduledOffsetsMs.map(function (offsetMs) { return (<button className='str-chat__message-actions-list-item-button' key={"reminder-offset-option--".concat(offsetMs)} onClick={function () {
-                Promise.resolve(undefined);
+      {scheduledOffsetsMs.map(function (offsetMs) { return (<button className='str-chat__message-actions-list-item-button' key={"reminder-offset-option--".concat(offsetMs)} onClick={function () {
+                /* TODO backend-wire-up: reminders.upsertReminder */
             }}>
           {t('duration/Remind Me', { milliseconds: offsetMs })}
         </button>); })}

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -25,21 +25,20 @@ export const RemindMeSubmenu = () => {
   const { t } = useTranslationContext();
   const { client } = useChatContext();
   const { message } = useMessageContext();
+  const scheduledOffsetsMs: number[] = [];
+  /* TODO backend-wire-up: reminders.scheduledOffsetsMs */
   return (
     <div
       aria-label={t('aria/Remind Me Options')}
       className='str-chat__message-actions-box__submenu'
       role='listbox'
     >
-      {client.reminders.scheduledOffsetsMs.map((offsetMs) => (
+      {scheduledOffsetsMs.map((offsetMs) => (
         <button
           className='str-chat__message-actions-list-item-button'
           key={`reminder-offset-option--${offsetMs}`}
           onClick={() => {
-            client.reminders.upsertReminder({
-              messageId: message.id,
-              remind_at: new Date(new Date().getTime() + offsetMs).toISOString(),
-            });
+            /* TODO backend-wire-up: reminders.upsertReminder */
           }}
         >
           {t('duration/Remind Me', { milliseconds: offsetMs })}


### PR DESCRIPTION
## Summary
- clean up StreamChat method calls in MessageActions components
- add placeholders for reminder actions

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9b3ac9d08326b78c8d8ba8b7f233