### PR TITLE
wireup(listUsers): implement users API

### DIFF
--- a/backend/chat/tests/test_list_users.py
+++ b/backend/chat/tests/test_list_users.py
@@ -1,0 +1,41 @@
+import jwt
+from accounts_supabase.models import CustomUser
+from django.conf import settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class ListUsersAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode(
+            {"sub": sub, "email": email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+
+    def setUp(self):
+        CustomUser.objects.create_user(
+            username="u1", email="u1@example.com", password="x", supabase_uid="u1"
+        )
+        CustomUser.objects.create_user(
+            username="u2", email="u2@example.com", password="x", supabase_uid="u2"
+        )
+
+    def test_list_users(self):
+        token = self.make_token()
+        url = reverse("query-users")
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 200)
+        usernames = sorted(u["username"] for u in res.data)
+        self.assertEqual(usernames, ["u1", "u2"])
+
+    def test_requires_auth(self):
+        url = reverse("query-users")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_wrong_method(self):
+        token = self.make_token()
+        url = reverse("query-users")
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 405)

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -290,7 +290,12 @@ export class LocalChatClient {
   }
 
   async queryUsers() {
-    return { users: this.user ? [this.user] : [] };
+    const resp = await fetch('/api/users/', {
+      method: 'GET',
+      credentials: 'same-origin',
+    });
+    const data = await resp.json();
+    return { users: data };
   }
 
   channel(type: string, id?: string) {

--- a/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -216,10 +216,7 @@ export const useChannelSearch = ({
         }
 
         if (searchForUsers) {
-          promises.push(
-            /* TODO backend-wire-up: client.queryUsers */
-            Promise.resolve({ users: [] } as UsersAPIResponse),
-          );
+          promises.push(client.queryUsers());
         }
 
         if (promises.length) {

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -105,7 +105,7 @@
     "stubName": "client.queryUsers",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `queryUsers` for LocalChatClient
- wire channel search to backend listUsers endpoint
- add backend tests for `GET /api/users/`
- mark listUsers as ok in wireup manifest

## Testing
- `pnpm lint:fix` *(fails: command not found)*
- `pytest` *(fails: 6 failed, 280 errors)*
- `pnpm test` *(fails: turbo not found)*
- `./scripts/gen_openapi.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686018579220832699e4068023d26f4e