### PR TITLE
✅ channel.watch shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -144,3 +144,26 @@ export async function channelStateLoadMessageIntoState(
   }
   return undefined;
 }
+
+export async function channelWatch(
+  channel: { cid: string },
+  options?: Record<string, any>,
+): Promise<{ messages: any[] }> {
+  const searchParams = new URLSearchParams();
+  if (options) {
+    for (const [key, value] of Object.entries(options)) {
+      if (value !== undefined && value !== null) {
+        searchParams.set(key, String(value));
+      }
+    }
+  }
+  const query = searchParams.toString();
+  const resp = await fetch(
+    `/api/rooms/${encodeURIComponent(channel.cid)}/messages/${
+      query ? `?${query}` : ""
+    }`,
+    { credentials: "same-origin" },
+  );
+  const data = await resp.json();
+  return { messages: data };
+}

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -30,5 +30,6 @@
   "channel.pin": "shim::channel.pin",
   "channel.unpin": "shim::channel.unpin",
   "channel.query": "shim::channel.query",
+  "channel.watch": "shim::channel.watch",
   "channel.state.loadMessageIntoState": "shim::channel.state.loadMessageIntoState"
 }


### PR DESCRIPTION
## Summary
- support `channel.watch` in chatSDKShim
- track stub mapping for channel.watch

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686088aa92588326b4169a8b4f2f733e