### PR TITLE
wireup shim::client.threads.activate

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.activate.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.activate.test.ts
@@ -1,0 +1,13 @@
+import { clientThreadsActivate } from "../src/chatSDKShim";
+
+describe("clientThreadsActivate", () => {
+  it("calls client.threads.activate when available", () => {
+    const fn = jest.fn();
+    clientThreadsActivate({ threads: { activate: fn } } as any);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("does nothing when not implemented", () => {
+    expect(() => clientThreadsActivate({} as any)).not.toThrow();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -256,24 +256,30 @@ export async function clientQueryChannels(
   return resp.json();
 }
 
-export async function clientQueryUsers(_client?: unknown): Promise<{ users: any[] }> {
-  const resp = await fetch('/api/users/', { credentials: 'same-origin' });
+export async function clientQueryUsers(
+  _client?: unknown,
+): Promise<{ users: any[] }> {
+  const resp = await fetch("/api/users/", { credentials: "same-origin" });
   const data = await resp.json();
   return { users: data };
 }
 
 export async function clientRemindersCreateReminder(
-  client: { reminders?: { createReminder?: (text: string, remind_at: string) => Promise<any> } },
+  client: {
+    reminders?: {
+      createReminder?: (text: string, remind_at: string) => Promise<any>;
+    };
+  },
   text: string,
   remind_at: string,
 ): Promise<any> {
   if (client.reminders?.createReminder) {
     return client.reminders.createReminder(text, remind_at);
   }
-  const resp = await fetch('/api/reminders/', {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
+  const resp = await fetch("/api/reminders/", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text, remind_at }),
   });
   return resp.json();
@@ -286,9 +292,18 @@ export async function clientRemindersDeleteReminder(
   if (client.reminders?.deleteReminder) {
     return client.reminders.deleteReminder(reminderId);
   }
-  const resp = await fetch(`/api/reminders/${encodeURIComponent(reminderId)}/`, {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  });
+  const resp = await fetch(
+    `/api/reminders/${encodeURIComponent(reminderId)}/`,
+    {
+      method: "DELETE",
+      credentials: "same-origin",
+    },
+  );
   return resp.json();
+}
+
+export function clientThreadsActivate(client: {
+  threads?: { activate?: () => void };
+}): void {
+  client.threads?.activate?.();
 }

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -1,17 +1,19 @@
-import React, { useEffect } from 'react';
-import type { ComputeItemKey, VirtuosoProps } from 'react-virtuoso';
-import { Virtuoso } from 'react-virtuoso';
+import React, { useEffect } from "react";
+import type { ComputeItemKey, VirtuosoProps } from "react-virtuoso";
+import { Virtuoso } from "react-virtuoso";
 
-import type { Thread, ThreadManagerState } from 'chat-shim';
+import type { Thread, ThreadManagerState } from "chat-shim";
 
-import { ThreadListItem as DefaultThreadListItem } from './ThreadListItem';
-import { ThreadListEmptyPlaceholder as DefaultThreadListEmptyPlaceholder } from './ThreadListEmptyPlaceholder';
-import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner } from './ThreadListUnseenThreadsBanner';
-import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from './ThreadListLoadingIndicator';
-import { useChatContext, useComponentContext } from '../../../context';
-import { useStateStore } from '../../../store';
+import { ThreadListItem as DefaultThreadListItem } from "./ThreadListItem";
+import { ThreadListEmptyPlaceholder as DefaultThreadListEmptyPlaceholder } from "./ThreadListEmptyPlaceholder";
+import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner } from "./ThreadListUnseenThreadsBanner";
+import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from "./ThreadListLoadingIndicator";
+import { useChatContext, useComponentContext } from "../../../context";
+import { useStateStore } from "../../../store";
 
-const selector = (nextValue: ThreadManagerState) => ({ threads: nextValue.threads });
+const selector = (nextValue: ThreadManagerState) => ({
+  threads: nextValue.threads,
+});
 
 const computeItemKey: ComputeItemKey<Thread, unknown> = (_, item) => item.id;
 
@@ -24,20 +26,20 @@ export const useThreadList = () => {
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        /* TODO backend-wire-up: client.threads.activate */
+      if (document.visibilityState === "visible") {
+        client.threads.activate();
       }
-      if (document.visibilityState === 'hidden') {
+      if (document.visibilityState === "hidden") {
         /* TODO backend-wire-up: client.threads.deactivate */
       }
     };
 
     handleVisibilityChange();
 
-    document.addEventListener('visibilitychange', handleVisibilityChange);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       /* TODO backend-wire-up: client.threads.deactivate */
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [client]);
 };
@@ -55,14 +57,15 @@ export const ThreadList = ({ virtuosoProps }: ThreadListProps) => {
   useThreadList();
 
   return (
-    <div className='str-chat__thread-list-container'>
+    <div className="str-chat__thread-list-container">
       {/* TODO: allow re-load on stale ThreadManager state */}
       <ThreadListUnseenThreadsBanner />
       <Virtuoso
         atBottomStateChange={(atBottom) =>
-          atBottom && /* TODO backend-wire-up: client.threads.loadNextPage */ null
+          atBottom &&
+          /* TODO backend-wire-up: client.threads.loadNextPage */ null
         }
-        className='str-chat__thread-list'
+        className="str-chat__thread-list"
         components={{
           EmptyPlaceholder: ThreadListEmptyPlaceholder,
           Footer: ThreadListLoadingIndicator,

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -37,5 +37,6 @@
   "channel.unarchive": "shim::channel.unarchive",
   "client.channel": "shim::client.channel",
   "client.off": "shim::client.off",
-  "client.on": "shim::client.on"
+  "client.on": "shim::client.on",
+  "client.threads.activate": "shim::client.threads.activate"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -384,7 +384,7 @@
     "stubName": "client.threads.activate",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `clientThreadsActivate` shim
- trigger `client.threads.activate()` in ThreadList
- add tests for new shim
- wire up mapping

## Testing
- `npx prettier` *(passed)*
- `pnpm exec jest libs/stream-chat-shim/__tests__/client.threads.activate.test.ts --runInBand` *(failed: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861021b7868832688d268176b1a879e