### PR TITLE
Implement client.reminders.deleteReminder shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.reminders.deleteReminder.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.reminders.deleteReminder.test.ts
@@ -1,0 +1,25 @@
+import { clientRemindersDeleteReminder } from '../src/chatSDKShim';
+
+describe('clientRemindersDeleteReminder', () => {
+  it('calls client.reminders.deleteReminder when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const client = { reminders: { deleteReminder: fn } } as any;
+    const res = await clientRemindersDeleteReminder(client, '42');
+    expect(fn).toHaveBeenCalledWith('42');
+    expect(res).toBe('ok');
+  });
+
+  it('falls back to HTTP request when not implemented', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await clientRemindersDeleteReminder({} as any, '42');
+    expect(fetchMock).toHaveBeenCalledWith('/api/reminders/42/', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    });
+    expect(res).toBe('ok');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -278,3 +278,17 @@ export async function clientRemindersCreateReminder(
   });
   return resp.json();
 }
+
+export async function clientRemindersDeleteReminder(
+  client: { reminders?: { deleteReminder?: (id: string) => Promise<any> } },
+  reminderId: string,
+): Promise<any> {
+  if (client.reminders?.deleteReminder) {
+    return client.reminders.deleteReminder(reminderId);
+  }
+  const resp = await fetch(`/api/reminders/${encodeURIComponent(reminderId)}/`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+  });
+  return resp.json();
+}

--- a/libs/stream-chat-shim/src/experimental/MessageActions/defaults.tsx
+++ b/libs/stream-chat-shim/src/experimental/MessageActions/defaults.tsx
@@ -133,8 +133,7 @@ const DefaultMessageActionComponents = {
         <DefaultDropdownActionButton
           onClick={() =>
             reminder
-              ? /* TODO backend-wire-up: client.reminders.deleteReminder */
-                Promise.resolve()
+              ? client.reminders.deleteReminder(reminder.id)
               : client.reminders.createReminder(
                   message.text || '',
                   new Date().toISOString(),

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -21,6 +21,7 @@
   "client.queryUsers": "listUsers",
   "client.queryChannels": "listRooms",
   "client.reminders.createReminder": "createReminder",
+  "client.reminders.deleteReminder": "shim::client.reminders.deleteReminder",
   "channel.archive": "shim::channel.archive",
   "channel.countUnread": "shim::channel.countUnread",
   "channel.getClient": "shim::channel.getClient",


### PR DESCRIPTION
## Summary
- wire up `client.reminders.deleteReminder` shim
- map stub token to operation id
- clean up SaveForLater action
- add unit test for the shim

## Testing
- `npx jest libs/stream-chat-shim/__tests__/client.reminders.deleteReminder.test.ts --runInBand --ci`
- `pnpm --filter frontend test` *(fails: Cannot find module '../api')*
- `pnpm --filter frontend build` *(fails to compile: Can't resolve 'ws')*

------
https://chatgpt.com/codex/tasks/task_e_6860fcafa764832691c78bfb6641facb