### PR TITLE
feat(channel.state.loadMessageIntoState): implement shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -25,45 +25,56 @@ export async function channelGetReplies(
   parentId: string,
   options?: { limit?: number; id_lt?: string },
 ): Promise<{ messages: any[] }> {
-  if (typeof channel.getReplies === 'function') {
+  if (typeof channel.getReplies === "function") {
     return channel.getReplies(parentId, options);
   }
   return { messages: [] };
 }
 
-export async function channelMarkRead(
-  channel: { markRead?: () => Promise<any> },
-): Promise<any> {
-  if (typeof channel.markRead === 'function') {
+export async function channelMarkRead(channel: {
+  markRead?: () => Promise<any>;
+}): Promise<any> {
+  if (typeof channel.markRead === "function") {
     return channel.markRead();
   }
   return undefined;
 }
 
 export function channelOff(
-  channel: { off?: (eventType?: string, handler?: (...args: any[]) => void) => void },
+  channel: {
+    off?: (eventType?: string, handler?: (...args: any[]) => void) => void;
+  },
   eventType?: string,
   handler?: (...args: any[]) => void,
 ): void {
-  if (typeof channel.off === 'function') {
+  if (typeof channel.off === "function") {
     // Forward the call to the underlying channel if available
-    (channel.off as (eventType?: string, handler?: (...args: any[]) => void) => void)(
-      eventType,
-      handler,
-    );
+    (
+      channel.off as (
+        eventType?: string,
+        handler?: (...args: any[]) => void,
+      ) => void
+    )(eventType, handler);
   }
 }
 
 export function channelOn(
-  channel: { on?: (eventType: string, handler: (...args: any[]) => void) => { unsubscribe?: () => void } },
+  channel: {
+    on?: (
+      eventType: string,
+      handler: (...args: any[]) => void,
+    ) => { unsubscribe?: () => void };
+  },
   eventType: string,
   handler: (...args: any[]) => void,
 ): { unsubscribe?: () => void } | undefined {
-  if (typeof channel.on === 'function') {
-    return (channel.on as (
-      eventType: string,
-      handler: (...args: any[]) => void,
-    ) => { unsubscribe?: () => void })(eventType, handler);
+  if (typeof channel.on === "function") {
+    return (
+      channel.on as (
+        eventType: string,
+        handler: (...args: any[]) => void,
+      ) => { unsubscribe?: () => void }
+    )(eventType, handler);
   }
   return undefined;
 }
@@ -72,7 +83,7 @@ export async function channelPin(
   channel: { pin?: (messageId: string) => Promise<any> },
   messageId: string,
 ): Promise<any> {
-  if (typeof channel.pin === 'function') {
+  if (typeof channel.pin === "function") {
     return channel.pin(messageId);
   }
   return undefined;
@@ -82,7 +93,7 @@ export async function channelQuery(
   channel: { query?: (options?: any) => Promise<any> },
   options?: any,
 ): Promise<any> {
-  if (typeof channel.query === 'function') {
+  if (typeof channel.query === "function") {
     return channel.query(options);
   }
   return { messages: [] };
@@ -96,11 +107,31 @@ export async function channelSendMessage(
   const resp = await fetch(
     `/api/rooms/${encodeURIComponent(channel.cid)}/messages/`,
     {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(message),
     },
   );
   return resp.json();
+}
+
+export async function channelStateLoadMessageIntoState(
+  channel: {
+    state?: {
+      loadMessageIntoState?: (
+        id: string,
+        around?: string,
+        limit?: number,
+      ) => Promise<any>;
+    };
+  },
+  messageId: string,
+  around?: string,
+  messageLimit?: number,
+): Promise<any> {
+  if (channel.state?.loadMessageIntoState) {
+    return channel.state.loadMessageIntoState(messageId, around, messageLimit);
+  }
+  return undefined;
 }

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -92,7 +92,12 @@ import {
   getVideoAttachmentConfiguration,
 } from "../Attachment/attachment-sizing";
 import { useSearchFocusedMessage } from "../../experimental/Search/hooks";
-import { channelGetReplies, channelMarkRead, channelQuery } from "../../chatSDKShim";
+import {
+  channelGetReplies,
+  channelMarkRead,
+  channelQuery,
+  channelStateLoadMessageIntoState,
+} from "../../chatSDKShim";
 
 type ChannelPropsForwardedToComponentContext = Pick<
   ComponentContextValue,
@@ -761,9 +766,12 @@ const ChannelInner = (
       highlightDuration = DEFAULT_HIGHLIGHT_DURATION,
     ) => {
       dispatch({ loadingMore: true, type: "setLoadingMore" });
-      await (async () => {
-        /* TODO backend-wire-up: channel.state.loadMessageIntoState */
-      })();
+      await channelStateLoadMessageIntoState(
+        channel,
+        messageId,
+        undefined,
+        messageLimit,
+      );
 
       loadMoreFinished(
         channel.state.messagePagination.hasPrev,
@@ -779,9 +787,7 @@ const ChannelInner = (
 
   const jumpToLatestMessage: ChannelActionContextValue["jumpToLatestMessage"] =
     useCallback(async () => {
-      await (async () => {
-        /* TODO backend-wire-up: channel.state.loadMessageIntoState */
-      })();
+      await channelStateLoadMessageIntoState(channel, "latest");
       loadMoreFinished(
         channel.state.messagePagination.hasPrev,
         channel.state.messages,
@@ -899,9 +905,12 @@ const ChannelInner = (
           try {
             const targetId = (firstUnreadMessageId ??
               lastReadMessageId) as string;
-            await (async () => {
-              /* TODO backend-wire-up: channel.state.loadMessageIntoState */
-            })();
+            await channelStateLoadMessageIntoState(
+              channel,
+              targetId,
+              undefined,
+              queryMessageLimit,
+            );
             /**
              * if the index of the last read message on the page is beyond the half of the page,
              * we have arrived to the oldest page of the channel

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -28,5 +28,6 @@
   "channel.on": "shim::channel.on",
   "channel.off": "shim::channel.off",
   "channel.pin": "shim::channel.pin",
-  "channel.query": "shim::channel.query"
+  "channel.query": "shim::channel.query",
+  "channel.state.loadMessageIntoState": "shim::channel.state.loadMessageIntoState"
 }


### PR DESCRIPTION
## Summary
- add `channelStateLoadMessageIntoState` shim implementation
- wire Channel jump helpers to use shim
- load message when selecting a search result
- map stub token in `openapi/stub_map.json`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607b79d9748326a3b16ed13e2f0772