### PR TITLE
feat(createMessage): wire up POST /api/rooms/{cid}/messages/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -106,15 +106,15 @@ class RoomMessageListCreateView(RoomFromCIDMixin, generics.ListCreateAPIView):
         try:
             channel_layer = get_channel_layer()
             cid = f"messaging:{room.uuid}"
+            message_payload = MessageSerializer(serializer.instance).data
             async_to_sync(channel_layer.group_send)(
-                cid.replace(":", "_"),
+                f"channel_{room.uuid}",
                 {
                     "type": "chat.message",
                     "payload": {
                         "type": "message.new",
                         "cid": cid,
-                        "text": serializer.instance.body,
-                        "user": serializer.instance.sent_by,
+                        "message": message_payload,
                     },
                 },
             )

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -5,9 +5,9 @@ from .models import (Flag, Message, Notification, Pin, Poll, PollOption,
 
 
 class MessageSerializer(serializers.ModelSerializer):
-    """Expose `body` as read-only and accept `text` on input."""
+    """Expose `body` via the `text` field while keeping the column read-only."""
 
-    text = serializers.CharField(write_only=True, required=False)
+    text = serializers.CharField(source="body", allow_blank=True)
 
     class Meta:
         model = Message
@@ -28,13 +28,6 @@ class MessageSerializer(serializers.ModelSerializer):
             "updated_at",
             "deleted_at",
         ]
-
-    def create(self, validated_data):
-        # Map the incoming text field to the body column
-        if "text" in validated_data:
-            validated_data["body"] = validated_data.pop("text")
-
-        return super().create(validated_data)
 
 
 class RoomSerializer(serializers.ModelSerializer):

--- a/backend/chat/tests/test_create_message.py
+++ b/backend/chat/tests/test_create_message.py
@@ -1,8 +1,11 @@
-from django.urls import reverse
-from rest_framework.test import APITestCase
+from unittest.mock import AsyncMock, patch
+
+from chat.models import Room
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from chat.models import Room
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
 
 @override_settings(ROOT_URLCONF="chat.urls")
 class CreateMessageAPITests(APITestCase):
@@ -17,6 +20,7 @@ class CreateMessageAPITests(APITestCase):
         resp = self.client.post(url, {"text": "hi"}, format="json")
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["body"], "hi")
+        self.assertEqual(resp.data["text"], "hi")
 
     def test_missing_body(self):
         self.client.force_authenticate(self.user)
@@ -28,3 +32,23 @@ class CreateMessageAPITests(APITestCase):
         url = reverse("room-messages", kwargs={"room_uuid": self.room.uuid})
         resp = self.client.post(url, {"text": "hi"}, format="json")
         self.assertEqual(resp.status_code, 403)
+
+    @patch("chat.api_views.get_channel_layer")
+    def test_broadcasts_message_event(self, mock_get_channel_layer):
+        self.client.force_authenticate(self.user)
+        mock_layer = mock_get_channel_layer.return_value
+        mock_layer.group_send = AsyncMock()
+
+        url = reverse("room-messages", kwargs={"room_uuid": self.room.uuid})
+        resp = self.client.post(url, {"text": "hi"}, format="json")
+
+        self.assertEqual(resp.status_code, 201)
+        mock_layer.group_send.assert_awaited_once()
+        group_name, payload = mock_layer.group_send.await_args.args
+        self.assertEqual(group_name, f"channel_{self.room.uuid}")
+        self.assertEqual(payload["type"], "chat.message")
+        event = payload["payload"]
+        self.assertEqual(event["type"], "message.new")
+        self.assertEqual(event["cid"], f"messaging:{self.room.uuid}")
+        self.assertEqual(event["message"]["body"], "hi")
+        self.assertEqual(event["message"]["text"], "hi")

