### PR TITLE
✅ Shim stopTyping

### DIFF
--- a/libs/stream-chat-shim/__tests__/stopTyping.test.ts
+++ b/libs/stream-chat-shim/__tests__/stopTyping.test.ts
@@ -1,0 +1,13 @@
+import { stopTyping } from '../src/chatSDKShim';
+import { stopTyping as impl } from 'chat-shim/typing';
+
+jest.mock('chat-shim/typing', () => ({
+  stopTyping: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('stopTyping', () => {
+  it('delegates to chat-shim implementation', async () => {
+    await stopTyping();
+    expect(impl).toHaveBeenCalled();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,5 +1,6 @@
 import { noopStore } from 'chat-shim/noopStore';
 import type { StateStore } from 'chat-shim';
+import { stopTyping as stopTypingImpl } from 'chat-shim/typing';
 
 export async function addAnswer(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
@@ -895,4 +896,8 @@ export async function stopAIResponse(channel?: {
   stopAIResponse?: () => Promise<void>;
 }): Promise<void> {
   await channel?.stopAIResponse?.();
+}
+
+export async function stopTyping(): Promise<void> {
+  await stopTypingImpl();
 }

--- a/libs/stream-chat-shim/src/components/MessageInput/hooks/useSubmitHandler.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/hooks/useSubmitHandler.ts
@@ -77,7 +77,6 @@ export const useSubmitHandler = (props: MessageInputProps) => {
             await sendMessage({ localMessage, message, options: sendOptions });
           }
           // if (messageComposer.config.text.publishTypingEvents)
-          //   /* TODO backend-wire-up: stopTyping */
           if (messageComposer.config.text.publishTypingEvents) {
             // safe no-op today; real SDK call tomorrow
             await stopTyping();


### PR DESCRIPTION
## Summary
- implement `stopTyping` in the chat SDK shim
- remove obsolete backend TODO
- add tests for the new shim helper

## Testing
- `pnpm test` *(fails: turbo_json_parse_error)*
- `npx jest libs/stream-chat-shim/__tests__/stopTyping.test.ts --runTestsByPath` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862f379c8a88326a378ef51b683895e