### PR TITLE
reminders.createReminder shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -530,6 +530,23 @@ export async function clientRemindersCreateReminder(
   return resp.json();
 }
 
+export async function remindersCreateReminder(
+  reminders: { createReminder?: (text: string, remind_at: string) => Promise<any> } | undefined,
+  text: string,
+  remind_at: string,
+): Promise<any> {
+  if (reminders?.createReminder) {
+    return reminders.createReminder(text, remind_at);
+  }
+  const resp = await fetch('/api/reminders/', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, remind_at }),
+  });
+  return resp.json();
+}
+
 export async function clientRemindersDeleteReminder(
   client: { reminders?: { deleteReminder?: (id: string) => Promise<any> } },
   reminderId: string,

--- a/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
@@ -7,6 +7,7 @@ import { useMessageReminder } from '../Message';
 import { useMessageComposer } from '../MessageInput';
 import {
   useComponentContext,
+  useChatContext,
   useMessageContext,
   useTranslationContext,
 } from '../../context';
@@ -52,6 +53,7 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
   const { customMessageActions, message, threadList } =
     useMessageContext('MessageActionsBox');
   const { t } = useTranslationContext('MessageActionsBox');
+  const { client } = useChatContext('MessageActionsBox');
   const messageComposer = useMessageComposer();
   const reminder = useMessageReminder(message.id);
 
@@ -169,9 +171,12 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
             className={buttonClassName}
             onClick={() => {
               if (reminder) {
-                /* TODO backend-wire-up: reminders.deleteReminder */
+                client.reminders.deleteReminder(reminder.id);
               } else {
-                /* TODO backend-wire-up: reminders.createReminder */
+                client.reminders.createReminder(
+                  message.text || '',
+                  new Date().toISOString(),
+                );
               }
             }}
             role='option'


### PR DESCRIPTION
## Summary
- implement `remindersCreateReminder` API helper in chatSDKShim
- wire Save for later action to create/delete reminders

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862897967f88326946e9e405ee04f61