### PR TITLE
✅ Shim helper task: close

### DIFF
--- a/libs/stream-chat-shim/__tests__/close.test.ts
+++ b/libs/stream-chat-shim/__tests__/close.test.ts
@@ -1,0 +1,7 @@
+import { close } from '../src/chatSDKShim';
+
+describe('close shim', () => {
+  it('resolves', async () => {
+    await expect(close()).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -16,6 +16,10 @@ export async function archive(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
 }
 
+export async function close(): Promise<void> {
+  // Placeholder implementation until backend endpoint is available
+}
+
 export async function unarchive(channel: { cid: string }): Promise<void> {
   await fetch(`/api/rooms/${encodeURIComponent(channel.cid)}/unarchive`, {
     method: "POST",

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/EndPollDialog.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/EndPollDialog.tsx
@@ -1,6 +1,7 @@
 import { PromptDialog } from '../../Dialog/PromptDialog';
 import React from 'react';
 import { usePollContext, useTranslationContext } from '../../../context';
+import { close as closePoll } from '../../../chatSDKShim';
 
 export type EndPollDialogProps = {
   close: () => void;
@@ -23,7 +24,7 @@ export const EndPollDialog = ({ close }: EndPollDialogProps) => {
           className:
             '.str-chat__dialog__controls-button--submit str-chat__dialog__controls-button--end-poll',
           onClick: () => {
-            /* TODO backend-wire-up: close */
+            closePoll();
           },
         },
       ]}

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -41,7 +41,7 @@
   "client.threads.activate": "shim::client.threads.activate",
   "client.threads.deactivate": "shim::client.threads.deactivate",
   "client.threads.loadNextPage": "shim::client.threads.loadNextPage",
-  "client.threads.reload": "shim::client.threads.reload"
-  ,
-  "client.threads.state": "shim::client.threads.state"
+  "client.threads.reload": "shim::client.threads.reload",
+  "client.threads.state": "shim::client.threads.state",
+  "close": "shim::close"
 }


### PR DESCRIPTION
## Summary
- implement `close` stub in `chatSDKShim`
- call stub from `EndPollDialog`
- map `close` token in `stub_map.json`
- add tests for new stub
- remove `backend-wire-up: close` TODO

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611de0bc2c832696f4d637d596519e