### PR TITLE
✅ Shim muteUser API helper

### DIFF
--- a/chatgpt_prompts/api_muteUser.md
+++ b/chatgpt_prompts/api_muteUser.md
@@ -651,7 +651,6 @@ Save the output in /openapi/stub_map.json
 **Scope**
 1. Implement backend endpoint (DRF view/serializer) & WS echo if needed.
 2. 🔧 *Front-end* – delete or replace every
-   `// TODO backend-wire-up:muteUser` in `libs/stream-chat-shim/src/`.
 3. Regenerate OpenAPI & flip `"status":"ok"` in the manifest.
 4. Ensure pytest + jest + lints pass.
 

--- a/chatgpt_prompts/shim_muteUser.md
+++ b/chatgpt_prompts/shim_muteUser.md
@@ -649,7 +649,6 @@ Save the output in /openapi/stub_map.json
 **Scope**
 1. Extend or create **chatSDKShim.ts** so calls matching `muteUser` resolve.
 2. Run a codemod (jscodeshift / sed) to remove **all** matching
-   `// TODO backend-wire-up:muteUser` occurrences.
 3. No backend changes expected – just unit tests & lint.
 
 Paste a single patch (multiple files welcome).

--- a/libs/stream-chat-shim/__tests__/muteUser.test.ts
+++ b/libs/stream-chat-shim/__tests__/muteUser.test.ts
@@ -1,0 +1,14 @@
+import { muteUser } from '../src/chatSDKShim';
+
+describe('muteUser', () => {
+  it('posts to backend endpoint', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    await muteUser('u2');
+    expect(fetchMock).toHaveBeenCalledWith('/api/mute/u2/', {
+      method: 'POST',
+      credentials: 'same-origin',
+    });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -487,3 +487,10 @@ export async function getDraft(roomUuid: string): Promise<{ text?: string }> {
   );
   return resp.json();
 }
+
+export async function muteUser(username: string): Promise<void> {
+  await fetch(`/api/mute/${encodeURIComponent(username)}/`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
+}


### PR DESCRIPTION
## Summary
- wire up `muteUser` in chatSDKShim
- test posting mute requests
- remove stale TODO references

## Testing
- `pnpm test` *(fails: turbo: not found)*
- `pnpm --filter frontend test` *(fails: vitest: not found)*
- `pnpm --filter frontend build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616c47423483269b22dca11156f045