### PR TITLE
Implement countUnread shim helper

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -42,6 +42,16 @@ export function channelCountUnread(
   return channel.countUnread();
 }
 
+export function countUnread(
+  channel: { countUnread?: (lastRead?: Date) => number },
+  lastRead?: Date,
+): number {
+  if (typeof channel.countUnread === 'function') {
+    return channel.countUnread(lastRead);
+  }
+  return 0;
+}
+
 export async function channelGetReplies(
   channel: { getReplies?: (id: string, options?: any) => Promise<any> },
   parentId: string,

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -24,6 +24,7 @@
   "client.reminders.deleteReminder": "shim::client.reminders.deleteReminder",
   "channel.archive": "shim::channel.archive",
   "channel.countUnread": "shim::channel.countUnread",
+  "countUnread": "shim::countUnread",
   "channel.getClient": "shim::channel.getClient",
   "channel.getReplies": "shim::channel.getReplies",
   "channel.markRead": "shim::channel.markRead",


### PR DESCRIPTION
## Summary
- add `countUnread` helper to chatSDKShim
- map `countUnread` in stub_map.json

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613a3970b08326a6d7a6b01a738dfa