### PR TITLE
Implement lastRead helper

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -61,6 +61,15 @@ export function countUnread(
   return 0;
 }
 
+export function lastRead(
+  channel: { lastRead?: () => Date | undefined },
+): Date | undefined {
+  if (typeof channel.lastRead === 'function') {
+    return channel.lastRead();
+  }
+  return undefined;
+}
+
 export async function channelGetReplies(
   channel: { getReplies?: (id: string, options?: any) => Promise<any> },
   parentId: string,

--- a/libs/stream-chat-shim/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/VirtualizedMessageList.tsx
@@ -11,6 +11,7 @@ import { Virtuoso } from 'react-virtuoso';
 
 import { GiphyPreviewMessage as DefaultGiphyPreviewMessage } from './GiphyPreviewMessage';
 import { useLastReadData } from './hooks';
+import { lastRead as getLastRead } from '../../chatSDKShim';
 import {
   useGiphyPreview,
   useMessageSetKey,
@@ -247,10 +248,7 @@ const VirtualizedMessageListWithContext = (
 
   const virtuoso = useRef<VirtuosoHandle>(null);
 
-  const lastRead = useMemo(() => {
-    /* TODO backend-wire-up: lastRead */
-    return undefined;
-  }, [channel]);
+  const lastRead = useMemo(() => getLastRead(channel), [channel]);
 
   const { show: showUnreadMessagesNotification, toggleShowUnreadMessagesNotification } =
     useUnreadMessagesNotificationVirtualized({

--- a/libs/stream-chat-shim/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
+++ b/libs/stream-chat-shim/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
@@ -5,6 +5,7 @@ import { getGroupStyles, insertIntro, processMessages } from '../../utils';
 
 import { useChatContext } from '../../../../context/ChatContext';
 import { useComponentContext } from '../../../../context/ComponentContext';
+import { lastRead as getLastRead } from '../../../../chatSDKShim';
 
 import type { Channel, LocalMessage } from 'chat-shim';
 
@@ -42,10 +43,7 @@ export const useEnrichedMessages = (args: {
   const { client } = useChatContext('useEnrichedMessages');
   const { HeaderComponent } = useComponentContext('useEnrichedMessages');
 
-  const lastRead = useMemo(() => {
-    /* TODO backend-wire-up: lastRead */
-    return undefined;
-  }, [channel]);
+  const lastRead = useMemo(() => getLastRead(channel), [channel]);
 
   const enableDateSeparator = !disableDateSeparator;
 

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -47,5 +47,6 @@
   "close": "shim::close",
   "createPollOption": "shim::createPollOption",
   "deleteReaction": "shim::deleteReaction",
-  "flagMessage": "shim::flagMessage"
+  "flagMessage": "shim::flagMessage",
+  "lastRead": "shim::lastRead"
 }


### PR DESCRIPTION
## Summary
- add `lastRead` helper to chatSDK shim
- wire up lastRead logic in message list components
- update stub map for lastRead

## Testing
- `pnpm --filter frontend test` *(fails: Cannot find module '../api')*
- `pnpm --filter frontend build` *(fails: Can't resolve 'ws')*

------
https://chatgpt.com/codex/tasks/task_e_6861634117848326a7159899a7595c82