### PR TITLE
✅ A? sendReaction backend wire

### DIFF
--- a/libs/stream-chat-shim/__tests__/sendReaction.test.ts
+++ b/libs/stream-chat-shim/__tests__/sendReaction.test.ts
@@ -1,0 +1,24 @@
+import { sendReaction } from '../src/chatSDKShim';
+
+describe('sendReaction', () => {
+  it('calls channel.sendReaction when available', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const res = await sendReaction({ sendReaction: fn } as any, 'm1', 'like');
+    expect(fn).toHaveBeenCalledWith('m1', 'like');
+    expect(res).toBe('ok');
+  });
+
+  it('POSTs to /api/messages/ when not implemented', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await sendReaction(undefined as any, 'm1', 'like');
+    expect(fetchMock).toHaveBeenCalledWith('/api/messages/m1/reactions/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'like' }),
+    });
+    expect(res).toBe('ok');
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -671,6 +671,22 @@ export async function pinMessage(messageId: string): Promise<any> {
   return resp.json();
 }
 
+export async function sendReaction(
+  messageId: string,
+  type: string,
+): Promise<any> {
+  const resp = await fetch(
+    `/api/messages/${encodeURIComponent(messageId)}/reactions/`,
+    {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type }),
+    },
+  );
+  return resp.json();
+}
+
 export async function sendAction(
   messageId: string,
   action: Record<string, unknown>,

--- a/libs/stream-chat-shim/src/components/Message/hooks/useReactionHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useReactionHandler.ts
@@ -8,6 +8,7 @@ import { useChannelStateContext } from '../../../context/ChannelStateContext';
 import { useChatContext } from '../../../context/ChatContext';
 
 import type { LocalMessage, Reaction, ReactionResponse } from 'chat-shim';
+import { sendReaction, deleteReaction } from '../../../chatSDKShim';
 
 export const reactionHandlerWarning = `Reaction handler was called, but it is missing one of its required arguments.
 Make sure the ChannelAction and ChannelState contexts are properly set and the hook is initialized with a valid message.`;
@@ -88,12 +89,8 @@ export const useReactionHandler = (message?: LocalMessage) => {
       thread?.upsertReplyLocally({ message: tempMessage });
 
       const messageResponse = add
-        ? await Promise.resolve(
-            /* TODO backend-wire-up: sendReaction */ { message: tempMessage },
-          )
-        : await Promise.resolve(
-            { message: tempMessage },
-          );
+        ? await sendReaction(id, type)
+        : await deleteReaction(id, type);
 
       // seems useless as we're expecting WS event to come in and replace this anyway
       updateMessage(messageResponse.message);


### PR DESCRIPTION
## Summary
- wire up sendReaction in chat SDK shim
- call sendReaction/deleteReaction in reaction hook
- add unit test for sendReaction

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e23bd38c83269ea48504e23491e4