### PR TITLE
✅ wireup shim::channel.markRead

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -30,3 +30,12 @@ export async function channelGetReplies(
   }
   return { messages: [] };
 }
+
+export async function channelMarkRead(
+  channel: { markRead?: () => Promise<any> },
+): Promise<any> {
+  if (typeof channel.markRead === 'function') {
+    return channel.markRead();
+  }
+  return undefined;
+}

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -92,7 +92,7 @@ import {
   getVideoAttachmentConfiguration,
 } from "../Attachment/attachment-sizing";
 import { useSearchFocusedMessage } from "../../experimental/Search/hooks";
-import { channelGetReplies } from "../../chatSDKShim";
+import { channelGetReplies, channelMarkRead } from "../../chatSDKShim";
 
 type ChannelPropsForwardedToComponentContext = Pick<
   ComponentContextValue,
@@ -396,10 +396,7 @@ const ChannelInner = (
                   : undefined,
               );
             } else {
-              const markReadResponse = await (async () => {
-                /* TODO backend-wire-up: channel.markRead */
-                return { event: { last_read_message_id: "" } } as any;
-              })();
+              const markReadResponse = await channelMarkRead(channel);
               if (updateChannelUiUnreadState && markReadResponse) {
                 _setChannelUnreadUiState({
                   last_read: lastRead.current,

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -23,5 +23,6 @@
   "channel.archive": "shim::channel.archive",
   "channel.countUnread": "shim::channel.countUnread",
   "channel.getClient": "shim::channel.getClient",
-  "channel.getReplies": "shim::channel.getReplies"
+  "channel.getReplies": "shim::channel.getReplies",
+  "channel.markRead": "shim::channel.markRead"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -258,7 +258,7 @@
     "stubName": "channel.markRead",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `channel.markRead` shim helper
- call new helper from Channel component
- register stub in map and manifest

## Testing
- `pnpm --filter frontend test` *(fails: Cannot find module '../api')*
- `pnpm --filter frontend build` *(fails: Can't resolve 'ws')*

------
https://chatgpt.com/codex/tasks/task_e_6860648c04d88326ab4ddc8dee6d745f