### PR TITLE
feat(listUserAgents): implement

### DIFF
--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -65,12 +65,15 @@ export const useChat = ({
 
     const version = process.env.STREAM_CHAT_REACT_VERSION;
 
-    const userAgent = /* TODO backend-wire-up: getUserAgent */ '';
-    if (!userAgent.includes('stream-chat-react')) {
-      // result looks like: 'stream-chat-react-2.3.2-stream-chat-javascript-client-browser-2.2.2'
-      // the upper-case text between double underscores is replaced with the actual semantic version of the library
-      /* TODO backend-wire-up: setUserAgent */
-    }
+    fetch('/api/user-agent/', { method: 'GET', credentials: 'same-origin' })
+      .then((res) => res.json() as Promise<{ user_agent?: string }>)
+      .then(({ user_agent }) => {
+        const userAgent = user_agent ?? '';
+        if (userAgent.includes('stream-chat-react')) return;
+        // result looks like: 'stream-chat-react-2.3.2-stream-chat-javascript-client-browser-2.2.2'
+        // the upper-case text between double underscores is replaced with the actual semantic version of the library
+        /* TODO backend-wire-up: setUserAgent */
+      });
 
     /* TODO backend-wire-up: threads.registerSubscriptions */
     /* TODO backend-wire-up: polls.registerSubscriptions */

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -237,6 +237,20 @@ paths:
                 properties:
                   status:
                     type: string
+  /user-agent/:
+    get:
+      operationId: listUserAgents
+      tags: [users]
+      responses:
+        '200':
+          description: user agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_agent:
+                    type: string
   /notifications/:
     get:
       operationId: listNotifications

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -96,7 +96,7 @@
     "stubName": "getUserAgent",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- wire up getUserAgent to fetch `/api/user-agent/`
- expose `/user-agent/` path in frontend openapi spec
- mark `listUserAgents` complete in manifest

## Testing
- `pnpm lint:fix` *(fails: command not found)*
- `black backend/accounts_supabase/views.py` *(reformats unchanged file then reverted)*
- `isort backend/accounts_supabase/views.py` *(ran but file reverted)*
- `pnpm test` *(fails: turbo_json_parse_error)*
- `pytest -q` *(fails: 6 failed, 5 warnings, 277 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686015f3908c8326a59de7f4b9f497f7