### PR TITLE
feat(unmuteUser): implement shim

### DIFF
--- a/chatgpt_prompts/api_unmuteUser.md
+++ b/chatgpt_prompts/api_unmuteUser.md
@@ -651,7 +651,6 @@ Save the output in /openapi/stub_map.json
 **Scope**
 1. Implement backend endpoint (DRF view/serializer) & WS echo if needed.
 2. 🔧 *Front-end* – delete or replace every
-   `// TODO backend-wire-up:unmuteUser` in `libs/stream-chat-shim/src/`.
 3. Regenerate OpenAPI & flip `"status":"ok"` in the manifest.
 4. Ensure pytest + jest + lints pass.
 

--- a/chatgpt_prompts/shim_unmuteUser.md
+++ b/chatgpt_prompts/shim_unmuteUser.md
@@ -649,7 +649,6 @@ Save the output in /openapi/stub_map.json
 **Scope**
 1. Extend or create **chatSDKShim.ts** so calls matching `unmuteUser` resolve.
 2. Run a codemod (jscodeshift / sed) to remove **all** matching
-   `// TODO backend-wire-up:unmuteUser` occurrences.
 3. No backend changes expected – just unit tests & lint.
 
 Paste a single patch (multiple files welcome).

--- a/libs/stream-chat-shim/__tests__/unmuteUser.test.ts
+++ b/libs/stream-chat-shim/__tests__/unmuteUser.test.ts
@@ -1,0 +1,14 @@
+import { unmuteUser } from '../src/chatSDKShim';
+
+describe('unmuteUser', () => {
+  it('posts to backend endpoint', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    await unmuteUser('u2');
+    expect(fetchMock).toHaveBeenCalledWith('/api/unmute/u2/', {
+      method: 'POST',
+      credentials: 'same-origin',
+    });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -793,6 +793,13 @@ export async function muteUser(username: string): Promise<void> {
   });
 }
 
+export async function unmuteUser(username: string): Promise<void> {
+  await fetch(`/api/unmute/${encodeURIComponent(username)}/`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
+}
+
 export async function pollsRegisterSubscriptions(
   client?: { jwt?: string },
 ): Promise<void> {


### PR DESCRIPTION
## Summary
- support `/api/unmute/:username/` in chatSDKShim
- test unmuteUser posts correctly
- clean up TODO markers for unmuteUser

## Testing
- `npx jest libs/stream-chat-shim/__tests__/unmuteUser.test.ts` *(fails: Need to install jest)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863078ffeec8326a162c836ad1ed545