### PR TITLE
Remove StreamChat refs in utils

### DIFF
--- a/libs/stream-chat-shim/src/utils/getChannel.js
+++ b/libs/stream-chat-shim/src/utils/getChannel.js
@@ -69,7 +69,7 @@ var getChannel = function (_a) { return __awaiter(void 0, [_a], void 0, function
                 if (!channel && !type) {
                     throw new Error('Channel or channel type have to be provided to query a channel.');
                 }
-                theChannel = channel || client.channel(type, id, { members: members });
+                theChannel = channel || /* TODO backend-wire-up: client.channel */ ({});
                 originalCid = (theChannel === null || theChannel === void 0 ? void 0 : theChannel.id)
                     ? theChannel.cid
                     : members && members.length

--- a/libs/stream-chat-shim/src/utils/getChannel.ts
+++ b/libs/stream-chat-shim/src/utils/getChannel.ts
@@ -45,7 +45,9 @@ export const getChannel = async ({
 
   // unfortunately typescript is not able to infer that if (!channel && !type) === false, then channel or type has to be truthy
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const theChannel = channel || client.channel(type!, id, { members });
+  const theChannel =
+    channel ||
+    /* TODO backend-wire-up: client.channel */ ({} as Channel);
 
   // need to keep as with call to channel.watch the id can be changed from undefined to an actual ID generated server-side
   const originalCid = theChannel?.id
@@ -66,7 +68,8 @@ export const getChannel = async ({
     await queryPromise;
   } else {
     try {
-      WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch(options);
+      WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] =
+        /* TODO backend-wire-up: channel.watch */ Promise.resolve(undefined);
       await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
     } finally {
       delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];


### PR DESCRIPTION
## Summary
- stub `client.channel` and `channel.watch` calls in stream-chat utils

## Testing
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no "tsc" script)*

------
https://chatgpt.com/codex/tasks/task_e_685e9e5b9e908326b74c0654f2a8d30f