### PR TITLE
Implement reminders.initTimers shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -733,6 +733,12 @@ export function pollsUnregisterSubscriptions(client?: {
   client?.polls?.unregisterSubscriptions?.();
 }
 
+export function remindersInitTimers(client?: {
+  reminders?: { initTimers?: () => void };
+}): void {
+  client?.reminders?.initTimers?.();
+}
+
 export function remindersClearTimers(client?: {
   reminders?: { clearTimers?: () => void };
 }): void {


### PR DESCRIPTION
## Summary
- add reminders.initTimers helper
- wire up shim

## Testing
- `npx jest libs/chat-shim/__tests__/localClient.test.ts` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_6862938b5fac8326bbfda0cd014f0fbe