### PR TITLE
reminders.unregisterSubscriptions ✅

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.unregisterSubscriptions.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.unregisterSubscriptions.test.ts
@@ -1,0 +1,13 @@
+import { remindersUnregisterSubscriptions } from '../src/chatSDKShim';
+
+describe('remindersUnregisterSubscriptions', () => {
+  it('calls client.reminders.unregisterSubscriptions when available', () => {
+    const fn = jest.fn();
+    remindersUnregisterSubscriptions({ reminders: { unregisterSubscriptions: fn } } as any);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('does nothing when not implemented', () => {
+    expect(() => remindersUnregisterSubscriptions({} as any)).not.toThrow();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -745,6 +745,12 @@ export function pollsUnregisterSubscriptions(client?: {
   client?.polls?.unregisterSubscriptions?.();
 }
 
+export function remindersUnregisterSubscriptions(client?: {
+  reminders?: { unregisterSubscriptions?: () => void };
+}): void {
+  client?.reminders?.unregisterSubscriptions?.();
+}
+
 export function remindersInitTimers(client?: {
   reminders?: { initTimers?: () => void };
 }): void {


### PR DESCRIPTION
## Summary
- add remindersUnregisterSubscriptions helper in chatSDKShim
- test remindersUnregisterSubscriptions

## Testing
- `pnpm exec jest` *(fails: Cannot find module '@testing-library/react', react issues)*

------
https://chatgpt.com/codex/tasks/task_e_6862bb508a008326b15fad47ee406b15