### PR TITLE
Add stub map for React backend wiring

### DIFF
--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -1,0 +1,23 @@
+{
+  "sendMessage": "createMessage",
+  "deleteMessage": "deleteMessage",
+  "connectUser": "syncUser",
+  "disconnectUser": "endSession",
+  "channel.muteStatus": "muteStatus",
+  "findMessage": "getMessage",
+  "muteUser": "muteUser",
+  "unmuteUser": "unmuteUser",
+  "getDraft": "listRoomDrafts",
+  "client.deleteMessage": "deleteMessage",
+  "channel.sendMessage": "createMessage",
+  "client.updateMessage": "updateMessage",
+  "reminders.createReminder": "createReminder",
+  "getAppSettings": "getAppSettings",
+  "getUserAgent": "listUserAgents",
+  "setUserAgent": "setUserAgent",
+  "threads.registerSubscriptions": "registerSubscriptions",
+  "polls.registerSubscriptions": "registerSubscriptions",
+  "reminders.registerSubscriptions": "registerSubscriptions",
+  "client.queryUsers": "listUsers",
+  "client.reminders.createReminder": "createReminder"
+}


### PR DESCRIPTION
## Summary
- map chat SDK stub tokens to backend operationIds

## Testing
- `cat openapi/stub_map.json`

------
https://chatgpt.com/codex/tasks/task_e_685fea79ea108326a7f16ff4074c2ac0