### PR TITLE
feat: implement queryReactions shim ✅

### DIFF
--- a/libs/stream-chat-shim/__tests__/queryReactions.test.ts
+++ b/libs/stream-chat-shim/__tests__/queryReactions.test.ts
@@ -1,0 +1,32 @@
+import { queryReactions } from '../src/chatSDKShim';
+
+describe('queryReactions', () => {
+  it('calls message.queryReactions when available', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValue({ next: 'n1', reactions: ['a'] });
+    const res = await queryReactions(
+      { id: 'm1', queryReactions: fn } as any,
+      { limit: 5 },
+    );
+    expect(fn).toHaveBeenCalledWith({ limit: 5 });
+    expect(res).toEqual({ next: 'n1', reactions: ['a'] });
+  });
+
+  it('fetches reactions when not implemented', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ next: 'n2', reactions: ['b'] }),
+    });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await queryReactions(
+      { id: 'm2' } as any,
+      { next: 'cur', reaction_type: 'like' },
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/messages/m2/reactions/?next=cur&reaction_type=like',
+      { credentials: 'same-origin' },
+    );
+    expect(res).toEqual({ next: 'n2', reactions: ['b'] });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -613,6 +613,40 @@ export async function pinMessage(messageId: string): Promise<any> {
   return resp.json();
 }
 
+export async function queryReactions(
+  message: { id: string; queryReactions?: (params?: any) => Promise<any> },
+  params: {
+    limit?: number;
+    next?: string;
+    reaction_type?: string;
+    sort?: Record<string, number>;
+  } = {},
+): Promise<{ next?: string; reactions: any[] }> {
+  if (typeof message.queryReactions === 'function') {
+    return message.queryReactions(params);
+  }
+  const searchParams = new URLSearchParams();
+  if (params.limit !== undefined) searchParams.set('limit', String(params.limit));
+  if (params.next !== undefined) searchParams.set('next', params.next);
+  if (params.reaction_type !== undefined)
+    searchParams.set('reaction_type', params.reaction_type);
+  if (params.sort) {
+    const [field, dir] = Object.entries(params.sort)[0] || [];
+    if (field) {
+      searchParams.set('sort', field);
+      searchParams.set('direction', String(dir));
+    }
+  }
+  const query = searchParams.toString();
+  const resp = await fetch(
+    `/api/messages/${encodeURIComponent(message.id)}/reactions/${
+      query ? `?${query}` : ''
+    }`,
+    { credentials: 'same-origin' },
+  );
+  return resp.json();
+}
+
 export async function getAppSettings(): Promise<any> {
   const resp = await fetch('/api/app-settings/', {
     credentials: 'same-origin',

--- a/libs/stream-chat-shim/src/components/Message/hooks/useReactionsFetcher.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useReactionsFetcher.ts
@@ -5,6 +5,7 @@ import type {
   ReactionSort,
   StreamChat,
 } from 'chat-shim';
+import { queryReactions } from '../../../chatSDKShim';
 import type { ReactionType } from '../../Reactions/types';
 
 export const MAX_MESSAGE_REACTIONS_TO_FETCH = 1000;
@@ -45,11 +46,15 @@ async function fetchMessageReactions(
   let hasNext = true;
 
   while (hasNext && reactions.length < MAX_MESSAGE_REACTIONS_TO_FETCH) {
-    const response = await Promise.resolve({
-      /* TODO backend-wire-up: queryReactions */
-      next: undefined,
-      reactions: [],
-    });
+    const response = await queryReactions(
+      { id: messageId } as any,
+      {
+        limit,
+        next,
+        reaction_type: reactionType,
+        sort,
+      },
+    );
 
     reactions.push(...response.reactions);
     next = response.next;


### PR DESCRIPTION
## Summary
- implement queryReactions helper in chatSDKShim
- wire useReactionsFetcher to call queryReactions
- test the new shim
- remove TODO comment

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628373804c832687ea05485f1df8c9