### PR TITLE
✔︎ Shim channel.off

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -39,3 +39,17 @@ export async function channelMarkRead(
   }
   return undefined;
 }
+
+export function channelOff(
+  channel: { off?: (eventType?: string, handler?: (...args: any[]) => void) => void },
+  eventType?: string,
+  handler?: (...args: any[]) => void,
+): void {
+  if (typeof channel.off === 'function') {
+    // Forward the call to the underlying channel if available
+    (channel.off as (eventType?: string, handler?: (...args: any[]) => void) => void)(
+      eventType,
+      handler,
+    );
+  }
+}

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -599,7 +599,6 @@ const ChannelInner = (
 
     return () => {
       if (errored || !done) return;
-      /* TODO backend-wire-up: channel.off */
       /* TODO backend-wire-up: client.off */
       /* TODO backend-wire-up: client.off */
       /* TODO backend-wire-up: client.off */

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
@@ -118,7 +118,6 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
     };
     /* TODO backend-wire-up: channel.on */
     return () => {
-      /* TODO backend-wire-up: channel.off */
     };
   }, [channel, client]);
 
@@ -151,11 +150,6 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
       /* TODO backend-wire-up: channel.on */
 
     return () => {
-        /* TODO backend-wire-up: channel.off */
-        /* TODO backend-wire-up: channel.off */
-        /* TODO backend-wire-up: channel.off */
-        /* TODO backend-wire-up: channel.off */
-        /* TODO backend-wire-up: channel.off */
     };
   }, [channel, refreshUnreadCount, channelUpdateCount]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
@@ -65,7 +65,6 @@ export const useMessageDeliveryStatus = ({
     /* TODO backend-wire-up: channel.on */
 
     return () => {
-      /* TODO backend-wire-up: channel.off */
     };
   }, [channel, client, isOwnMessage]);
 
@@ -78,7 +77,6 @@ export const useMessageDeliveryStatus = ({
     /* TODO backend-wire-up: channel.on */
 
     return () => {
-      /* TODO backend-wire-up: channel.off */
     };
   }, [channel, client, lastMessage, isOwnMessage]);
 

--- a/libs/stream-chat-shim/src/components/MessageList/hooks/useMarkRead.ts
+++ b/libs/stream-chat-shim/src/components/MessageList/hooks/useMarkRead.ts
@@ -102,7 +102,6 @@ export const useMarkRead = ({
     }
 
     return () => {
-      /* TODO backend-wire-up: channel.off */
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -24,5 +24,6 @@
   "channel.countUnread": "shim::channel.countUnread",
   "channel.getClient": "shim::channel.getClient",
   "channel.getReplies": "shim::channel.getReplies",
-  "channel.markRead": "shim::channel.markRead"
+  "channel.markRead": "shim::channel.markRead",
+  "channel.off": "shim::channel.off"
 }


### PR DESCRIPTION
## Summary
- implement `channelOff` helper in `chatSDKShim`
- register `channel.off` in `stub_map.json`
- drop `TODO backend-wire-up: channel.off` comments

## Testing
- `pnpm lint:fix` *(fails: Command "lint:fix" not found)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606a87cccc8326a0c90b8f4261b1a7