### PR TITLE
wireup:setUserAgent ☐→✅

### DIFF
--- a/libs/stream-chat-shim/__tests__/setUserAgent.test.ts
+++ b/libs/stream-chat-shim/__tests__/setUserAgent.test.ts
@@ -1,0 +1,19 @@
+import { setUserAgent } from '../src/chatSDKShim';
+
+describe('setUserAgent', () => {
+  it('POSTs user agent to backend', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ status: 'ok' }) });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const res = await setUserAgent('ua/1');
+    expect(fetchMock).toHaveBeenCalledWith('/api/core-user-agent/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_agent: 'ua/1' }),
+    });
+    expect(res).toEqual({ status: 'ok' });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -752,6 +752,16 @@ export async function getUserAgent(): Promise<string> {
   return data.user_agent;
 }
 
+export async function setUserAgent(userAgent: string): Promise<{ status: string }> {
+  const resp = await fetch('/api/core-user-agent/', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_agent: userAgent }),
+  });
+  return resp.json();
+}
+
 export async function getDraft(roomUuid: string): Promise<{ text?: string }> {
   const resp = await fetch(
     `/api/rooms/${encodeURIComponent(roomUuid)}/draft/`,

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -159,7 +159,7 @@
     "stubName": "setUserAgent",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement setUserAgent API call in chatSDKShim
- add unit test for setUserAgent
- mark setUserAgent as ok in wireup_manifest

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `npx jest` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8537f8483268a1b953ee7d3a6a0