### PR TITLE
feat(shim::client.threads.state): implement

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.state.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.state.test.ts
@@ -1,0 +1,16 @@
+import { clientThreadsState } from '../src/chatSDKShim';
+import { StateStore } from 'chat-shim';
+import { noopStore } from 'chat-shim/noopStore';
+
+describe('clientThreadsState', () => {
+  it('returns client.threads.state when available', () => {
+    const store = new StateStore({ count: 1 });
+    const client = { threads: { state: store } } as any;
+    expect(clientThreadsState(client)).toBe(store);
+  });
+
+  it('falls back to noopStore when not implemented', () => {
+    const client = {} as any;
+    expect(clientThreadsState(client)).toBe(noopStore);
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,3 +1,6 @@
+import { noopStore } from 'chat-shim/noopStore';
+import type { StateStore } from 'chat-shim';
+
 export async function addAnswer(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
 }
@@ -332,4 +335,10 @@ export async function clientThreadsReload(client: {
   }
   const resp = await fetch('/api/threads/', { credentials: 'same-origin' });
   return resp.json();
+}
+
+export function clientThreadsState(client: {
+  threads?: { state?: StateStore<any> };
+}): StateStore<any> {
+  return client.threads?.state ?? noopStore;
 }

--- a/libs/stream-chat-shim/src/components/ChatView/ChatView.tsx
+++ b/libs/stream-chat-shim/src/components/ChatView/ChatView.tsx
@@ -11,6 +11,7 @@ import type { Thread, ThreadManagerState } from 'chat-shim';
 import clsx from 'clsx';
 
 import { noopStore } from 'chat-shim/noopStore';
+import { clientThreadsState } from '../../chatSDKShim';
 
 type ChatView = 'channels' | 'threads';
 
@@ -133,13 +134,10 @@ const selector = ({ unreadThreadCount }: ThreadManagerState) => ({
 
 const ChatViewSelector = () => {
   const { client } = useChatContext();
-  // const { unreadThreadCount } = useStateStore(
-  //   /* TODO backend-wire-up: client.threads.state */
-  //   return () => { /* noop */ };
-  //   selector,
-  // );
-  /** swap in the real store later — for now just use the noop one */
-  const { unreadThreadCount } = useStateStore(noopStore, selector);
+  const { unreadThreadCount } = useStateStore(
+    clientThreadsState(client),
+    selector,
+  );
 
   const { activeChatView, setActiveChatView } = useContext(ChatViewContext);
 

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -10,6 +10,7 @@ import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner }
 import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from "./ThreadListLoadingIndicator";
 import { useChatContext, useComponentContext } from "../../../context";
 import { useStateStore } from "../../../store";
+import { clientThreadsState } from "../../../chatSDKShim";
 import {
   clientThreadsDeactivate,
   clientThreadsLoadNextPage,
@@ -56,7 +57,7 @@ export const ThreadList = ({ virtuosoProps }: ThreadListProps) => {
     ThreadListLoadingIndicator = DefaultThreadListLoadingIndicator,
     ThreadListUnseenThreadsBanner = DefaultThreadListUnseenThreadsBanner,
   } = useComponentContext();
-  const { threads } = useStateStore(client.threads.state, selector);
+  const { threads } = useStateStore(clientThreadsState(client), selector);
 
   useThreadList();
 

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListLoadingIndicator.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListLoadingIndicator.tsx
@@ -5,6 +5,7 @@ import type { ThreadManagerState } from 'chat-shim';
 import { LoadingIndicator as DefaultLoadingIndicator } from '../../Loading';
 import { useChatContext, useComponentContext } from '../../../context';
 import { useStateStore } from '../../../store';
+import { clientThreadsState } from '../../../chatSDKShim';
 
 const selector = (nextValue: ThreadManagerState) => ({
   isLoadingNext: nextValue.pagination.isLoadingNext,
@@ -13,7 +14,10 @@ const selector = (nextValue: ThreadManagerState) => ({
 export const ThreadListLoadingIndicator = () => {
   const { LoadingIndicator = DefaultLoadingIndicator } = useComponentContext();
   const { client } = useChatContext();
-  const { isLoadingNext } = useStateStore(client.threads.state, selector);
+  const { isLoadingNext } = useStateStore(
+    clientThreadsState(client),
+    selector,
+  );
 
   if (!isLoadingNext) return null;
 

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
@@ -5,6 +5,7 @@ import type { ThreadManagerState } from 'chat-shim';
 import { Icon } from '../icons';
 import { useChatContext } from '../../../context';
 import { useStateStore } from '../../../store';
+import { clientThreadsState } from '../../../chatSDKShim';
 
 const selector = (nextValue: ThreadManagerState) => ({
   unseenThreadIds: nextValue.unseenThreadIds,
@@ -12,7 +13,10 @@ const selector = (nextValue: ThreadManagerState) => ({
 
 export const ThreadListUnseenThreadsBanner = () => {
   const { client } = useChatContext();
-  const { unseenThreadIds } = useStateStore(client.threads.state, selector);
+  const { unseenThreadIds } = useStateStore(
+    clientThreadsState(client),
+    selector,
+  );
 
   if (!unseenThreadIds.length) return null;
 

--- a/libs/stream-chat-shim/src/components/Threads/hooks/useThreadManagerState.ts
+++ b/libs/stream-chat-shim/src/components/Threads/hooks/useThreadManagerState.ts
@@ -2,11 +2,12 @@ import type { ThreadManagerState } from 'chat-shim';
 
 import { useChatContext } from '../../../context';
 import { useStateStore } from '../../../store';
+import { clientThreadsState } from '../../../chatSDKShim';
 
 export const useThreadManagerState = <T extends readonly unknown[]>(
   selector: (nextValue: ThreadManagerState) => T,
 ) => {
   const { client } = useChatContext();
 
-  return useStateStore(client.threads.state, selector);
+  return useStateStore(clientThreadsState(client), selector);
 };

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -42,4 +42,6 @@
   "client.threads.deactivate": "shim::client.threads.deactivate",
   "client.threads.loadNextPage": "shim::client.threads.loadNextPage",
   "client.threads.reload": "shim::client.threads.reload"
+  ,
+  "client.threads.state": "shim::client.threads.state"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -416,11 +416,11 @@
   {
     "method": "",
     "path": "",
-    "operationId": "shim::client.threads.state",
-    "stubName": "client.threads.state",
-    "ticketType": "shim",
-    "todoCount": 1,
-    "status": "missing"
+  "operationId": "shim::client.threads.state",
+  "stubName": "client.threads.state",
+  "ticketType": "shim",
+  "todoCount": 1,
+  "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `clientThreadsState` helper
- wire thread state accessor into thread-related components
- add unit test
- map stub token in `stub_map.json` and mark done in `wireup_manifest.json`

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686113fbb1248326a8c818c2d4509f7e