### PR TITLE
✅ A6a threads.registerSubscriptions

### DIFF
--- a/libs/stream-chat-shim/__tests__/threads.registerSubscriptions.test.ts
+++ b/libs/stream-chat-shim/__tests__/threads.registerSubscriptions.test.ts
@@ -1,0 +1,15 @@
+import { threadsRegisterSubscriptions } from '../src/chatSDKShim';
+
+describe('threadsRegisterSubscriptions', () => {
+  it('POSTs to backend endpoint', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    await threadsRegisterSubscriptions({ jwt: 'tok' });
+    expect(fetchMock).toHaveBeenCalledWith('/api/register-subscriptions/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Authorization: 'Bearer tok' },
+    });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -809,6 +809,18 @@ export async function remindersRegisterSubscriptions(
   });
 }
 
+export async function threadsRegisterSubscriptions(
+  client?: { jwt?: string },
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (client?.jwt) headers['Authorization'] = `Bearer ${client.jwt}`;
+  await fetch('/api/register-subscriptions/', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers,
+  });
+}
+
 export function pollsUnregisterSubscriptions(client?: {
   polls?: { unregisterSubscriptions?: () => void };
 }): void {


### PR DESCRIPTION
## Summary
- add `threadsRegisterSubscriptions` helper to Chat SDK shim
- test that it POSTs `/api/register-subscriptions/`

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe82faa883269324df99a737fd4f