### PR TITLE
Implement client.queryUsers shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.queryUsers.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.queryUsers.test.ts
@@ -1,0 +1,13 @@
+import { clientQueryUsers } from '../src/chatSDKShim';
+
+describe('clientQueryUsers', () => {
+  it('fetches users from backend', async () => {
+    const users = [{ id: 1, username: 'test' }];
+    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve(users) });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await clientQueryUsers();
+    expect(fetchMock).toHaveBeenCalledWith('/api/users/', { credentials: 'same-origin' });
+    expect(res).toEqual({ users });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -255,3 +255,9 @@ export async function clientQueryChannels(
   });
   return resp.json();
 }
+
+export async function clientQueryUsers(_client?: unknown): Promise<{ users: any[] }> {
+  const resp = await fetch('/api/users/', { credentials: 'same-origin' });
+  const data = await resp.json();
+  return { users: data };
+}


### PR DESCRIPTION
## Summary
- support `client.queryUsers` in chatSDKShim
- add unit test for client.queryUsers

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `npx jest` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68609e469e408326b7a6d1e5e4091686