### PR TITLE
Wire createReminder ✅

### DIFF
--- a/libs/chat-shim/__tests__/createReminder.test.ts
+++ b/libs/chat-shim/__tests__/createReminder.test.ts
@@ -1,0 +1,14 @@
+import { ReminderManager } from '../index';
+
+describe('createReminder', () => {
+  test('posts to backend and updates store', async () => {
+    const manager = new ReminderManager();
+    const mockReminder = { id: 1, text: 'hello', remind_at: '2025-01-01T00:00:00Z', created_at: '2024-01-01T00:00:00Z' };
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ reminder: mockReminder }),
+    }) as any;
+    await manager.createReminder('hello', '2025-01-01T00:00:00Z');
+    expect(fetch).toHaveBeenCalledWith('/api/reminders/', expect.any(Object));
+    expect(manager.store.getLatestValue().reminders[0].reminder.id).toBe(1);
+  });
+});

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -228,6 +228,7 @@ declare module 'stream-chat' {
     registerSubscriptions(): void;
     unregisterSubscriptions(): void;
     initTimers(): void;
+    createReminder(text: string, remind_at: string): Promise<Reminder>;
     clearTimers(): void;
   }
   export class FixedSizeQueueCache<K, T> {

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -897,6 +897,22 @@ export class ReminderManager {
     }
   }
 
+  /** Create a reminder via the backend and store it */
+  async createReminder(text: string, remind_at: string): Promise<Reminder> {
+    const resp = await fetch('/api/reminders/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, remind_at }),
+    });
+    const data = await resp.json();
+    const reminder: Reminder = data.reminder;
+    const list = this.store.getLatestValue().reminders.slice();
+    list.push({ reminder });
+    this.store.dispatch({ reminders: list });
+    this.initTimers();
+    return reminder;
+  }
+
   /** clear all scheduled reminders */
   clearTimers() {
     for (const t of this.timers.values()) clearTimeout(t);

--- a/libs/stream-chat-shim/src/experimental/MessageActions/defaults.tsx
+++ b/libs/stream-chat-shim/src/experimental/MessageActions/defaults.tsx
@@ -135,8 +135,10 @@ const DefaultMessageActionComponents = {
             reminder
               ? /* TODO backend-wire-up: client.reminders.deleteReminder */
                 Promise.resolve()
-              : /* TODO backend-wire-up: client.reminders.createReminder */
-                Promise.resolve()
+              : client.reminders.createReminder(
+                  message.text || '',
+                  new Date().toISOString(),
+                )
           }
         >
           {reminder ? t('Remove reminder') : t('Save for later')}

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -499,6 +499,48 @@ paths:
           description: ''
       tags:
       - api
+  /api/reminders/:
+    get:
+      operationId: listReminders
+      description: List reminders for the current user.
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+          description: ''
+      tags:
+      - api
+    post:
+      operationId: createReminder
+      description: Create a new reminder.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                remind_at:
+                  type: string
+                  format: date-time
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reminder:
+                    type: object
+          description: ''
+      tags:
+      - api
 components:
   schemas:
     User:
@@ -530,6 +572,21 @@ components:
         sent_by:
           type: string
           readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+    Reminder:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        text:
+          type: string
+        remind_at:
+          type: string
+          format: date-time
         created_at:
           type: string
           format: date-time

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -15,25 +15,25 @@
     "stubName": "channel.sendMessage",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "ok"
-  },
-  {
-    "method": "",
-    "path": "",
-    "operationId": "createReminder",
-    "stubName": "reminders.createReminder",
-    "ticketType": "api",
-    "todoCount": 1,
     "status": "missing"
   },
   {
     "method": "",
     "path": "",
-    "operationId": "createReminder",
-    "stubName": "client.reminders.createReminder",
-    "ticketType": "api",
-    "todoCount": 1,
-    "status": "missing"
+  "operationId": "createReminder",
+  "stubName": "reminders.createReminder",
+  "ticketType": "api",
+  "todoCount": 1,
+  "status": "ok"
+},
+  {
+    "method": "",
+    "path": "",
+  "operationId": "createReminder",
+  "stubName": "client.reminders.createReminder",
+  "ticketType": "api",
+  "todoCount": 1,
+  "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement backend reminders path in OpenAPI spec
- expose `createReminder()` on `ReminderManager`
- wire SaveForLater to call new method
- mark createReminder as wired
- add unit test for reminder creation

## Testing
- `npx jest libs/chat-shim/__tests__/createReminder.test.ts --runInBand`
- `pytest backend/chat/tests/test_reminders.py::ReminderAPITests::test_create_reminder -q`


------
https://chatgpt.com/codex/tasks/task_e_685ff88511088326a29e3f64841e4c27