### PR TITLE
feat: implement getUserAgent shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/getUserAgent.test.ts
+++ b/libs/stream-chat-shim/__tests__/getUserAgent.test.ts
@@ -1,0 +1,16 @@
+import { getUserAgent } from '../src/chatSDKShim';
+
+describe('getUserAgent', () => {
+  it('fetches user agent from backend', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ user_agent: 'ua' }) });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const ua = await getUserAgent();
+    expect(fetchMock).toHaveBeenCalledWith('/api/user-agent/', {
+      credentials: 'same-origin',
+    });
+    expect(ua).toBe('ua');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -452,3 +452,11 @@ export async function getAppSettings(): Promise<any> {
   });
   return resp.json();
 }
+
+export async function getUserAgent(): Promise<string> {
+  const resp = await fetch('/api/user-agent/', {
+    credentials: 'same-origin',
+  });
+  const data = await resp.json();
+  return data.user_agent;
+}


### PR DESCRIPTION
## Summary
- add `getUserAgent` API helper in chat SDK shim
- include unit test

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615bcd73b48326b9dcecac67a2c8e8