### PR TITLE
Implement createLinkPreview endpoint

### DIFF
--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -1,15 +1,11 @@
 # backend/jatte/urls.py
-from django.contrib import admin
-from django.urls import re_path, include, path
 from chat import api
+from chat.api_views import (LinkPreviewView, RoomConfigStateView,
+                            RoomConfigView, RoomDraftView, RoomMembersCIDView,
+                            RoomMessageListCreateView)
 from chat.views import TokenView  # real view
-from chat.api_views import (
-    RoomDraftView,
-    RoomConfigView,
-    RoomConfigStateView,
-    RoomMessageListCreateView,
-    RoomMembersCIDView,
-)
+from django.contrib import admin
+from django.urls import include, path, re_path
 
 # from chat.views import dev_token        # <- if you still need the dev stub
 
@@ -37,6 +33,8 @@ urlpatterns += [
         "api/editing-audit-state/", api.editing_audit_state, name="editing-audit-state"
     ),
     re_path(r"^api/editing-audit-state/?$", api.editing_audit_state),
+    path("api/link-preview/", LinkPreviewView.as_view(), name="link-preview"),
+    re_path(r"^api/link-preview/?$", LinkPreviewView.as_view()),
     path(
         "api/rooms/<str:room_uuid>/draft/", RoomDraftView.as_view(), name="room-draft"
     ),

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -66,7 +66,7 @@
     "method": "POST",
     "path": "/link-preview/",
     "operationId": "createLinkPreview",
-    "status": "missing",
+    "status": "ok",
     "todoCount": 0
   },
   {


### PR DESCRIPTION
## Summary
- expose LinkPreview endpoint from core URLConf
- mark createLinkPreview as complete in wireup manifest

## Testing
- `python manage.py test chat.tests.test_link_preview -v 2`
- `python manage.py test` *(fails: Reverse for 'room-show' not found, other errors)*
- `pnpm test` *(fails: turbo not found)*
- `scripts/gen_openapi.sh` *(fails: No such file or directory)*
- `scripts/diff_openapi.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685fd9b4f7ec8326b32ef3b1099036ea