### PR TITLE
✅ polls.unregisterSubscriptions

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -592,3 +592,9 @@ export async function pollsRegisterSubscriptions(
     headers,
   });
 }
+
+export function pollsUnregisterSubscriptions(client?: {
+  polls?: { unregisterSubscriptions?: () => void };
+}): void {
+  client?.polls?.unregisterSubscriptions?.();
+}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -555,7 +555,7 @@
     "stubName": "polls.unregisterSubscriptions",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement `pollsUnregisterSubscriptions` shim
- mark `polls.unregisterSubscriptions` as done in manifest

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c2c7e3508326b71f3e158252e333