### PR TITLE
✅ wire up client.threads.deactivate

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.deactivate.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.deactivate.test.ts
@@ -1,0 +1,13 @@
+import { clientThreadsDeactivate } from "../src/chatSDKShim";
+
+describe("clientThreadsDeactivate", () => {
+  it("calls client.threads.deactivate when available", () => {
+    const fn = jest.fn();
+    clientThreadsDeactivate({ threads: { deactivate: fn } } as any);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("does nothing when not implemented", () => {
+    expect(() => clientThreadsDeactivate({} as any)).not.toThrow();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -307,3 +307,9 @@ export function clientThreadsActivate(client: {
 }): void {
   client.threads?.activate?.();
 }
+
+export function clientThreadsDeactivate(client: {
+  threads?: { deactivate?: () => void };
+}): void {
+  client.threads?.deactivate?.();
+}

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -10,6 +10,7 @@ import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner }
 import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from "./ThreadListLoadingIndicator";
 import { useChatContext, useComponentContext } from "../../../context";
 import { useStateStore } from "../../../store";
+import { clientThreadsDeactivate } from "../../../chatSDKShim";
 
 const selector = (nextValue: ThreadManagerState) => ({
   threads: nextValue.threads,
@@ -30,7 +31,7 @@ export const useThreadList = () => {
         client.threads.activate();
       }
       if (document.visibilityState === "hidden") {
-        /* TODO backend-wire-up: client.threads.deactivate */
+        clientThreadsDeactivate(client);
       }
     };
 
@@ -38,7 +39,7 @@ export const useThreadList = () => {
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      /* TODO backend-wire-up: client.threads.deactivate */
+      clientThreadsDeactivate(client);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [client]);

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -38,5 +38,6 @@
   "client.channel": "shim::client.channel",
   "client.off": "shim::client.off",
   "client.on": "shim::client.on",
-  "client.threads.activate": "shim::client.threads.activate"
+  "client.threads.activate": "shim::client.threads.activate",
+  "client.threads.deactivate": "shim::client.threads.deactivate"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -393,7 +393,7 @@
     "stubName": "client.threads.deactivate",
     "ticketType": "shim",
     "todoCount": 2,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- handle `client.threads.deactivate` in `chatSDKShim`
- call the shim from `ThreadList` component
- add tests for the new helper
- map stub token to operationId
- mark shim entry as ok

## Testing
- `pnpm test` *(fails: `turbo` not found)*
- `pnpm build` *(fails: Command "build" not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: no `tsc` script)*
- `pnpm lint:fix` *(fails: Command "lint:fix" not found)*
- `black .` *(runs, reformats files)*
- `isort .` *(runs, fixes imports)*

------
https://chatgpt.com/codex/tasks/task_e_6861098c7fa0832685809b87ceaf2dd1