### PR TITLE
Implement channel.getReplies shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -19,3 +19,14 @@ export function channelCountUnread(
 ): number {
   return channel.countUnread();
 }
+
+export async function channelGetReplies(
+  channel: { getReplies?: (id: string, options?: any) => Promise<any> },
+  parentId: string,
+  options?: { limit?: number; id_lt?: string },
+): Promise<{ messages: any[] }> {
+  if (typeof channel.getReplies === 'function') {
+    return channel.getReplies(parentId, options);
+  }
+  return { messages: [] };
+}

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -92,6 +92,7 @@ import {
   getVideoAttachmentConfiguration,
 } from "../Attachment/attachment-sizing";
 import { useSearchFocusedMessage } from "../../experimental/Search/hooks";
+import { channelGetReplies } from "../../chatSDKShim";
 
 type ChannelPropsForwardedToComponentContext = Pick<
   ComponentContextValue,
@@ -1176,10 +1177,10 @@ const ChannelInner = (
     const oldestMessageId = oldMessages[0]?.id;
 
     try {
-      const queryResponse = await (async () => {
-        /* TODO backend-wire-up: channel.getReplies */
-        return { messages: [] } as any;
-      })();
+      const queryResponse = await channelGetReplies(channel, parentId, {
+        limit,
+        id_lt: oldestMessageId,
+      });
 
       const threadHasMoreMessages = hasMoreMessagesProbably(
         queryResponse.messages.length,

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -22,5 +22,6 @@
   "client.reminders.createReminder": "createReminder",
   "channel.archive": "shim::channel.archive",
   "channel.countUnread": "shim::channel.countUnread",
-  "channel.getClient": "shim::channel.getClient"
+  "channel.getClient": "shim::channel.getClient",
+  "channel.getReplies": "shim::channel.getReplies"
 }


### PR DESCRIPTION
## Summary
- add `channelGetReplies` helper to the chat SDK shim
- use the shim in the Channel component when loading thread messages
- map `channel.getReplies` to `shim::channel.getReplies` in stub map

## Testing
- `npx jest` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686060bec1888326b1f7fee199822e6a