### PR TITLE
✅ A7f onPollVoteChanged helper

### DIFF
--- a/libs/stream-chat-shim/__tests__/onPollVoteChanged.test.ts
+++ b/libs/stream-chat-shim/__tests__/onPollVoteChanged.test.ts
@@ -1,0 +1,14 @@
+import { onPollVoteChanged } from '../src/chatSDKShim';
+
+describe('onPollVoteChanged', () => {
+  test('delegates to client.on', () => {
+    const unsub = jest.fn();
+    const client = {
+      on: jest.fn(() => ({ unsubscribe: unsub })),
+    };
+    const handler = jest.fn();
+    const result = onPollVoteChanged(client, handler);
+    expect(client.on).toHaveBeenCalledWith('poll.vote_changed', handler);
+    expect(result?.unsubscribe).toBe(unsub);
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -330,6 +330,18 @@ export function onPollVoteCasted(
   return on(client, "poll.vote_casted", handler);
 }
 
+export function onPollVoteChanged(
+  client: {
+    on?: (
+      eventType: string,
+      handler: (...args: any[]) => void,
+    ) => { unsubscribe?: () => void };
+  },
+  handler: (...args: any[]) => void,
+): { unsubscribe?: () => void } | undefined {
+  return on(client, "poll.vote_changed", handler);
+}
+
 export async function deleteMessage(messageId: string): Promise<any> {
   const resp = await fetch(`/api/messages/${encodeURIComponent(messageId)}/`, {
     method: "DELETE",


### PR DESCRIPTION
## Summary
- add onPollVoteChanged shim helper
- test that onPollVoteChanged proxies to client.on

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: Next.js build worker exited)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_68619d61933c832682d48deaffefd537