### PR TITLE
✅ registerSubscriptions

### DIFF
--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -72,19 +72,19 @@ export const useChat = ({
         if (userAgent.includes('stream-chat-react')) return;
         // result looks like: 'stream-chat-react-2.3.2-stream-chat-javascript-client-browser-2.2.2'
         // the upper-case text between double underscores is replaced with the actual semantic version of the library
-        /* TODO backend-wire-up: setUserAgent */
+        client.setUserAgent(`stream-chat-react-${version}-${userAgent}`);
       });
 
-    /* TODO backend-wire-up: threads.registerSubscriptions */
-    /* TODO backend-wire-up: polls.registerSubscriptions */
-    /* TODO backend-wire-up: reminders.registerSubscriptions */
-    /* TODO backend-wire-up: reminders.initTimers */
+    client.threads.registerSubscriptions();
+    client.polls.registerSubscriptions();
+    client.reminders.registerSubscriptions();
+    client.reminders.initTimers();
 
     return () => {
-        /* TODO backend-wire-up: threads.unregisterSubscriptions */
-        /* TODO backend-wire-up: polls.unregisterSubscriptions */
-        /* TODO backend-wire-up: reminders.unregisterSubscriptions */
-        /* TODO backend-wire-up: reminders.clearTimers */
+        client.threads.unregisterSubscriptions();
+        client.polls.unregisterSubscriptions();
+        client.reminders.unregisterSubscriptions();
+        client.reminders.clearTimers();
     };
   }, [client]);
 

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -449,7 +449,7 @@ paths:
       - api
   /api/register-subscriptions/:
     post:
-      operationId: createregister_subscriptions
+      operationId: registerSubscriptions
       description: Register web push subscriptions and echo them back.
       parameters: []
       requestBody:
@@ -461,7 +461,7 @@ paths:
           multipart/form-data:
             schema: {}
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema: {}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -132,7 +132,7 @@
     "stubName": "threads.registerSubscriptions",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",
@@ -141,7 +141,7 @@
     "stubName": "polls.registerSubscriptions",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",
@@ -150,7 +150,7 @@
     "stubName": "reminders.registerSubscriptions",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- hook up reminders registerSubscriptions in useChat
- document POST /api/register-subscriptions/ and return 200
- mark registerSubscriptions tasks complete in the manifest

## Testing
- `pytest` *(fails: 6 failed, 280 errors)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686024ec64ec8326ab61390413d16e50