### PR TITLE
feat(endSession): wire up DELETE /api/session/

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -21,6 +21,22 @@ async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<
   }
 }
 
+async function endSession(): Promise<void> {
+  const response = await fetch("/api/session/", {
+    method: "DELETE",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to end session (status ${response.status})`,
+    );
+    (error as Record<string, unknown>).status = response.status;
+    throw error;
+  }
+}
+
 export const chatAPI = {
   deleteMessage,
+  endSession,
 };

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -2,6 +2,7 @@ import { noopStore } from 'chat-shim/noopStore';
 import type { StateStore } from 'chat-shim';
 import { stopTyping as stopTypingImpl } from 'chat-shim/typing';
 
+import { chatAPI } from './api/chatAPI';
 import {
   createMessage,
   type CreateMessagePayload,
@@ -258,10 +259,7 @@ export async function connectUser(
 }
 
 export async function disconnectUser(): Promise<void> {
-  await fetch("/api/session/", {
-    method: "DELETE",
-    credentials: "same-origin",
-  });
+  await chatAPI.endSession();
 }
 
 export async function channelQuery(

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -60,7 +60,7 @@
     "stubName": "disconnectUser",
     "ticketType": "api",
     "todoCount": 2,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.endSession` helper that wraps DELETE /api/session/
- route the shim's `disconnectUser` implementation through the new helper
- mark the `endSession` wireup entry as complete in the manifest

## Testing
- python -m pytest backend/chat/tests/test_disconnect_user.py backend/chat/tests/test_disconnected.py *(fails: fixture 'settings' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d540761800832688c5cc983bb38f43