### PR TITLE
Implement addAnswer stub

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,0 +1,3 @@
+export async function addAnswer(): Promise<void> {
+  // Placeholder implementation until backend endpoint is available
+}

--- a/libs/stream-chat-shim/src/index.ts
+++ b/libs/stream-chat-shim/src/index.ts
@@ -7,3 +7,4 @@ export * from './i18n';
 export * from './store';
 export * from './types';
 export * from './utils';
+export * from './chatSDKShim';


### PR DESCRIPTION
## Summary
- add placeholder for `addAnswer` in chat SDK shim
- re-export shim from stream-chat-shim index

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686049e9d57c83269df80ac9a09b4ca9