### PR TITLE
✅ channel.muteStatus shim

### DIFF
--- a/libs/chat-shim/__tests__/localChannel.test.ts
+++ b/libs/chat-shim/__tests__/localChannel.test.ts
@@ -21,4 +21,14 @@ describe('LocalChannel', () => {
     expect(typeof channel.stateStore.getState).toBe('function');
     expect(channel.stateStore.getState().messages).toEqual([]);
   });
+
+  test('muteStatus reflects client state', async () => {
+    const client = new LocalChatClient();
+    await client.connectUser({ id: 'u1' }, 'jwt');
+    const channel = client.channel('messaging', 'general');
+    await channel.watch();
+    expect(channel.muteStatus().muted).toBe(false);
+    (client as any).mutedChannels.push(channel.cid);
+    expect(channel.muteStatus().muted).toBe(true);
+  });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -67,6 +67,7 @@ declare module 'stream-chat' {
     off(evt: string, cb: (ev: any) => void): void;
     markRead(): void;
     countUnread(): number;
+    muteStatus(): { muted: boolean };
     getClient(): LocalChatClient;
     getConfig(): { typing_events: boolean; read_events: boolean };
   }

--- a/libs/chat-shim/index.js
+++ b/libs/chat-shim/index.js
@@ -237,6 +237,10 @@ var LocalChannel = /** @class */ (function () {
     LocalChannel.prototype.countUnread = function () {
         return this.state.countUnread(this.getUserId());
     };
+    LocalChannel.prototype.muteStatus = function () {
+        var muted = this.client.mutedChannels.includes(this.cid);
+        return { muted: muted };
+    };
     LocalChannel.prototype.getClient = function () {
         return this.client;
     };

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -169,6 +169,12 @@ export class LocalChannel {
     return this.state.countUnread(this.getUserId());
   }
 
+  /** Return whether this channel is muted for the current user */
+  muteStatus() {
+    const muted = this.client.mutedChannels.includes(this.cid);
+    return { muted };
+  }
+
   /** Expose the parent client instance */
   getClient() {
     return this.client;

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
@@ -7,13 +7,10 @@ import type { Channel } from 'chat-shim';
 export const useIsChannelMuted = (channel: Channel) => {
   const { client } = useChatContext('useIsChannelMuted');
 
-  const [muted, setMuted] = useState(
-    /* TODO backend-wire-up: channel.muteStatus */ false,
-  );
+  const [muted, setMuted] = useState(channel.muteStatus().muted);
 
   useEffect(() => {
-    const handleEvent = () =>
-      setMuted(/* TODO backend-wire-up: channel.muteStatus */ false);
+    const handleEvent = () => setMuted(channel.muteStatus().muted);
 
     /* TODO backend-wire-up: client.on */
     return () => {


### PR DESCRIPTION
## Summary
- implement `muteStatus` on LocalChannel
- expose method in typings
- remove stub usage and add hook call
- test LocalChannel.muteStatus

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686067f41e9083269eece8c6badfe672