### PR TITLE
feat(client.channel): implement shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -175,3 +175,15 @@ export async function channelWatch(
   const data = await resp.json();
   return { messages: data };
 }
+
+export function clientChannel(
+  client: { channel?: (type: string, id?: string, extra?: any) => any },
+  type: string,
+  id?: string,
+  extra?: any,
+): any {
+  if (typeof client.channel === "function") {
+    return client.channel(type, id, extra);
+  }
+  return undefined;
+}

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelListShape.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelListShape.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils';
 import { useChatContext } from '../../../context';
 import { getChannel } from '../../../utils';
+import { clientChannel } from '../../../chatSDKShim';
 import type { ChannelListProps } from '../ChannelList';
 
 type SetChannels = Dispatch<SetStateAction<Channel[]>>;
@@ -110,7 +111,11 @@ export const useChannelListShapeDefaults = () => {
       if (!channelType || !channelId) return;
 
       setChannels((currentChannels) => {
-        const targetChannel = /* TODO backend-wire-up: client.channel */ {} as any;
+        const targetChannel = clientChannel(
+          client,
+          channelType,
+          channelId,
+        ) as any;
         const targetChannelIndex = currentChannels.indexOf(targetChannel);
         const targetChannelExistsWithinList = targetChannelIndex >= 0;
 
@@ -280,7 +285,11 @@ export const useChannelListShapeDefaults = () => {
       const pinnedAtSort = extractSortValue({ atIndex: 0, sort, targetKey: 'pinned_at' });
 
       setChannels((currentChannels) => {
-        const targetChannel = /* TODO backend-wire-up: client.channel */ {} as any;
+        const targetChannel = clientChannel(
+          client,
+          event.channel_type!,
+          event.channel_id!,
+        ) as any;
         // assumes that channel instances are not changing
         const targetChannelIndex = currentChannels.indexOf(targetChannel);
         const targetChannelExistsWithinList = targetChannelIndex >= 0;

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import uniqBy from 'lodash.uniqby';
 
 import { moveChannelUp } from '../utils';
+import { clientChannel } from '../../../chatSDKShim';
 
 import { useChatContext } from '../../../context/ChatContext';
 
@@ -32,7 +33,11 @@ export const useMessageNewListener = (
             allowNewMessagesFromUnfilteredChannels &&
             event.channel_type
           ) {
-            const channel = /* TODO backend-wire-up: client.channel */ {} as any;
+            const channel = clientChannel(
+              client,
+              event.channel_type,
+              event.channel_id,
+            ) as any;
             return uniqBy([channel, ...channels], 'cid');
           }
 

--- a/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -7,6 +7,7 @@ import type { ChannelOrUserResponse } from '../utils';
 import { isChannel } from '../utils';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientChannel } from '../../../chatSDKShim';
 
 import type {
   Channel,
@@ -179,8 +180,11 @@ export const useChannelSearch = ({
         setActiveChannel(result);
         selectedChannel = result;
       } else {
-        const newChannel =
-          /* TODO backend-wire-up: client.channel */ ({} as Channel);
+        const newChannel = clientChannel(
+          client,
+          result.type,
+          result.id,
+        ) as Channel;
         await /* TODO backend-wire-up: channel.watch */ Promise.resolve();
 
         setActiveChannel(newChannel);

--- a/libs/stream-chat-shim/src/experimental/Search/SearchResults/SearchResultItem.tsx
+++ b/libs/stream-chat-shim/src/experimental/Search/SearchResults/SearchResultItem.tsx
@@ -8,7 +8,10 @@ import { Avatar } from "../../../components/Avatar";
 import { ChannelPreview } from "../../../components/ChannelPreview";
 import { useChannelListContext, useChatContext } from "../../../context";
 import { DEFAULT_JUMP_TO_PAGE_SIZE } from "../../../constants/limits";
-import { channelStateLoadMessageIntoState } from "../../../chatSDKShim";
+import {
+  channelStateLoadMessageIntoState,
+  clientChannel,
+} from "../../../chatSDKShim";
 
 export type ChannelSearchResultItemProps = {
   item: Channel;
@@ -45,6 +48,7 @@ export const MessageSearchResultItem = ({
     channel: activeChannel,
     searchController,
     setActiveChannel,
+    client,
   } = useChatContext();
   const { setChannels } = useChannelListContext();
 
@@ -52,7 +56,7 @@ export const MessageSearchResultItem = ({
     const { channel: channelData } = item;
     const type = channelData?.type ?? "unknown";
     const id = channelData?.id ?? "unknown";
-    return /* TODO backend-wire-up: client.channel */ undefined as unknown as Channel;
+    return clientChannel(client, type, id) as Channel;
   }, [item]);
 
   const onSelect = useCallback(async () => {
@@ -94,13 +98,16 @@ export type UserSearchResultItemProps = {
 };
 
 export const UserSearchResultItem = ({ item }: UserSearchResultItemProps) => {
-  const { setActiveChannel } = useChatContext();
+  const { setActiveChannel, client } = useChatContext();
   const { setChannels } = useChannelListContext();
   const { directMessagingChannelType } = useSearchContext();
 
   const onClick = useCallback(() => {
-    const newChannel =
-      /* TODO backend-wire-up: client.channel */ undefined as unknown as Channel;
+    const newChannel = clientChannel(
+      client,
+      directMessagingChannelType,
+      item.id,
+    ) as Channel;
     /* TODO backend-wire-up: channel.watch */
     setActiveChannel(newChannel);
     setChannels?.((channels) => uniqBy([newChannel, ...channels], "cid"));

--- a/libs/stream-chat-shim/src/utils/getChannel.ts
+++ b/libs/stream-chat-shim/src/utils/getChannel.ts
@@ -4,6 +4,7 @@ import type {
   QueryChannelAPIResponse,
   StreamChat,
 } from 'chat-shim';
+import { clientChannel } from '../chatSDKShim';
 
 /**
  * prevent from duplicate invocation of channel.watch()
@@ -47,7 +48,7 @@ export const getChannel = async ({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const theChannel =
     channel ||
-    /* TODO backend-wire-up: client.channel */ ({} as Channel);
+    (clientChannel(client, type!, id) as Channel);
 
   // need to keep as with call to channel.watch the id can be changed from undefined to an actual ID generated server-side
   const originalCid = theChannel?.id

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -32,5 +32,6 @@
   "channel.query": "shim::channel.query",
   "channel.watch": "shim::channel.watch",
   "channel.state.loadMessageIntoState": "shim::channel.state.loadMessageIntoState"
-  "channel.unarchive": "shim::channel.unarchive"
+  "channel.unarchive": "shim::channel.unarchive",
+  "client.channel": "shim::client.channel"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -339,7 +339,7 @@
     "stubName": "client.channel",
     "ticketType": "shim",
     "todoCount": 7,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add `clientChannel` shim in `chatSDKShim`
- connect `client.channel` usage in ChannelSearch, ChannelList, MessageNewListener, Search results
- hook up `getChannel` helper
- update stub mappings for `client.channel`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608dc4c0e88326a4972d088c3aa58d