### PR TITLE
feat(notifications.store): implement shim ✅

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -487,3 +487,9 @@ export async function getDraft(roomUuid: string): Promise<{ text?: string }> {
   );
   return resp.json();
 }
+
+export function notificationsStore(client: {
+  notifications?: { store?: StateStore<{ notifications: any[] }> };
+}): StateStore<{ notifications: any[] }> {
+  return client.notifications?.store ?? (noopStore as StateStore<any>);
+}

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -49,5 +49,6 @@
   "deleteReaction": "shim::deleteReaction",
   "flagMessage": "shim::flagMessage",
   "markUnread": "shim::markUnread",
-  "lastRead": "shim::lastRead"
+  "lastRead": "shim::lastRead",
+  "notifications.store": "shim::notifications.store"
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -492,7 +492,7 @@
     "stubName": "notifications.store",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement notificationsStore helper in chatSDKShim
- map notifications.store stub to shim operation
- mark stub as wired in manifest

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_6861732517a883269f24c5b2d9f41b98