### PR TITLE
feat(reminders.deleteReminder): add shim ✅

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.deleteReminder.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.deleteReminder.test.ts
@@ -1,0 +1,23 @@
+import { remindersDeleteReminder } from '../src/chatSDKShim';
+
+describe('remindersDeleteReminder', () => {
+  it('calls reminders.deleteReminder when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const reminders = { deleteReminder: fn } as any;
+    const res = await remindersDeleteReminder(reminders, '42');
+    expect(fn).toHaveBeenCalledWith('42');
+    expect(res).toBe('ok');
+  });
+
+  it('falls back to HTTP request when not implemented', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await remindersDeleteReminder(undefined, '42');
+    expect(fetchMock).toHaveBeenCalledWith('/api/reminders/42/', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    });
+    expect(res).toBe('ok');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -564,6 +564,20 @@ export async function clientRemindersDeleteReminder(
   return resp.json();
 }
 
+export async function remindersDeleteReminder(
+  reminders: { deleteReminder?: (id: string) => Promise<any> } | undefined,
+  reminderId: string,
+): Promise<any> {
+  if (reminders?.deleteReminder) {
+    return reminders.deleteReminder(reminderId);
+  }
+  const resp = await fetch(`/api/reminders/${encodeURIComponent(reminderId)}/`, {
+    method: "DELETE",
+    credentials: "same-origin",
+  });
+  return resp.json();
+}
+
 export function clientThreadsActivate(client: {
   threads?: { activate?: () => void };
 }): void {


### PR DESCRIPTION
## Summary
- implement `remindersDeleteReminder` helper in `chatSDKShim`
- add unit test covering client and HTTP fallback

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm build` *(fails: command not found)*
- `pnpm -F frontend tsc --noEmit` *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68628f2cacc08326a920130cb203edf3