### PR TITLE
✅ Shim helper: channel.getClient

### DIFF
--- a/frontend/types/stream-chat-shim.d.ts
+++ b/frontend/types/stream-chat-shim.d.ts
@@ -41,6 +41,7 @@ declare module 'stream-chat' {
     ): { unsubscribe(): void };
     off(evt: string, cb: (ev: any) => void): void;
     markRead(): void;
+    getClient(): LocalChatClient;
   };
 
   

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -67,6 +67,7 @@ declare module 'stream-chat' {
     off(evt: string, cb: (ev: any) => void): void;
     markRead(): void;
     countUnread(): number;
+    getClient(): LocalChatClient;
     getConfig(): { typing_events: boolean; read_events: boolean };
   }
 

--- a/libs/chat-shim/index.js
+++ b/libs/chat-shim/index.js
@@ -170,11 +170,12 @@ var ChannelState = /** @class */ (function () {
 }());
 exports.ChannelState = ChannelState;
 var LocalChannel = /** @class */ (function () {
-    function LocalChannel(cid, sock, getUid) {
+    function LocalChannel(cid, sock, getUid, client) {
         var _this = this;
         this.cid = cid;
         this.sock = sock;
         this.listeners = new Map();
+        this.client = client;
         var _a = cid.split(':'), type = _a[0], id = _a[1];
         this.type = type;
         this.id = id !== null && id !== void 0 ? id : '';
@@ -235,6 +236,9 @@ var LocalChannel = /** @class */ (function () {
     /** Return unread count for the current user */
     LocalChannel.prototype.countUnread = function () {
         return this.state.countUnread(this.getUserId());
+    };
+    LocalChannel.prototype.getClient = function () {
+        return this.client;
     };
     return LocalChannel;
 }());
@@ -351,7 +355,7 @@ var LocalChatClient = /** @class */ (function () {
                 (_a = _this.channels.get(data.cid)) === null || _a === void 0 ? void 0 : _a.emit(data.type, data);
             };
             this.sockets.set(cid, sock);
-            var chan = new LocalChannel(cid, sock, function () { return _this.userId; });
+            var chan = new LocalChannel(cid, sock, function () { return _this.userId; }, _this);
             this.channels.set(cid, chan);
             this.activeChannels[cid] = chan;
             this.state.channels.set(cid, chan);

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -112,6 +112,7 @@ export class LocalChannel {
     readonly cid: string,
     private sock: WebSocket,
     getUid: () => string,
+    private client: LocalChatClient,
   ) {
     const [type, id] = cid.split(":");
     this.type = type;
@@ -166,6 +167,11 @@ export class LocalChannel {
   /** Return unread count for the current user */
   countUnread() {
     return this.state.countUnread(this.getUserId());
+  }
+
+  /** Expose the parent client instance */
+  getClient() {
+    return this.client;
   }
 }
 
@@ -315,7 +321,7 @@ export class LocalChatClient {
         this.channels.get(data.cid)?.emit(data.type, data);
       };
       this.sockets.set(cid, sock);
-      const chan = new LocalChannel(cid, sock, () => this.userId);
+      const chan = new LocalChannel(cid, sock, () => this.userId, this);
       this.channels.set(cid, chan);
       this.activeChannels[cid] = chan;
       (this.state.channels as Map<string, any>).set(cid, chan);

--- a/libs/stream-chat-shim/src/components/ChannelPreview/utils.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/utils.tsx
@@ -49,7 +49,7 @@ export const getLatestMessagePreview = (
     if (!poll.vote_count) {
         const createdBy =
         poll.created_by?.id ===
-          /* TODO backend-wire-up: channel.getClient */ ''
+          channel.getClient()
           ? t('You')
           : poll.created_by?.name ?? t('Poll');
       return t('📊 {{createdBy}} created: {{ pollName}}', {
@@ -68,7 +68,7 @@ export const getLatestMessagePreview = (
           pollOptionText: option.text,
             votedBy:
               latestVote?.user?.id ===
-                /* TODO backend-wire-up: channel.getClient */ ''
+                channel.getClient()
                 ? t('You')
                 : latestVote.user?.name ?? t('Poll'),
         });

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -21,5 +21,6 @@
   "client.queryUsers": "listUsers",
   "client.reminders.createReminder": "createReminder",
   "channel.archive": "shim::channel.archive",
-  "channel.countUnread": "shim::channel.countUnread"
+  "channel.countUnread": "shim::channel.countUnread",
+  "channel.getClient": "shim::channel.getClient"
 }


### PR DESCRIPTION
## Summary
- implement `channel.getClient` on LocalChannel
- wire channel creation to keep parent client reference
- expose `getClient` in type declarations
- drop stub comments in ChannelPreview utils
- map stub token in `stub_map.json`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605e680e348326a41d5ba5e03450a5