### PR TITLE
Add vote casted shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -318,6 +318,18 @@ export function on(
   return undefined;
 }
 
+export function onPollVoteCasted(
+  client: {
+    on?: (
+      eventType: string,
+      handler: (...args: any[]) => void,
+    ) => { unsubscribe?: () => void };
+  },
+  handler: (...args: any[]) => void,
+): { unsubscribe?: () => void } | undefined {
+  return on(client, "poll.vote_casted", handler);
+}
+
 export async function deleteMessage(messageId: string): Promise<any> {
   const resp = await fetch(`/api/messages/${encodeURIComponent(messageId)}/`, {
     method: "DELETE",


### PR DESCRIPTION
## Summary
- add `onPollVoteCasted` to the chat SDK shim

## Testing
- `pnpm -F frontend test` *(fails: `vitest` not found)*
- `pnpm -F frontend build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618debdc1c8326bdc3acf9f3f02c8a