### PR TITLE
Shim helper: client.threads.loadNextPage

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.loadNextPage.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.loadNextPage.test.ts
@@ -1,0 +1,24 @@
+import { clientThreadsLoadNextPage } from '../src/chatSDKShim';
+
+describe('clientThreadsLoadNextPage', () => {
+  it('calls client.threads.loadNextPage when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const client = { threads: { loadNextPage: fn } } as any;
+    const res = await clientThreadsLoadNextPage(client);
+    expect(fn).toHaveBeenCalled();
+    expect(res).toBe('ok');
+  });
+
+  it('falls back to HTTP request when not implemented', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await clientThreadsLoadNextPage({} as any);
+    expect(fetchMock).toHaveBeenCalledWith('/api/threads/', {
+      credentials: 'same-origin',
+    });
+    expect(res).toBe('ok');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -313,3 +313,13 @@ export function clientThreadsDeactivate(client: {
 }): void {
   client.threads?.deactivate?.();
 }
+
+export async function clientThreadsLoadNextPage(client: {
+  threads?: { loadNextPage?: () => Promise<any> };
+}): Promise<any> {
+  if (client.threads?.loadNextPage) {
+    return client.threads.loadNextPage();
+  }
+  const resp = await fetch('/api/threads/', { credentials: 'same-origin' });
+  return resp.json();
+}

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -10,7 +10,10 @@ import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner }
 import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from "./ThreadListLoadingIndicator";
 import { useChatContext, useComponentContext } from "../../../context";
 import { useStateStore } from "../../../store";
-import { clientThreadsDeactivate } from "../../../chatSDKShim";
+import {
+  clientThreadsDeactivate,
+  clientThreadsLoadNextPage,
+} from "../../../chatSDKShim";
 
 const selector = (nextValue: ThreadManagerState) => ({
   threads: nextValue.threads,
@@ -63,8 +66,7 @@ export const ThreadList = ({ virtuosoProps }: ThreadListProps) => {
       <ThreadListUnseenThreadsBanner />
       <Virtuoso
         atBottomStateChange={(atBottom) =>
-          atBottom &&
-          /* TODO backend-wire-up: client.threads.loadNextPage */ null
+          atBottom && clientThreadsLoadNextPage(client)
         }
         className="str-chat__thread-list"
         components={{

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -39,5 +39,6 @@
   "client.off": "shim::client.off",
   "client.on": "shim::client.on",
   "client.threads.activate": "shim::client.threads.activate",
-  "client.threads.deactivate": "shim::client.threads.deactivate"
+  "client.threads.deactivate": "shim::client.threads.deactivate",
+  "client.threads.loadNextPage": "shim::client.threads.loadNextPage"
 }


### PR DESCRIPTION
## Summary
- implement `clientThreadsLoadNextPage` helper
- wire ThreadList to call `clientThreadsLoadNextPage`
- map stub token to shim handler
- add unit tests for new helper

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610cac7200832698052dbbfcdde5d4