### PR TITLE
Add polls.fromState shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/polls.fromState.test.ts
+++ b/libs/stream-chat-shim/__tests__/polls.fromState.test.ts
@@ -1,0 +1,17 @@
+import { pollsFromState } from '../src/chatSDKShim';
+import { StateStore } from 'chat-shim';
+
+describe('pollsFromState', () => {
+  it('returns poll when found in store', () => {
+    const poll = { id: 'p1' } as any;
+    const store = new StateStore<{ polls: any[] }>({ polls: [poll] });
+    const client = { polls: { store } } as any;
+    expect(pollsFromState(client, 'p1')).toBe(poll);
+  });
+
+  it('returns undefined when not found', () => {
+    const store = new StateStore<{ polls: any[] }>({ polls: [] });
+    const client = { polls: { store } } as any;
+    expect(pollsFromState(client, 'p1')).toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -28,6 +28,20 @@ export async function createPollOption(
   return resp.json();
 }
 
+export function pollsFromState(
+  client: { polls?: { store?: StateStore<{ polls: any[] }> } },
+  pollId: string,
+): any | undefined {
+  const polls = client.polls?.store?.getLatestValue().polls;
+  if (!polls) return undefined;
+  for (const p of polls) {
+    if (!p) continue;
+    if (p.id === pollId) return p;
+    if ((p as any).poll?.id === pollId) return (p as any).poll;
+  }
+  return undefined;
+}
+
 export async function archive(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
 }

--- a/libs/stream-chat-shim/src/components/Message/MessageSimple.tsx
+++ b/libs/stream-chat-shim/src/components/Message/MessageSimple.tsx
@@ -36,6 +36,7 @@ import type { MessageContextValue } from '../../context/MessageContext';
 import { useMessageContext } from '../../context/MessageContext';
 
 import { useChatContext, useTranslationContext } from '../../context';
+import { pollsFromState } from '../../chatSDKShim';
 import { MessageEditedTimestamp } from './MessageEditedTimestamp';
 
 import type { MessageUIComponentProps } from './types';
@@ -145,8 +146,7 @@ const MessageSimpleWithContext = (props: MessageSimpleWithContextProps) => {
     },
   );
 
-  const poll = message.poll_id &&
-    /* TODO backend-wire-up: polls.fromState */ undefined;
+  const poll = message.poll_id && pollsFromState(client, message.poll_id);
 
   return (
     <>

--- a/libs/stream-chat-shim/src/components/Message/QuotedMessage.tsx
+++ b/libs/stream-chat-shim/src/components/Message/QuotedMessage.tsx
@@ -5,6 +5,7 @@ import type { TranslationLanguages } from 'chat-shim';
 import { Attachment as DefaultAttachment } from '../Attachment';
 import { Avatar as DefaultAvatar } from '../Avatar';
 import { Poll } from '../Poll';
+import { pollsFromState } from '../../chatSDKShim';
 import { useChatContext } from '../../context/ChatContext';
 import { useComponentContext } from '../../context/ComponentContext';
 import { useMessageContext } from '../../context/MessageContext';
@@ -33,9 +34,7 @@ export const QuotedMessage = ({ renderText: propsRenderText }: QuotedMessageProp
 
   const { quoted_message } = message;
 
-  const poll =
-    quoted_message?.poll_id &&
-    /* TODO backend-wire-up: polls.fromState */ undefined;
+  const poll = quoted_message?.poll_id && pollsFromState(client, quoted_message.poll_id);
   const quotedMessageDeleted =
     quoted_message?.deleted_at || quoted_message?.type === 'deleted';
 

--- a/libs/stream-chat-shim/src/components/MessageInput/QuotedMessagePreview.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/QuotedMessagePreview.tsx
@@ -4,6 +4,7 @@ import { CloseIcon } from './icons';
 import { Attachment as DefaultAttachment } from '../Attachment';
 import { Avatar as DefaultAvatar } from '../Avatar';
 import { Poll } from '../Poll';
+import { pollsFromState } from '../../chatSDKShim';
 
 import { useChatContext } from '../../context/ChatContext';
 import { useComponentContext } from '../../context/ComponentContext';
@@ -135,7 +136,7 @@ export const QuotedMessagePreview = ({
   );
 
   const poll = quotedMessage?.poll_id
-    ? /* TODO backend-wire-up: polls.fromState */ undefined
+    ? pollsFromState(client, quotedMessage.poll_id)
     : undefined;
 
   if (!quotedMessageText && !quotedMessageAttachments.length && !poll) return null;


### PR DESCRIPTION
## Summary
- implement `pollsFromState` in chatSDKShim
- wire polls.fromState usage in Message components
- add unit test for pollsFromState
- remove TODO comments

## Testing
- `npx jest` *(fails: Cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861b6bab9908326b840b146d95febba