### PR TITLE
Implement shim for client.off

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.off.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.off.test.ts
@@ -1,0 +1,14 @@
+import { clientOff } from '../src/chatSDKShim';
+
+describe('clientOff', () => {
+  it('calls client.off when available', () => {
+    const fn = jest.fn();
+    const handler = jest.fn();
+    clientOff({ off: fn }, 'user.updated', handler);
+    expect(fn).toHaveBeenCalledWith('user.updated', handler);
+  });
+
+  it('does nothing when not implemented', () => {
+    expect(() => clientOff({} as any, 'event', () => {})).not.toThrow();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -188,6 +188,21 @@ export function clientChannel(
   return undefined;
 }
 
+export function clientOff(
+  client: {
+    off?: (eventType?: string, handler?: (...args: any[]) => void) => void;
+  },
+  eventType?: string,
+  handler?: (...args: any[]) => void,
+): void {
+  if (typeof client.off === "function") {
+    (client.off as (
+      eventType?: string,
+      handler?: (...args: any[]) => void,
+    ) => void)(eventType, handler);
+  }
+}
+
 export async function clientDeleteMessage(
   _client: unknown,
   messageId: string,

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -33,5 +33,6 @@
   "channel.watch": "shim::channel.watch",
   "channel.state.loadMessageIntoState": "shim::channel.state.loadMessageIntoState"
   "channel.unarchive": "shim::channel.unarchive",
-  "client.channel": "shim::client.channel"
+  "client.channel": "shim::client.channel",
+  "client.off": "shim::client.off"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -348,7 +348,7 @@
     "stubName": "client.off",
     "ticketType": "shim",
     "todoCount": 22,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `clientOff` helper in chatSDKShim
- add tests for `clientOff`
- register stub mapping
- mark client.off wireup as ok

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pnpm --filter frontend lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686093f7d8c4832687541767dec2ff6b