### PR TITLE
Wire up client.reminders.createReminder

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -261,3 +261,20 @@ export async function clientQueryUsers(_client?: unknown): Promise<{ users: any[
   const data = await resp.json();
   return { users: data };
 }
+
+export async function clientRemindersCreateReminder(
+  client: { reminders?: { createReminder?: (text: string, remind_at: string) => Promise<any> } },
+  text: string,
+  remind_at: string,
+): Promise<any> {
+  if (client.reminders?.createReminder) {
+    return client.reminders.createReminder(text, remind_at);
+  }
+  const resp = await fetch('/api/reminders/', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, remind_at }),
+  });
+  return resp.json();
+}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -33,7 +33,7 @@
     "stubName": "client.reminders.createReminder",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `client.reminders.createReminder` shim
- mark stub completed in wireup manifest

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm lint:fix` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a26d72ac83268295ab73ebe66bf0