### PR TITLE
shim::sendAction ✅

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -651,6 +651,22 @@ export async function pinMessage(messageId: string): Promise<any> {
   return resp.json();
 }
 
+export async function sendAction(
+  messageId: string,
+  action: Record<string, unknown>,
+): Promise<any> {
+  const resp = await fetch(
+    `/api/messages/${encodeURIComponent(messageId)}/actions/`,
+    {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(action),
+    },
+  );
+  return resp.json();
+}
+
 export async function queryReactions(
   message: { id: string; queryReactions?: (params?: any) => Promise<any> },
   params: {

--- a/libs/stream-chat-shim/src/components/Message/hooks/useActionHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useActionHandler.ts
@@ -1,5 +1,6 @@
 import { useChannelActionContext } from '../../../context/ChannelActionContext';
 import { useChannelStateContext } from '../../../context/ChannelStateContext';
+import { sendAction } from '../../../chatSDKShim';
 
 import type React from 'react';
 import type { LocalMessage } from 'chat-shim';
@@ -38,9 +39,7 @@ export function useActionHandler(message?: LocalMessage): ActionHandlerReturnTyp
     }
 
     if (messageID) {
-      const data = await Promise.resolve(
-        /* TODO backend-wire-up: sendAction */ undefined,
-      );
+      const data = await sendAction(messageID, formData);
 
       if (data?.message) {
         updateMessage(data.message);

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -671,8 +671,8 @@
     "operationId": "shim::sendAction",
     "stubName": "sendAction",
     "ticketType": "shim",
-    "todoCount": 1,
-    "status": "missing"
+    "todoCount": 0,
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement sendAction in chatSDKShim
- wire useActionHandler to call sendAction
- mark shim::sendAction as complete in wireup_manifest

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cdb972b88326881dce99b88db30d