### PR TITLE
feat(reminders.upsertReminder): wire shim ✅

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
@@ -1,0 +1,24 @@
+import { remindersUpsertReminder } from '../src/chatSDKShim';
+
+describe('remindersUpsertReminder', () => {
+  it('calls reminders.upsertReminder when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const res = await remindersUpsertReminder({ upsertReminder: fn } as any, '42', '2024-01-01T00:00:00Z');
+    expect(fn).toHaveBeenCalledWith('42', '2024-01-01T00:00:00Z');
+    expect(res).toBe('ok');
+  });
+
+  it('falls back to HTTP request when not implemented', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await remindersUpsertReminder(undefined, '42', '2024-01-01T00:00:00Z');
+    expect(fetchMock).toHaveBeenCalledWith('/api/reminders/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messageId: '42', remind_at: '2024-01-01T00:00:00Z' }),
+    });
+    expect(res).toBe('ok');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -775,3 +775,25 @@ export function remindersScheduledOffsetsMs(client?: {
     ]
   );
 }
+
+export async function remindersUpsertReminder(
+  reminders: {
+    upsertReminder?: (
+      messageId: string,
+      remind_at: string,
+    ) => Promise<any>;
+  } | undefined,
+  messageId: string,
+  remind_at: string,
+): Promise<any> {
+  if (reminders?.upsertReminder) {
+    return reminders.upsertReminder(messageId, remind_at);
+  }
+  const resp = await fetch('/api/reminders/', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messageId, remind_at }),
+  });
+  return resp.json();
+}

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useChatContext, useMessageContext, useTranslationContext } from '../../context';
-import { remindersScheduledOffsetsMs } from '../../chatSDKShim';
+import {
+  remindersScheduledOffsetsMs,
+  remindersUpsertReminder,
+} from '../../chatSDKShim';
 import { ButtonWithSubmenu } from '../Dialog';
 import type { ComponentProps } from 'react';
 
@@ -38,7 +41,11 @@ export const RemindMeSubmenu = () => {
           className='str-chat__message-actions-list-item-button'
           key={`reminder-offset-option--${offsetMs}`}
           onClick={() => {
-            /* TODO backend-wire-up: reminders.upsertReminder */
+            remindersUpsertReminder(
+              client.reminders,
+              message.id,
+              new Date(Date.now() + offsetMs).toISOString(),
+            );
           }}
         >
           {t('duration/Remind Me', { milliseconds: offsetMs })}


### PR DESCRIPTION
## Summary
- implement `remindersUpsertReminder` helper
- hook up RemindMeSubmenu to call `remindersUpsertReminder`
- add tests

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf274fe88326afd277d5a08e1d00