### PR TITLE
frontend ✅ add truncate helper

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -115,6 +115,14 @@ export async function unarchive(channel: { cid: string }): Promise<void> {
   });
 }
 
+export async function truncate(channel: { cid: string }): Promise<void> {
+  await fetch(`/api/rooms/${encodeURIComponent(channel.cid)}/truncate/`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 export function channelCountUnread(
   channel: { countUnread: () => number },
   _lastRead?: Date,


### PR DESCRIPTION
## Summary
- add truncate helper in chatSDK shim

## Testing
- `pnpm --filter frontend test` *(fails: MODULE_NOT_FOUND)*
- `pnpm --filter frontend build` *(fails: Can't resolve 'ws')*

------
https://chatgpt.com/codex/tasks/task_e_686304c716b08326afea4ce24698bdb9