### PR TITLE
Implement queryAnswers shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/queryAnswers.test.ts
+++ b/libs/stream-chat-shim/__tests__/queryAnswers.test.ts
@@ -1,0 +1,19 @@
+import { queryAnswers } from '../src/chatSDKShim';
+
+describe('queryAnswers', () => {
+  it('calls poll.queryAnswers when available', async () => {
+    const fn = jest.fn().mockResolvedValue({ next: 'n1', votes: ['a'] });
+    const res = await queryAnswers({ id: 'p1', queryAnswers: fn } as any, { limit: 5 });
+    expect(fn).toHaveBeenCalledWith({ limit: 5 });
+    expect(res).toEqual({ next: 'n1', votes: ['a'] });
+  });
+
+  it('fetches answers when not implemented', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve({ next: 'n2', votes: ['b'] }) });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await queryAnswers({ id: 'p2' } as any, { next: 'cur' });
+    expect(fetchMock).toHaveBeenCalledWith('/api/polls/p2/answers/?next=cur', { credentials: 'same-origin' });
+    expect(res).toEqual({ next: 'n2', votes: ['b'] });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -28,6 +28,26 @@ export async function createPollOption(
   return resp.json();
 }
 
+export async function queryAnswers(
+  poll: { id: string; queryAnswers?: (params?: any) => Promise<any> },
+  params: { limit?: number; next?: string } = {},
+): Promise<{ next?: string; votes: any[] }> {
+  if (typeof poll.queryAnswers === 'function') {
+    return poll.queryAnswers(params);
+  }
+  const searchParams = new URLSearchParams();
+  if (params.limit !== undefined) searchParams.set('limit', String(params.limit));
+  if (params.next !== undefined) searchParams.set('next', params.next);
+  const query = searchParams.toString();
+  const resp = await fetch(
+    `/api/polls/${encodeURIComponent(poll.id)}/answers/${
+      query ? `?${query}` : ''
+    }`,
+    { credentials: 'same-origin' },
+  );
+  return resp.json();
+}
+
 export function pollsFromState(
   client: { polls?: { store?: StateStore<{ polls: any[] }> } },
   pollId: string,

--- a/libs/stream-chat-shim/src/components/Poll/hooks/usePollAnswerPagination.ts
+++ b/libs/stream-chat-shim/src/components/Poll/hooks/usePollAnswerPagination.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../InfiniteScrollPaginator/hooks/useCursorPaginator';
 import { useCursorPaginator } from '../../InfiniteScrollPaginator/hooks/useCursorPaginator';
 import { usePollContext } from '../../../context';
+import { queryAnswers } from '../../../chatSDKShim';
 
 import { useStateStore } from '../../../store';
 import type { PollAnswer, PollAnswersQueryParams, PollVote } from 'chat-shim';
@@ -29,10 +30,10 @@ export const usePollAnswerPagination = ({
 
   const paginationFn = useCallback<PaginationFn<PollAnswer>>(
     async (next) => {
-      const { next: newNext, votes } = await (async () => {
-        /* TODO backend-wire-up: queryAnswers */
-        return { next: undefined, votes: [] as PollAnswer[] };
-      })();
+      const { next: newNext, votes } = await queryAnswers(poll, {
+        ...(paginationParams ?? {}),
+        next,
+      });
       return { items: votes, next: newNext };
     },
     [paginationParams, poll],


### PR DESCRIPTION
## Summary
- add `queryAnswers` helper in stream chat SDK shim
- hook poll answer pagination to backend via `queryAnswers`
- test the new helper

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ccd2cd2483269dc5e584b7fa897e