### PR TITLE
feat(deleteMessage): wire up DELETE /api/rooms/{cid}/messages/{message_id}/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -125,6 +125,60 @@ class RoomMessageListCreateView(RoomFromCIDMixin, generics.ListCreateAPIView):
 # New Stream Chat API endpoints below
 
 
+class RoomMessageDeleteView(RoomFromCIDMixin, APIView):
+    """Delete a message in a room."""
+
+    authentication_classes = [DevTokenOrJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def _get_room(self, cid: str) -> Room:
+        if ":" in cid:
+            _, room_uuid = cid.split(":", 1)
+        else:
+            room_uuid = cid
+        return get_object_or_404(Room, uuid=room_uuid)
+
+    def _can_delete(self, user, room: Room, message: Message) -> bool:
+        if message.sent_by == user.username:
+            return True
+        if room.agent_id and room.agent_id == user.id:
+            return True
+        if getattr(user, "is_staff", False) or getattr(user, "is_superuser", False):
+            return True
+        return False
+
+    def delete(self, request, cid: str, message_id: int):
+        room = self._get_room(cid)
+        message = get_object_or_404(room.messages, id=message_id)
+
+        if not self._can_delete(request.user, room, message):
+            return Response(status=403)
+
+        deleted_at = timezone.now()
+        message.deleted_at = deleted_at
+        message.save(update_fields=["deleted_at"])
+
+        try:
+            channel_layer = get_channel_layer()
+            async_to_sync(channel_layer.group_send)(
+                f"channel_{room.uuid}",
+                {
+                    "type": "chat.message",
+                    "payload": {
+                        "type": "message.deleted",
+                        "cid": room.uuid,
+                        "message_id": message.id,
+                        "deleted_by": request.user.id,
+                        "ts": deleted_at.isoformat(),
+                    },
+                },
+            )
+        except Exception:
+            pass
+
+        return Response(status=204)
+
+
 class RoomMarkReadView(RoomFromCIDMixin, APIView):
     """Mark all messages in a room as read for the current user."""
 

--- a/backend/chat/tests/test_delete_message_api.py
+++ b/backend/chat/tests/test_delete_message_api.py
@@ -1,0 +1,84 @@
+from unittest.mock import AsyncMock, patch
+
+from chat.models import Channel, Message, Room
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+@override_settings(ROOT_URLCONF="chat.urls")
+class DeleteMessageAPITests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="u1", password="pw")
+        self.agent = User.objects.create_user(username="agent", password="pw")
+        self.room = Room.objects.create(uuid="room-1", client="client-1")
+        self.channel = Channel.objects.create(uuid=self.room.uuid, client=self.room.client)
+        self.message = Message.objects.create(
+            channel=self.channel,
+            body="hello",
+            sent_by=self.user.username,
+        )
+        self.room.messages.add(self.message)
+
+    def _url(self):
+        return reverse(
+            "room-message-delete",
+            kwargs={
+                "cid": f"messaging:{self.room.uuid}",
+                "message_id": self.message.id,
+            },
+        )
+
+    def test_author_can_delete_message(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.delete(self._url())
+        self.assertEqual(response.status_code, 204)
+
+        self.message.refresh_from_db()
+        self.assertIsNotNone(self.message.deleted_at)
+
+    def test_non_author_is_forbidden(self):
+        other = get_user_model().objects.create_user(username="u2", password="pw")
+        self.client.force_authenticate(other)
+        response = self.client.delete(self._url())
+        self.assertEqual(response.status_code, 403)
+
+        self.message.refresh_from_db()
+        self.assertIsNone(self.message.deleted_at)
+
+    def test_room_agent_can_delete(self):
+        self.room.agent = self.agent
+        self.room.save(update_fields=["agent"])
+
+        self.client.force_authenticate(self.agent)
+        response = self.client.delete(self._url())
+        self.assertEqual(response.status_code, 204)
+
+        self.message.refresh_from_db()
+        self.assertIsNotNone(self.message.deleted_at)
+
+    @patch("chat.api_views.get_channel_layer")
+    def test_broadcasts_deleted_event(self, mock_get_channel_layer):
+        mock_layer = mock_get_channel_layer.return_value
+        mock_layer.group_send = AsyncMock()
+
+        self.client.force_authenticate(self.user)
+        response = self.client.delete(self._url())
+
+        self.assertEqual(response.status_code, 204)
+        mock_layer.group_send.assert_awaited_once()
+
+        group_name, payload = mock_layer.group_send.await_args.args
+        self.assertEqual(group_name, f"channel_{self.room.uuid}")
+        self.assertEqual(payload["type"], "chat.message")
+
+        event = payload["payload"]
+        self.assertEqual(event["type"], "message.deleted")
+        self.assertEqual(event["cid"], self.room.uuid)
+        self.assertEqual(event["message_id"], self.message.id)
+        self.assertEqual(event["deleted_by"], self.user.id)
+
+        self.message.refresh_from_db()
+        self.assertEqual(event["ts"], self.message.deleted_at.isoformat())

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -4,6 +4,7 @@ from .api_views import (
     RoomListCreateView,
     RoomDetailView,
     RoomMessageListCreateView,
+    RoomMessageDeleteView,
     RoomMarkReadView,
     RoomMarkUnreadView,
     RoomCountUnreadView,
@@ -78,6 +79,11 @@ urlpatterns = [
         "api/rooms/<str:room_uuid>/messages/",
         RoomMessageListCreateView.as_view(),
         name="room-messages",
+    ),
+    path(
+        "api/rooms/<path:cid>/messages/<int:message_id>/",
+        RoomMessageDeleteView.as_view(),
+        name="room-message-delete",
     ),
     path(
         "api/rooms/<str:room_uuid>/mark_read/",

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1,0 +1,26 @@
+export type DeleteMessageParams = {
+  cid: string;
+  message_id: number;
+};
+
+async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<void> {
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(cid)}/messages/${encodeURIComponent(String(message_id))}/`,
+    {
+      method: "DELETE",
+      credentials: "same-origin",
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to delete message (status ${response.status})`,
+    );
+    (error as Record<string, unknown>).status = response.status;
+    throw error;
+  }
+}
+
+export const chatAPI = {
+  deleteMessage,
+};

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -98,6 +98,7 @@ import {
   channelQuery,
   channelStateLoadMessageIntoState,
 } from "../../chatSDKShim";
