### PR TITLE
Implement channel.countUnread shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -12,3 +12,10 @@ export async function castVote(
 export async function archive(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
 }
+
+export function channelCountUnread(
+  channel: { countUnread: () => number },
+  _lastRead?: Date,
+): number {
+  return channel.countUnread();
+}

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
@@ -114,7 +114,7 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
     const handleEvent = (event: Event) => {
       if (channel.cid !== event.cid) return;
       if (event.user?.id !== client.user?.id) return;
-        setUnread(/* TODO backend-wire-up: channel.countUnread */ 0);
+      setUnread(channel.countUnread());
     };
     /* TODO backend-wire-up: channel.on */
     return () => {
@@ -128,7 +128,7 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
         if (muted) {
           setUnread(0);
         } else {
-            setUnread(/* TODO backend-wire-up: channel.countUnread */ 0);
+          setUnread(channel.countUnread());
         }
       }, 400),
     [channel, muted],

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -20,5 +20,6 @@
   "reminders.registerSubscriptions": "registerSubscriptions",
   "client.queryUsers": "listUsers",
   "client.reminders.createReminder": "createReminder",
-  "channel.archive": "shim::channel.archive"
+  "channel.archive": "shim::channel.archive",
+  "channel.countUnread": "shim::channel.countUnread"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -230,8 +230,8 @@
     "operationId": "shim::channel.countUnread",
     "stubName": "channel.countUnread",
     "ticketType": "shim",
-    "todoCount": 2,
-    "status": "missing"
+    "todoCount": 0,
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add `channelCountUnread` helper to chatSDKShim
- wire ChannelPreview to use `channel.countUnread`
- document mapping for `channel.countUnread`
- update wireup manifest status

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605b4f05d08326af70ee82a6feaccb