### PR TITLE
Implement onPollVoteRemoved shim

### DIFF
--- a/chatgpt_prompts/shim_on(poll.vote_removed).md
+++ b/chatgpt_prompts/shim_on(poll.vote_removed).md
@@ -649,7 +649,6 @@ Save the output in /openapi/stub_map.json
 **Scope**
 1. Extend or create **chatSDKShim.ts** so calls matching `on(poll.vote_removed)` resolve.
 2. Run a codemod (jscodeshift / sed) to remove **all** matching
-   `// TODO backend-wire-up:on(poll.vote_removed)` occurrences.
 3. No backend changes expected – just unit tests & lint.
 
 Paste a single patch (multiple files welcome).

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -330,6 +330,18 @@ export function onPollVoteCasted(
   return on(client, "poll.vote_casted", handler);
 }
 
+export function onPollVoteRemoved(
+  client: {
+    on?: (
+      eventType: string,
+      handler: (...args: any[]) => void,
+    ) => { unsubscribe?: () => void };
+  },
+  handler: (...args: any[]) => void,
+): { unsubscribe?: () => void } | undefined {
+  return on(client, "poll.vote_removed", handler);
+}
+
 export function onPollVoteChanged(
   client: {
     on?: (


### PR DESCRIPTION
## Summary
- provide `onPollVoteRemoved` helper in chatSDKShim
- clean up leftover TODO comment about backend wiring

## Testing
- `pnpm --filter frontend lint` *(fails: various eslint errors)*
- `pnpm test` *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_6861b181d2f88326b4d54d4045353e29