--- a/libs/stream-chat-shim/__tests__/channel.sendMessage.test.ts
+++ b/libs/stream-chat-shim/__tests__/channel.sendMessage.test.ts
@@ -12,6 +12,6 @@ describe('channelSendMessage', () => {
       '/api/rooms/messaging:123/messages/',
       expect.objectContaining({ method: 'POST' }),
     );
-    expect(res).toEqual(json);
+    expect(res).toEqual({ message: json });
   });
 });

--- a/libs/stream-chat-shim/src/api/messages.ts
+++ b/libs/stream-chat-shim/src/api/messages.ts
@@ -1,0 +1,36 @@
+export type CreateMessagePayload = { text: string } & Record<string, unknown>;
+
+export type CreateMessageResult = Record<string, unknown>;
+
+/**
+ * Persist a new message for the given channel identifier.
+ */
+export async function createMessage(
+  cid: string,
+  payload: CreateMessagePayload,
+  init?: RequestInit,
+): Promise<CreateMessageResult> {
+  const url = `/api/rooms/${encodeURIComponent(cid)}/messages/`;
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    method: "POST",
+    credentials: init?.credentials ?? "same-origin",
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to create message (status ${response.status})`,
+    );
+    (error as Record<string, unknown>).status = response.status;
+    throw error;
+  }
+
+  return (await response.json()) as CreateMessageResult;
+}

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -2,6 +2,14 @@ import { noopStore } from 'chat-shim/noopStore';
 import type { StateStore } from 'chat-shim';
 import { stopTyping as stopTypingImpl } from 'chat-shim/typing';
 
+import {
+  createMessage,
+  type CreateMessagePayload,
+  type CreateMessageResult,
+} from './api/messages';
+
+type SendMessageResponse = { message: CreateMessageResult };
+
 export async function addAnswer(): Promise<void> {
   // Placeholder implementation until backend endpoint is available
 }
@@ -267,23 +275,21 @@ export async function channelQuery(
 }
 
 export async function sendMessage(
-  channel: { cid: string; sendMessage?: (msg: any, options?: any) => Promise<any> },
-  message: Record<string, any>,
+  channel: {
+    cid: string;
+    sendMessage?: (
+      msg: CreateMessagePayload,
+      options?: any,
+    ) => Promise<SendMessageResponse>;
+  },
+  message: CreateMessagePayload,
   options?: any,
-): Promise<any> {
+): Promise<SendMessageResponse> {
   if (typeof channel.sendMessage === 'function') {
     return channel.sendMessage(message, options);
   }
-  const resp = await fetch(
-    `/api/rooms/${encodeURIComponent(channel.cid)}/messages/`,
-    {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(message),
-    },
-  );
-  return resp.json();
+  const saved = await createMessage(channel.cid, message);
+  return { message: saved };
 }
 
 export async function query(
@@ -308,19 +314,11 @@ export async function query(
 
 export async function channelSendMessage(
   channel: { cid: string },
-  message: Record<string, any>,
+  message: CreateMessagePayload,
   _options?: any,
-): Promise<any> {
-  const resp = await fetch(
-    `/api/rooms/${encodeURIComponent(channel.cid)}/messages/`,
-    {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(message),
-    },
-  );
-  return resp.json();
+): Promise<SendMessageResponse> {
+  const saved = await createMessage(channel.cid, message);
+  return { message: saved };
 }
 
 export async function channelStateLoadMessageIntoState(

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -669,7 +669,6 @@ components:
           readOnly: true
         text:
           type: string
-          writeOnly: true
         body:
           type: string
           readOnly: true


### PR DESCRIPTION
## Summary
- return the saved message payload in websocket fan-out for createMessage and emit on the channel_<uuid> group
- expose message.text via the serializer and broadcast tests covering the new event shape
- add a typed chat API helper for creating messages and update the shim sendMessage path to use it

## Testing
- python manage.py test chat.tests.test_create_message


------
https://chatgpt.com/codex/tasks/task_e_68d059754c74832686002601d55363d0