### PR TITLE
Remove StreamChat calls from Notifications

### DIFF
--- a/libs/stream-chat-shim/src/components/Notifications/hooks/useNotifications.ts
+++ b/libs/stream-chat-shim/src/components/Notifications/hooks/useNotifications.ts
@@ -1,13 +1,7 @@
-import { useChatContext } from '../../../context';
-import { useStateStore } from '../../../store';
-import type { Notification, NotificationManagerState } from 'chat-shim';
 
-const selector = (state: NotificationManagerState) => ({
-  notifications: state.notifications,
-});
+import type { Notification } from 'chat-shim';
 
 export const useNotifications = (): Notification[] => {
-  const { client } = useChatContext();
-  const result = useStateStore(client.notifications.store, selector);
-  return result.notifications;
+  /* TODO backend-wire-up: notifications.store */
+  return [];
 };


### PR DESCRIPTION
## Summary
- excise Stream Chat client usage in `useNotifications`

## Testing
- `pnpm build` *(fails: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e9b6cfb048326b72a97f926046356