### PR TITLE
✅ shim reminders.scheduledOffsetsMs

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.scheduledOffsetsMs.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.scheduledOffsetsMs.test.ts
@@ -1,0 +1,14 @@
+import { remindersScheduledOffsetsMs } from '../src/chatSDKShim';
+
+describe('remindersScheduledOffsetsMs', () => {
+  it('returns client.reminders.scheduledOffsetsMs when available', () => {
+    const client = { reminders: { scheduledOffsetsMs: [1, 2, 3] } } as any;
+    expect(remindersScheduledOffsetsMs(client)).toEqual([1, 2, 3]);
+  });
+
+  it('falls back to default values when not implemented', () => {
+    const res = remindersScheduledOffsetsMs();
+    expect(Array.isArray(res)).toBe(true);
+    expect(res.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -756,3 +756,16 @@ export function remindersClearTimers(client?: {
 }): void {
   client?.reminders?.clearTimers?.();
 }
+
+export function remindersScheduledOffsetsMs(client?: {
+  reminders?: { scheduledOffsetsMs?: number[] };
+}): number[] {
+  return (
+    client?.reminders?.scheduledOffsetsMs ?? [
+      5 * 60 * 1000,
+      30 * 60 * 1000,
+      60 * 60 * 1000,
+      24 * 60 * 60 * 1000,
+    ]
+  );
+}

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useChatContext, useMessageContext, useTranslationContext } from '../../context';
+import { remindersScheduledOffsetsMs } from '../../chatSDKShim';
 import { ButtonWithSubmenu } from '../Dialog';
 import type { ComponentProps } from 'react';
 
@@ -25,8 +26,7 @@ export const RemindMeSubmenu = () => {
   const { t } = useTranslationContext();
   const { client } = useChatContext();
   const { message } = useMessageContext();
-  const scheduledOffsetsMs: number[] = [];
-  /* TODO backend-wire-up: reminders.scheduledOffsetsMs */
+  const scheduledOffsetsMs = remindersScheduledOffsetsMs(client);
   return (
     <div
       aria-label={t('aria/Remind Me Options')}


### PR DESCRIPTION
## Summary
- implement `remindersScheduledOffsetsMs` shim helper
- use it in `RemindMeSubmenu`
- add unit test

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629c0c9adc8326a9308a9b33c8a142