### PR TITLE
Implement client.updateMessage shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.updateMessage.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.updateMessage.test.ts
@@ -1,0 +1,22 @@
+import { clientUpdateMessage } from '../src/chatSDKShim';
+
+describe('clientUpdateMessage', () => {
+  it('calls client.updateMessage when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const client = { updateMessage: fn } as any;
+    const res = await clientUpdateMessage(client, '42', 'hi');
+    expect(fn).toHaveBeenCalledWith('42', 'hi');
+    expect(res).toBe('ok');
+  });
+
+  it('falls back to HTTP request when not implemented', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await clientUpdateMessage({} as any, '42', 'hi');
+    expect(fetchMock).toHaveBeenCalledWith('/api/messages/42/', expect.objectContaining({ method: 'PUT' }));
+    expect(res).toBe('ok');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -240,6 +240,25 @@ export async function clientDeleteMessage(
   return resp.json();
 }
 
+export async function clientUpdateMessage(
+  client: { updateMessage?: (id: string, text: string) => Promise<any> } | unknown,
+  messageId: string,
+  text: string,
+): Promise<any> {
+  if (
+    typeof (client as any).updateMessage === "function"
+  ) {
+    return (client as any).updateMessage(messageId, text);
+  }
+  const resp = await fetch(`/api/messages/${encodeURIComponent(messageId)}/`, {
+    method: "PUT",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  return resp.json();
+}
+
 export async function clientQueryChannels(
   _client: unknown,
   options?: Record<string, any>,


### PR DESCRIPTION
## Summary
- handle `client.updateMessage` in chatSDK shim
- add unit test for `clientUpdateMessage`

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611b4c7f5c8326b3bc50311831218c