### PR TITLE
wireup unpinMessage

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -680,6 +680,13 @@ export async function pinMessage(messageId: string): Promise<any> {
   return resp.json();
 }
 
+export async function unpinMessage(messageId: string): Promise<void> {
+  await fetch(`/api/messages/${encodeURIComponent(messageId)}/unpin/`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+  });
+}
+
 export async function sendReaction(
   messageId: string,
   type: string,

--- a/libs/stream-chat-shim/src/components/Message/hooks/usePinHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/usePinHandler.ts
@@ -1,4 +1,5 @@
 import { defaultPinPermissions, validateAndGetMessage } from '../utils';
+import { unpinMessage } from '../../../chatSDKShim';
 
 import { useChannelActionContext } from '../../../context/ChannelActionContext';
 import { useChannelStateContext } from '../../../context/ChannelStateContext';
@@ -93,9 +94,7 @@ export const usePinHandler = (
 
         updateMessage(optimisticMessage);
 
-        await Promise.resolve(
-          /* TODO backend-wire-up: unpinMessage */ undefined,
-        );
+        await unpinMessage(message.id);
       } catch (e) {
         const errorMessage =
           getErrorNotification && validateAndGetMessage(getErrorNotification, [message]);


### PR DESCRIPTION
## Summary
- implement `unpinMessage` helper in chatSDKShim
- call `unpinMessage` from `usePinHandler`

## Testing
- `pnpm lint:fix` *(fails: Command "lint:fix" not found)*
- `pnpm --filter frontend test` *(fails: vitest not found)*
- `pnpm --filter frontend build` *(fails: build errors)*
- `black --check .` *(fails: would reformat many files)*
- `isort --check-only .` *(fails: imports incorrectly sorted)*

------
https://chatgpt.com/codex/tasks/task_e_686311207f688326964a64f492507f7e