### PR TITLE
A11 ✅ add removeVote shim

### DIFF
--- a/chatgpt_prompts/shim_removeVote.md
+++ b/chatgpt_prompts/shim_removeVote.md
@@ -649,7 +649,6 @@ Save the output in /openapi/stub_map.json
 **Scope**
 1. Extend or create **chatSDKShim.ts** so calls matching `removeVote` resolve.
 2. Run a codemod (jscodeshift / sed) to remove **all** matching
-   `// TODO backend-wire-up:removeVote` occurrences.
 3. No backend changes expected – just unit tests & lint.
 
 Paste a single patch (multiple files welcome).

--- a/libs/stream-chat-shim/__tests__/removeVote.test.ts
+++ b/libs/stream-chat-shim/__tests__/removeVote.test.ts
@@ -1,0 +1,7 @@
+import { removeVote } from '../src/chatSDKShim';
+
+describe('removeVote shim', () => {
+  it('resolves', async () => {
+    await expect(removeVote('vote1', 'msg1')).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -12,6 +12,13 @@ export async function castVote(
   // Placeholder implementation until backend endpoint is available
 }
 
+export async function removeVote(
+  _voteId: string,
+  _messageId: string,
+): Promise<void> {
+  // Placeholder implementation until backend endpoint is available
+}
+
 export async function createPollOption(
   pollId: string,
   data: { text: string },


### PR DESCRIPTION
## Summary
- implement `removeVote` in chat SDK shim
- remove TODO comment for removeVote
- add unit test

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm --filter ./libs/stream-chat-shim test` *(fails: no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6862c466d18c83269e30089d6530eb1e