### PR TITLE
codex/wire-up-markUnread

### DIFF
--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -159,6 +159,12 @@ export class LocalChannel {
     this.sock.send(JSON.stringify({ type: "mark.read", cid: this.cid }));
   }
 
+  markUnread(messageId: string) {
+    this.sock.send(
+      JSON.stringify({ type: "mark.unread", cid: this.cid, id: messageId }),
+    );
+  }
+
   /** Return basic configuration flags expected by Stream UI */
   getConfig() {
     return { typing_events: true, read_events: true };

--- a/libs/stream-chat-shim/__tests__/markUnread.test.ts
+++ b/libs/stream-chat-shim/__tests__/markUnread.test.ts
@@ -1,0 +1,14 @@
+import { markUnread } from '../src/chatSDKShim';
+
+describe('markUnread', () => {
+  it('calls channel.markUnread when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const res = await markUnread({ markUnread: fn } as any, 'm1');
+    expect(fn).toHaveBeenCalledWith('m1');
+    expect(res).toBe('ok');
+  });
+
+  it('resolves undefined when not implemented', async () => {
+    await expect(markUnread({} as any, 'm1')).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -90,6 +90,16 @@ export async function channelMarkRead(channel: {
   return undefined;
 }
 
+export async function markUnread(
+  channel: { markUnread?: (id: string) => Promise<any> },
+  messageId: string,
+): Promise<any> {
+  if (typeof channel.markUnread === "function") {
+    return channel.markUnread(messageId);
+  }
+  return undefined;
+}
+
 export function channelOff(
   channel: {
     off?: (eventType?: string, handler?: (...args: any[]) => void) => void;

--- a/libs/stream-chat-shim/src/components/Message/hooks/useMarkUnreadHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useMarkUnreadHandler.ts
@@ -1,5 +1,6 @@
 import { validateAndGetMessage } from '../utils';
 import { useChannelStateContext, useTranslationContext } from '../../../context';
+import { markUnread } from '../../../chatSDKShim';
 
 import type { LocalMessage } from 'chat-shim';
 import type { ReactEventHandler } from '../types';
@@ -27,9 +28,7 @@ export const useMarkUnreadHandler = (
     }
 
     try {
-      await Promise.resolve(
-        /* TODO backend-wire-up: markUnread */ undefined,
-      );
+      await markUnread(channel, message.id);
       if (!notify) return;
       const successMessage =
         getSuccessNotification &&

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -48,5 +48,6 @@
   "createPollOption": "shim::createPollOption",
   "deleteReaction": "shim::deleteReaction",
   "flagMessage": "shim::flagMessage",
+  "markUnread": "shim::markUnread",
   "lastRead": "shim::lastRead"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -483,7 +483,7 @@
     "stubName": "markUnread",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement markUnread shim in chat libraries
- expose markUnread via chatSDKShim and update hook
- add unit test for markUnread
- map stub to shim op and mark as complete

## Testing
- `pnpm lint:fix` *(fails: command not found)*
- `npx jest libs/stream-chat-shim/__tests__/markUnread.test.ts` *(prompts for package install)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861674047cc8326959e70221da593b3