+import { chatAPI } from "../../api/chatAPI";
 
 type ChannelPropsForwardedToComponentContext = Pick<
   ComponentContextValue,
@@ -962,22 +963,33 @@ const ChannelInner = (
       ],
     );
 
+  /** Custom action handler to delete a message via the backend */
   const deleteMessage = useCallback(
     async (message: LocalMessage): Promise<MessageResponse> => {
       if (!message?.id) {
         throw new Error("Cannot delete a message - missing message ID.");
       }
-      let deletedMessage;
-      if (doDeleteMessageRequest) {
-        deletedMessage = await doDeleteMessageRequest(message);
-      } else {
-        const result = await client.deleteMessage(message.id);
-        deletedMessage = result;
+      if (!channel?.cid) {
+        throw new Error("Cannot delete a message - missing channel CID.");
       }
 
-      return deletedMessage;
+      if (doDeleteMessageRequest) {
+        return await doDeleteMessageRequest(message);
+      }
+
+      const messageId = Number(message.id);
+      if (Number.isNaN(messageId)) {
+        throw new Error(
+          `Cannot delete a message - invalid message ID "${message.id}".`,
+        );
+      }
+
+      await chatAPI.deleteMessage({ cid: channel.cid, message_id: messageId });
+
+      const deletedAt = new Date().toISOString();
+      return { ...message, deleted_at: deletedAt } as MessageResponse;
     },
-    [client, doDeleteMessageRequest],
+    [channel, doDeleteMessageRequest],
   );
 
   const updateMessage = (updatedMessage: MessageResponse | LocalMessage) => {

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -95,6 +95,25 @@ paths:
                 type: array
                 items:
                   $ref: '#/paths/~1rooms~1/get/responses/200/content/application~1json/schema/items'
+  /api/rooms/{cid}/messages/{message_id}/:
+    delete:
+      description: Delete a message in a room.
+      operationId: deleteMessage
+      parameters:
+        - in: path
+          name: cid
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: message_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: ''
+      tags: [api]
   /messages/{messageId}/:
     parameters:
       - name: messageId

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -42,7 +42,7 @@
     "stubName": "deleteMessage",
     "ticketType": "api",
     "todoCount": 6,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",
@@ -51,7 +51,7 @@
     "stubName": "client.deleteMessage",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a room-scoped delete API that enforces author/moderator permissions and broadcasts `message.deleted`
- document the new endpoint in the OpenAPI manifests and update wire-up status for `deleteMessage`
- add a typed `chatAPI.deleteMessage` helper and route the Channel shim through it with backend tests for the flow

## Testing
- python -m pytest chat/tests/test_delete_message_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d5344f957c83268e86add6d2a86d72