### PR TITLE
feat ✅ reminders.registerSubscriptions

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.registerSubscriptions.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.registerSubscriptions.test.ts
@@ -1,0 +1,15 @@
+import { remindersRegisterSubscriptions } from '../src/chatSDKShim';
+
+describe('remindersRegisterSubscriptions', () => {
+  it('POSTs to backend endpoint', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    await remindersRegisterSubscriptions({ jwt: 'tok' });
+    expect(fetchMock).toHaveBeenCalledWith('/api/register-subscriptions/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Authorization: 'Bearer tok' },
+    });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -727,6 +727,18 @@ export async function pollsRegisterSubscriptions(
   });
 }
 
+export async function remindersRegisterSubscriptions(
+  client?: { jwt?: string },
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (client?.jwt) headers['Authorization'] = `Bearer ${client.jwt}`;
+  await fetch('/api/register-subscriptions/', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers,
+  });
+}
+
 export function pollsUnregisterSubscriptions(client?: {
   polls?: { unregisterSubscriptions?: () => void };
 }): void {

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -150,7 +150,7 @@
     "stubName": "reminders.registerSubscriptions",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- wire up reminders.registerSubscriptions shim
- mark reminders.registerSubscriptions as implemented in wireup manifest
- add unit test for remindersRegisterSubscriptions

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm lint:fix` *(fails: Command "lint:fix" not found)*
- `pnpm test` *(fails: turbo_json_parse_error)*
- `npx jest` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686298cd1f8c8326b414186b356ee862