### PR TITLE
✅ FE shim: implement query support

### DIFF
--- a/libs/stream-chat-shim/__tests__/query.test.ts
+++ b/libs/stream-chat-shim/__tests__/query.test.ts
@@ -1,0 +1,24 @@
+import { query } from '../src/chatSDKShim';
+
+describe('query', () => {
+  it('calls channel.query when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const res = await query({ cid: 'room1', query: fn } as any, { limit: 2 });
+    expect(fn).toHaveBeenCalledWith({ watch: true, watchers: { limit: 2 } });
+    expect(res).toBe('ok');
+  });
+
+  it('fetches members when not implemented', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve(['m1']) });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await query({ cid: 'room2' } as any, { offset: 1 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/rooms/room2/members/?offset=1',
+      { credentials: 'same-origin' },
+    );
+    expect(res).toEqual({ members: ['m1'] });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -201,6 +201,26 @@ export async function channelQuery(
   return { messages: [] };
 }
 
+export async function query(
+  channel: { cid: string; query?: (opts: any) => Promise<any> },
+  watchers: { limit?: number; offset?: number } = {},
+): Promise<any> {
+  if (typeof channel.query === "function") {
+    return channel.query({ watch: true, watchers });
+  }
+  const params = new URLSearchParams();
+  if (watchers.limit !== undefined) params.set('limit', String(watchers.limit));
+  if (watchers.offset !== undefined)
+    params.set('offset', String(watchers.offset));
+  const q = params.toString();
+  const resp = await fetch(
+    `/api/rooms/${encodeURIComponent(channel.cid)}/members/${q ? `?${q}` : ''}`,
+    { credentials: 'same-origin' },
+  );
+  const data = await resp.json();
+  return { members: data };
+}
+
 export async function channelSendMessage(
   channel: { cid: string },
   message: Record<string, any>,

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -17,6 +17,7 @@ import type {
   OwnUserResponse,
   StreamChat,
 } from 'chat-shim';
+import { query } from '../../../chatSDKShim';
 
 export type UseChatParams = {
   client: StreamChat;
@@ -134,7 +135,7 @@ return () => { /* noop */ };
       if (event && event.preventDefault) event.preventDefault();
 
       if (activeChannel && Object.keys(watchers).length) {
-        await /* TODO backend-wire-up: query */ Promise.resolve();
+        await query(activeChannel, watchers);
       }
 
       setChannel(activeChannel);

--- a/openapi/stub_map.json
+++ b/openapi/stub_map.json
@@ -60,7 +60,7 @@
   "pinMessage": "shim::pinMessage",
   "polls.fromState": "shim::polls.fromState",
   "polls.unregisterSubscriptions": "shim::polls.unregisterSubscriptions",
-  "query": "shim::query",
+  "query": "listRoomMembersCIDs",
   "queryAnswers": "shim::queryAnswers",
   "queryOptionVotes": "shim::queryOptionVotes",
   "queryReactions": "shim::queryReactions",


### PR DESCRIPTION
## Summary
- add query helper in `chatSDKShim`
- wire up `useChat` hook to call new query function
- test query logic
- map `query` stub token to `listRoomMembersCIDs`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c58e674c8326972a58a7dbae28db