### PR TITLE
✅ wireup syncUser

### DIFF
--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -278,6 +278,13 @@ export class LocalChatClient {
     this.listeners = {};
     this.mutedChannels = [];
 
+    /* notify backend we are online */
+    await fetch('/api/sync-user/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+
     this.user = undefined;
     this.wsConnection.online = false;
 

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useCreateChatClient.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useCreateChatClient.ts
@@ -36,8 +36,9 @@ export const useCreateChatClient = ({
     const client = new StreamChat(apiKey, undefined, cachedOptions);
     let didUserConnectInterrupt = false;
 
-    const connectionPromise =
-      /* TODO backend-wire-up: connectUser */ Promise.resolve().then(() => {
+    const connectionPromise = client
+      .connectUser(cachedUserData, tokenOrProvider as string)
+      .then(() => {
         if (!didUserConnectInterrupt) setChatClient(client);
       });
 
@@ -45,7 +46,7 @@ export const useCreateChatClient = ({
       didUserConnectInterrupt = true;
       setChatClient(null);
       connectionPromise
-        .then(() => /* TODO backend-wire-up: disconnectUser */ Promise.resolve())
+        .then(() => client.disconnectUser())
         .then(() => {
           console.log(`Connection for user "${cachedUserData.id}" has been closed`);
         });

--- a/libs/stream-chat-shim/src/stories/utils.tsx
+++ b/libs/stream-chat-shim/src/stories/utils.tsx
@@ -31,15 +31,17 @@ const useClient = ({
     const client = new StreamChat(apiKey);
 
     let didUserConnectInterrupt = false;
-    const connectionPromise = Promise.resolve(/* TODO backend-wire-up: connectUser */).then(() => {
-      if (!didUserConnectInterrupt) setChatClient(client);
-    });
+    const connectionPromise = client
+      .connectUser(userData, tokenOrProvider as string)
+      .then(() => {
+        if (!didUserConnectInterrupt) setChatClient(client);
+      });
 
     return () => {
       didUserConnectInterrupt = true;
       setChatClient(null);
       connectionPromise
-        .then(() => Promise.resolve(/* TODO backend-wire-up: disconnectUser */))
+        .then(() => client.disconnectUser())
         .then(() => {
           console.log('connection closed');
         });

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -168,7 +168,7 @@
     "stubName": "connectUser",
     "ticketType": "api",
     "todoCount": 2,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- connectUser uses sync-user endpoint
- hook up useCreateChatClient and storybook utilities
- update manifest for syncUser

## Testing
- `black --check .` *(fails: would reformat multiple files)*
- `isort --check-only .` *(fails: incorrectly sorted imports)*
- `pytest` *(fails: 6 failed, 280 errors)*
- `pnpm --filter frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860392ff110832685ec4c7fecbb4763