### PR TITLE
Implement queryOptionVotes shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -48,6 +48,35 @@ export async function queryAnswers(
   return resp.json();
 }
 
+export async function queryOptionVotes(
+  poll: { id: string; queryOptionVotes?: (params?: any) => Promise<any> },
+  params: {
+    filter: { option_id: string };
+    options?: { limit?: number; next?: string };
+    sort?: Record<string, number>;
+  },
+): Promise<{ next?: string; votes: any[] }> {
+  if (typeof poll.queryOptionVotes === 'function') {
+    return poll.queryOptionVotes(params);
+  }
+  const searchParams = new URLSearchParams();
+  if (params.filter?.option_id)
+    searchParams.set('option_id', params.filter.option_id);
+  if (params.options?.limit !== undefined)
+    searchParams.set('limit', String(params.options.limit));
+  if (params.options?.next !== undefined)
+    searchParams.set('next', params.options.next);
+  // ignoring sort except created_at
+  const query = searchParams.toString();
+  const resp = await fetch(
+    `/api/polls/${encodeURIComponent(poll.id)}/votes/${
+      query ? `?${query}` : ''
+    }`,
+    { credentials: 'same-origin' },
+  );
+  return resp.json();
+}
+
 export function pollsFromState(
   client: { polls?: { store?: StateStore<{ polls: any[] }> } },
   pollId: string,

--- a/libs/stream-chat-shim/src/components/Poll/hooks/usePollOptionVotesPagination.ts
+++ b/libs/stream-chat-shim/src/components/Poll/hooks/usePollOptionVotesPagination.ts
@@ -7,6 +7,7 @@ import type {
 import { useCursorPaginator } from '../../InfiniteScrollPaginator/hooks/useCursorPaginator';
 import { useStateStore } from '../../../store';
 import { usePollContext } from '../../../context';
+import { queryOptionVotes } from '../../../chatSDKShim';
 
 import type { PollOptionVotesQueryParams, PollVote } from 'chat-shim';
 
@@ -29,10 +30,13 @@ export const usePollOptionVotesPagination = ({
 
   const paginationFn = useCallback<PaginationFn<PollVote>>(
     async (next) => {
-      const { next: newNext, votes } = await (async () => {
-        /* TODO backend-wire-up: queryOptionVotes */
-        return { next: undefined, votes: [] as PollVote[] };
-      })();
+      const { next: newNext, votes } = await queryOptionVotes(poll, {
+        filter: paginationParams.filter,
+        options: !next
+          ? paginationParams?.options
+          : { ...(paginationParams?.options ?? {}), next },
+        sort: { created_at: -1, ...(paginationParams?.sort ?? {}) },
+      });
       return { items: votes, next: newNext };
     },
     [paginationParams, poll],


### PR DESCRIPTION
## Summary
- implement `queryOptionVotes` helper in chatSDKShim
- hook `usePollOptionVotesPagination` to the helper

## Testing
- `pnpm exec jest --runInBand` *(fails: Cannot find module 'react', '@testing-library/react', etc.)*
- `pnpm lint` *(fails: same module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861ebb40ed08326b67a4e9d73454c21