### PR TITLE
wireup listRoomDrafts

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -460,3 +460,11 @@ export async function getUserAgent(): Promise<string> {
   const data = await resp.json();
   return data.user_agent;
 }
+
+export async function getDraft(roomUuid: string): Promise<{ text?: string }> {
+  const resp = await fetch(
+    `/api/rooms/${encodeURIComponent(roomUuid)}/draft/`,
+    { credentials: 'same-origin' },
+  );
+  return resp.json();
+}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -87,7 +87,7 @@
     "stubName": "getDraft",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",
@@ -416,11 +416,11 @@
   {
     "method": "",
     "path": "",
-  "operationId": "shim::client.threads.state",
-  "stubName": "client.threads.state",
-  "ticketType": "shim",
-  "todoCount": 1,
-  "status": "ok"
+    "operationId": "shim::client.threads.state",
+    "stubName": "client.threads.state",
+    "ticketType": "shim",
+    "todoCount": 1,
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `getDraft` fetch in chatSDKShim
- mark `getDraft` as wired up in `wireup_manifest.json`

## Testing
- `pnpm --filter frontend test` *(fails: Cannot find module '../api')*
- `pnpm --filter frontend build` *(fails: module 'ws' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686160ab69ac8326a1ad1c42c165406a