### PR TITLE
feat: threads.unregisterSubscriptions helper ✅

### DIFF
--- a/libs/stream-chat-shim/__tests__/threads.unregisterSubscriptions.test.ts
+++ b/libs/stream-chat-shim/__tests__/threads.unregisterSubscriptions.test.ts
@@ -1,0 +1,13 @@
+import { threadsUnregisterSubscriptions } from '../src/chatSDKShim';
+
+describe('threadsUnregisterSubscriptions', () => {
+  it('calls client.threads.unregisterSubscriptions when available', () => {
+    const fn = jest.fn();
+    threadsUnregisterSubscriptions({ threads: { unregisterSubscriptions: fn } } as any);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('does nothing when not implemented', () => {
+    expect(() => threadsUnregisterSubscriptions({} as any)).not.toThrow();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -821,6 +821,12 @@ export async function threadsRegisterSubscriptions(
   });
 }
 
+export function threadsUnregisterSubscriptions(client?: {
+  threads?: { unregisterSubscriptions?: () => void };
+}): void {
+  client?.threads?.unregisterSubscriptions?.();
+}
+
 export function pollsUnregisterSubscriptions(client?: {
   polls?: { unregisterSubscriptions?: () => void };
 }): void {

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -708,7 +708,7 @@
     "stubName": "threads.unregisterSubscriptions",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add `threadsUnregisterSubscriptions` shim
- test helper logic
- mark wireup entry as done

## Testing
- `npx jest libs/stream-chat-shim/__tests__/threads.unregisterSubscriptions.test.ts` *(fails: cannot find module 'chat-shim/…')*

------
https://chatgpt.com/codex/tasks/task_e_686302426f948326b5cb76ded7817c1d