### PR TITLE
wireup syncUser

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -120,6 +120,18 @@ export async function channelUnpin(channel: {
   return undefined;
 }
 
+export async function connectUser(
+  _user: { id: string },
+  jwt: string,
+): Promise<any> {
+  const resp = await fetch("/api/sync-user/", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  return resp.json();
+}
+
 export async function channelQuery(
   channel: { query?: (options?: any) => Promise<any> },
   options?: any,

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -168,7 +168,7 @@
     "stubName": "connectUser",
     "ticketType": "api",
     "todoCount": 2,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement connectUser shim in chatSDKShim
- mark syncUser as done in manifest

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613a0984208326b3d0162d321a204a