### PR TITLE
Add channel.pin shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -67,3 +67,13 @@ export function channelOn(
   }
   return undefined;
 }
+
+export async function channelPin(
+  channel: { pin?: (messageId: string) => Promise<any> },
+  messageId: string,
+): Promise<any> {
+  if (typeof channel.pin === 'function') {
+    return channel.pin(messageId);
+  }
+  return undefined;
+}

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -26,5 +26,6 @@
   "channel.getReplies": "shim::channel.getReplies",
   "channel.markRead": "shim::channel.markRead",
   "channel.on": "shim::channel.on",
-  "channel.off": "shim::channel.off"
+  "channel.off": "shim::channel.off",
+  "channel.pin": "shim::channel.pin"
 }


### PR DESCRIPTION
## Summary
- implement `channelPin` in chatSDKShim to call `channel.pin`
- map `channel.pin` stub to `shim::channel.pin`

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607164ba288326ae051d73e2fe0884