### PR TITLE
feat: implement stopAIResponse shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -890,3 +890,9 @@ export async function search(
   });
   return resp.json();
 }
+
+export async function stopAIResponse(channel?: {
+  stopAIResponse?: () => Promise<void>;
+}): Promise<void> {
+  await channel?.stopAIResponse?.();
+}

--- a/libs/stream-chat-shim/src/components/MessageInput/MessageInputFlat.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/MessageInputFlat.tsx
@@ -30,6 +30,7 @@ import { useComponentContext } from '../../context/ComponentContext';
 import { useAttachmentManagerState } from './hooks/useAttachmentManagerState';
 import { useMessageContext } from '../../context';
 import { WithDragAndDropUpload } from './WithDragAndDropUpload';
+import { stopAIResponse } from '../../chatSDKShim';
 
 export const MessageInputFlat = () => {
   const { message } = useMessageContext();
@@ -61,7 +62,7 @@ export const MessageInputFlat = () => {
   const { aiState } = useAIState(channel);
 
   const stopGenerating = useCallback(() => {
-    /* TODO backend-wire-up: stopAIResponse */
+    stopAIResponse(channel);
   }, [channel]);
 
   const [


### PR DESCRIPTION
## Summary
- implement `stopAIResponse` helper in chatSDKShim
- hook MessageInputFlat's stop generation button up to the shim

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f0b82a808326ab7e3a9063dab153