### PR TITLE
Shim createPollOption

### DIFF
--- a/libs/stream-chat-shim/__tests__/createPollOption.test.ts
+++ b/libs/stream-chat-shim/__tests__/createPollOption.test.ts
@@ -1,0 +1,7 @@
+import { createPollOption } from '../src/chatSDKShim';
+
+describe('createPollOption shim', () => {
+  it('resolves', async () => {
+    await expect(createPollOption('poll1', { text: 'opt' })).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -12,6 +12,13 @@ export async function castVote(
   // Placeholder implementation until backend endpoint is available
 }
 
+export async function createPollOption(
+  _pollId: string,
+  _data: { text: string },
+): Promise<void> {
+  // Placeholder implementation until backend endpoint is available
+}
+
 export async function archive(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
 }

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -43,5 +43,6 @@
   "client.threads.loadNextPage": "shim::client.threads.loadNextPage",
   "client.threads.reload": "shim::client.threads.reload",
   "client.threads.state": "shim::client.threads.state",
-  "close": "shim::close"
+  "close": "shim::close",
+  "createPollOption": "shim::createPollOption"
 }


### PR DESCRIPTION
## Summary
- add stub for `createPollOption`
- export mapping in `stub_map.json`
- test that shim resolves

## Testing
- `pnpm exec jest libs/stream-chat-shim/__tests__/createPollOption.test.ts` *(fails: Cannot find module 'react')*


------
https://chatgpt.com/codex/tasks/task_e_686136d372bc8326be594da640c84762