### PR TITLE
reminders.clearTimers shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.clearTimers.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.clearTimers.test.ts
@@ -1,0 +1,13 @@
+import { remindersClearTimers } from '../src/chatSDKShim';
+
+describe('remindersClearTimers', () => {
+  it('calls client.reminders.clearTimers when available', () => {
+    const fn = jest.fn();
+    remindersClearTimers({ reminders: { clearTimers: fn } } as any);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('does nothing when not implemented', () => {
+    expect(() => remindersClearTimers({} as any)).not.toThrow();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -701,3 +701,9 @@ export function pollsUnregisterSubscriptions(client?: {
 }): void {
   client?.polls?.unregisterSubscriptions?.();
 }
+
+export function remindersClearTimers(client?: {
+  reminders?: { clearTimers?: () => void };
+}): void {
+  client?.reminders?.clearTimers?.();
+}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -600,7 +600,7 @@
     "stubName": "reminders.clearTimers",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add remindersClearTimers wrapper
- test clearing reminders timers
- mark reminders.clearTimers stub as wired

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm exec jest libs/stream-chat-shim/__tests__/reminders.clearTimers.test.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862866b66bc8326ad2971c658bac6a4