### PR TITLE
feat(flagMessage): implement shim handler

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -437,3 +437,11 @@ export async function deleteReaction(
     { method: 'DELETE', credentials: 'same-origin' },
   );
 }
+
+export async function flagMessage(messageId: string): Promise<any> {
+  const resp = await fetch(
+    `/api/messages/${encodeURIComponent(messageId)}/flag/`,
+    { method: 'POST', credentials: 'same-origin' },
+  );
+  return resp.json();
+}

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -46,5 +46,6 @@
   "client.threads.state": "shim::client.threads.state",
   "close": "shim::close",
   "createPollOption": "shim::createPollOption",
-  "deleteReaction": "shim::deleteReaction"
+  "deleteReaction": "shim::deleteReaction",
+  "flagMessage": "shim::flagMessage"
 }


### PR DESCRIPTION
## Summary
- implement `flagMessage` in `chatSDKShim`
- map stub token in `stub_map.json`
- remove any leftover TODO comments for `flagMessage`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm lint:fix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614fc377ac83269653404a7ea6d54a