### PR TITLE
feat(channel.unpin): implement shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/channel.unpin.test.ts
+++ b/libs/stream-chat-shim/__tests__/channel.unpin.test.ts
@@ -1,0 +1,14 @@
+import { channelUnpin } from '../src/chatSDKShim';
+
+describe('channelUnpin', () => {
+  it('calls channel.unpin when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const res = await channelUnpin({ unpin: fn });
+    expect(fn).toHaveBeenCalled();
+    expect(res).toBe('ok');
+  });
+
+  it('resolves undefined when not implemented', async () => {
+    await expect(channelUnpin({} as any)).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -89,6 +89,15 @@ export async function channelPin(
   return undefined;
 }
 
+export async function channelUnpin(
+  channel: { unpin?: () => Promise<any> },
+): Promise<any> {
+  if (typeof channel.unpin === "function") {
+    return channel.unpin();
+  }
+  return undefined;
+}
+
 export async function channelQuery(
   channel: { query?: (options?: any) => Promise<any> },
   options?: any,

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
@@ -6,6 +6,7 @@ import { useChannelMembershipState } from '../ChannelList';
 import { Icon } from './icons';
 import { useTranslationContext } from '../../context';
 
+import { channelUnpin } from '../../chatSDKShim';
 export type ChannelPreviewActionButtonsProps = {
   channel: Channel;
 };
@@ -28,7 +29,7 @@ export function ChannelPreviewActionButtons({
         onClick={(e) => {
           e.stopPropagation();
           if (membership.pinned_at) {
-            /* TODO backend-wire-up: channel.unpin */
+            channelUnpin(channel);
           } else {
             /* TODO backend-wire-up: channel.pin */
           }

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -28,6 +28,7 @@
   "channel.on": "shim::channel.on",
   "channel.off": "shim::channel.off",
   "channel.pin": "shim::channel.pin",
+  "channel.unpin": "shim::channel.unpin",
   "channel.query": "shim::channel.query",
   "channel.state.loadMessageIntoState": "shim::channel.state.loadMessageIntoState"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -321,7 +321,7 @@
     "stubName": "channel.unpin",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- support `channel.unpin` shim
- remove stub from `ChannelPreviewActionButtons`
- map `channel.unpin` in openapi stub map
- mark `channel.unpin` done in manifest
- add unit test

## Testing
- `pnpm lint:fix` *(fails: Command "lint:fix" not found)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `npx jest libs/stream-chat-shim/__tests__/channel.unpin.test.ts` *(fails: interactive prompt to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686085be1b288326b014fc234da379cf