### PR TITLE
feat: wire up createReminder endpoint

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -19,11 +19,18 @@ from .mixins import RoomFromCIDMixin
 from .models import (Channel, Draft, Flag, Message, Notification, Pin, Poll,
                      PollOption, Reaction, ReadState, Reminder, Room, RoomMute,
                      UserMute)
-from .serializers import (FlagSerializer, MessageSerializer,
-                          NotificationSerializer, PinSerializer,
-                          PollOptionSerializer, PollSerializer,
-                          ReactionSerializer, ReminderSerializer,
-                          RoomSerializer)
+from .serializers import (
+    FlagSerializer,
+    MessageSerializer,
+    NotificationSerializer,
+    PinSerializer,
+    PollOptionSerializer,
+    PollSerializer,
+    ReactionSerializer,
+    ReminderCreateSerializer,
+    ReminderSerializer,
+    RoomSerializer,
+)
 
 
 class RoomListCreateView(generics.ListCreateAPIView):
@@ -747,19 +754,54 @@ class ReminderListCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        reminders = Reminder.objects.filter(user=request.user)
+        reminders = Reminder.objects.filter(created_by=request.user)
         serializer = ReminderSerializer(reminders, many=True)
         return Response(serializer.data)
 
-    def post(self, request):
-        serializer = ReminderSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        reminder = Reminder.objects.create(
-            user=request.user,
-            text=serializer.validated_data["text"],
-            remind_at=serializer.validated_data["remind_at"],
+
+class RoomReminderCreateView(RoomFromCIDMixin, APIView):
+    """Create a reminder scoped to a room."""
+
+    authentication_classes = [DevTokenOrJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, cid: str):
+        room = self.get_room(cid)
+        username = request.user.username
+        is_member = (
+            room.agent_id == request.user.id
+            or room.client == username
+            or room.messages.filter(sent_by=username).exists()
+            or getattr(request.user, "is_staff", False)
+            or getattr(request.user, "is_superuser", False)
         )
-        return Response({"reminder": ReminderSerializer(reminder).data}, status=201)
+        if not is_member:
+            return Response(status=403)
+        serializer = ReminderCreateSerializer(
+            data=request.data, context={"room": room, "user": request.user}
+        )
+        serializer.is_valid(raise_exception=True)
+        reminder = serializer.save()
+        reminder_data = ReminderSerializer(reminder).data
+
+        try:
+            channel_layer = get_channel_layer()
+            cid_value = f"messaging:{room.uuid}" if ":" not in cid else cid
+            async_to_sync(channel_layer.group_send)(
+                f"channel_{room.uuid}",
+                {
+                    "type": "chat.message",
+                    "payload": {
+                        "type": "reminder.created",
+                        "cid": cid_value,
+                        "reminder": reminder_data,
+                    },
+                },
+            )
+        except Exception:
+            pass
+
+        return Response(reminder_data, status=201)
 
 
 class ThreadListView(APIView):

--- a/backend/chat/migrations/0006_update_reminder_model.py
+++ b/backend/chat/migrations/0006_update_reminder_model.py
@@ -1,0 +1,58 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("chat", "0005_add_message_updated_at"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="reminder",
+            old_name="user",
+            new_name="created_by",
+        ),
+        migrations.RenameField(
+            model_name="reminder",
+            old_name="text",
+            new_name="note",
+        ),
+        migrations.AddField(
+            model_name="reminder",
+            name="message",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="reminders",
+                to="chat.message",
+            ),
+        ),
+        migrations.AddField(
+            model_name="reminder",
+            name="room",
+            field=models.ForeignKey(
+                null=True,
+                blank=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="reminders",
+                to="chat.room",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="reminder",
+            name="created_by",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="created_reminders",
+                to="accounts_supabase.customuser",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="reminder",
+            name="note",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -146,7 +146,21 @@ class RoomMute(models.Model):
 
 
 class Reminder(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    text = models.CharField(max_length=255)
+    room = models.ForeignKey(
+        Room, related_name="reminders", on_delete=models.CASCADE, null=True, blank=True
+    )
+    message = models.ForeignKey(
+        Message,
+        related_name="reminders",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+    )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="created_reminders",
+    )
+    note = models.CharField(max_length=255, blank=True, null=True)
     remind_at = models.DateTimeField()
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -122,7 +122,53 @@ class PollSerializer(serializers.ModelSerializer):
 
 
 class ReminderSerializer(serializers.ModelSerializer):
+    message_id = serializers.IntegerField(read_only=True, allow_null=True)
+    note = serializers.CharField(allow_blank=True, allow_null=True, required=False)
+    created_by = serializers.IntegerField(source="created_by_id", read_only=True)
+
     class Meta:
         model = Reminder
-        fields = ["id", "text", "remind_at", "created_at"]
-        read_only_fields = ["id", "created_at"]
+        fields = [
+            "id",
+            "remind_at",
+            "message_id",
+            "note",
+            "created_by",
+            "created_at",
+        ]
+        read_only_fields = ["id", "message_id", "created_by", "created_at"]
+
+
+class ReminderCreateSerializer(serializers.Serializer):
+    remind_at = serializers.DateTimeField()
+    message_id = serializers.IntegerField(required=False, allow_null=True)
+    note = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, max_length=255
+    )
+
+    def validate_message_id(self, value):
+        if value is None:
+            return value
+        room = self.context.get("room")
+        try:
+            message = Message.objects.get(id=value)
+        except Message.DoesNotExist:
+            raise serializers.ValidationError("Invalid message_id")
+        if room and not room.messages.filter(id=message.id).exists():
+            raise serializers.ValidationError("Message does not belong to this room")
+        self.context["message_obj"] = message
+        return value
+
+    def create(self, validated_data):
+        room = self.context["room"]
+        user = self.context["user"]
+        message = self.context.get("message_obj")
+        note = validated_data.get("note")
+        reminder = Reminder.objects.create(
+            room=room,
+            message=message,
+            created_by=user,
+            note=note,
+            remind_at=validated_data["remind_at"],
+        )
+        return reminder

--- a/backend/chat/tests/test_reminders.py
+++ b/backend/chat/tests/test_reminders.py
@@ -1,20 +1,55 @@
-from django.urls import reverse
-from rest_framework.test import APITestCase
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
 from django.conf import settings
+from django.urls import reverse
+from django.test import override_settings
+from rest_framework.test import APITestCase
 import jwt
 
 from accounts_supabase.models import CustomUser
-from chat.models import Reminder
+from chat.models import Channel, Message, Reminder, Room
 
+@override_settings(ROOT_URLCONF="chat.urls")
 class ReminderAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
         return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
 
     def setUp(self):
-        self.user = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
-        self.other = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
-        Reminder.objects.create(user=self.user, text="hi", remind_at="2025-01-01T00:00:00Z")
-        Reminder.objects.create(user=self.other, text="bye", remind_at="2025-01-02T00:00:00Z")
+        self.user = CustomUser.objects.create_user(
+            username="u1",
+            email="u1@example.com",
+            password="x",
+            supabase_uid="u1",
+        )
+        self.other = CustomUser.objects.create_user(
+            username="u2",
+            email="u2@example.com",
+            password="x",
+            supabase_uid="u2",
+        )
+        self.room = Room.objects.create(uuid="r1", client="c1")
+        self.channel = Channel.objects.create(uuid=self.room.uuid, client=self.room.client)
+        self.message = Message.objects.create(
+            channel=self.channel,
+            body="hello",
+            sent_by=self.user.username,
+        )
+        self.room.messages.add(self.message)
+        Reminder.objects.create(
+            room=self.room,
+            message=self.message,
+            created_by=self.user,
+            note="hi",
+            remind_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+        Reminder.objects.create(
+            room=self.room,
+            message=self.message,
+            created_by=self.other,
+            note="bye",
+            remind_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+        )
 
     def test_list_reminders(self):
         token = self.make_token()
@@ -22,7 +57,7 @@ class ReminderAPITests(APITestCase):
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
         self.assertEqual(len(res.data), 1)
-        self.assertEqual(res.data[0]["text"], "hi")
+        self.assertEqual(res.data[0]["note"], "hi")
 
     def test_reminders_requires_auth(self):
         url = reverse("reminders")
@@ -35,11 +70,29 @@ class ReminderAPITests(APITestCase):
         res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 405)
 
-    def test_create_reminder(self):
+    @patch("chat.api_views.get_channel_layer")
+    def test_create_reminder(self, mock_get_channel_layer):
+        channel_layer = Mock()
+        channel_layer.group_send = AsyncMock()
+        mock_get_channel_layer.return_value = channel_layer
         token = self.make_token()
-        url = reverse("reminders")
-        res = self.client.post(url, {"text": "new", "remind_at": "2025-01-03T00:00:00Z"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        url = reverse("room-reminders", kwargs={"cid": f"messaging:{self.room.uuid}"})
+        payload = {
+            "remind_at": "2025-01-03T00:00:00Z",
+            "message_id": self.message.id,
+            "note": "new",
+        }
+        res = self.client.post(
+            url,
+            payload,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
         self.assertEqual(res.status_code, 201)
-        self.assertEqual(Reminder.objects.filter(text="new").count(), 1)
-        self.assertEqual(res.data["reminder"]["text"], "new")
+        self.assertEqual(Reminder.objects.filter(note="new").count(), 1)
+        self.assertEqual(res.data["note"], "new")
+        channel_layer.group_send.assert_awaited_once()
+        group_name, event = channel_layer.group_send.await_args.args
+        self.assertEqual(group_name, f"channel_{self.room.uuid}")
+        self.assertEqual(event["payload"]["type"], "reminder.created")
 

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -44,6 +44,7 @@ from .api_views import (
     UnmuteUserView,
     AttachmentUploadView,
     ReminderListCreateView,
+    RoomReminderCreateView,
     ThreadListView,
     RecoverStateView,
     TextComposerView,
@@ -183,6 +184,11 @@ urlpatterns = [
     ),
     path("api/notifications/", NotificationListView.as_view(), name="notifications"),
     path("api/reminders/", ReminderListCreateView.as_view(), name="reminders"),
+    path(
+        "api/rooms/<path:cid>/reminders/",
+        RoomReminderCreateView.as_view(),
+        name="room-reminders",
+    ),
     path("api/threads/", ThreadListView.as_view(), name="threads"),
     path("api/muted-channels/", MutedChannelListView.as_view(), name="muted-channels"),
     path(

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,13 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/libs/**/?(*.)+(test).[tj]s?(x)'],
+  moduleNameMapper: {
+    '^chat-shim$': '<rootDir>/libs/chat-shim',
+    '^chat-shim/(.*)$': '<rootDir>/libs/chat-shim/$1',
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json',
+    },
+  },
 };

--- a/libs/chat-shim/__tests__/createReminder.test.ts
+++ b/libs/chat-shim/__tests__/createReminder.test.ts
@@ -3,12 +3,29 @@ import { ReminderManager } from '../index';
 describe('createReminder', () => {
   test('posts to backend and updates store', async () => {
     const manager = new ReminderManager();
-    const mockReminder = { id: 1, text: 'hello', remind_at: '2025-01-01T00:00:00Z', created_at: '2024-01-01T00:00:00Z' };
+    const mockReminder = {
+      id: 1,
+      note: 'hello',
+      remind_at: '2025-01-01T00:00:00Z',
+      created_at: '2024-01-01T00:00:00Z',
+      created_by: 7,
+      message_id: 9,
+    };
     global.fetch = jest.fn().mockResolvedValue({
-      json: async () => ({ reminder: mockReminder }),
+      json: async () => mockReminder,
     }) as any;
-    await manager.createReminder('hello', '2025-01-01T00:00:00Z');
-    expect(fetch).toHaveBeenCalledWith('/api/reminders/', expect.any(Object));
+    await manager.createReminder({
+      cid: 'messaging:test',
+      note: 'hello',
+      remind_at: '2025-01-01T00:00:00Z',
+      message_id: 9,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/rooms/messaging%3Atest/reminders/',
+      expect.objectContaining({
+        body: JSON.stringify({ note: 'hello', remind_at: '2025-01-01T00:00:00Z', message_id: 9 }),
+      }),
+    );
     expect(manager.store.getLatestValue().reminders[0].reminder.id).toBe(1);
   });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -214,9 +214,19 @@ declare module 'stream-chat' {
   export function isVoteAnswer(vote: PollVote | PollAnswer): vote is PollAnswer;
 
   export interface Reminder {
-    id: string;
-    text: string;
+    id: number | string;
     remind_at: string;
+    message_id?: number | null;
+    note?: string | null;
+    created_by?: number;
+    created_at?: string;
+  }
+
+  export interface ReminderCreateParams {
+    cid: string;
+    remind_at: string;
+    message_id?: number;
+    note?: string;
   }
 
   export interface ReminderState {
@@ -233,7 +243,7 @@ declare module 'stream-chat' {
     registerSubscriptions(): void;
     unregisterSubscriptions(): void;
     initTimers(): void;
-    createReminder(text: string, remind_at: string): Promise<Reminder>;
+    createReminder(params: ReminderCreateParams): Promise<Reminder>;
     clearTimers(): void;
   }
   export class FixedSizeQueueCache<K, T> {

--- a/libs/chat-shim/index.js
+++ b/libs/chat-shim/index.js
@@ -824,6 +824,33 @@ var ReminderManager = /** @class */ (function () {
             r.timer = undefined;
         }
     };
+    ReminderManager.prototype.createReminder = function (params) {
+        return __awaiter(this, void 0, void 0, function () {
+            var cid, body, resp, reminder, list;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        cid = params.cid, body = __assign({}, params);
+                        delete body.cid;
+                        return [4 /*yield*/, fetch("/api/rooms/".concat(encodeURIComponent(cid), "/reminders/"), {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify(body),
+                            })];
+                    case 1:
+                        resp = _a.sent();
+                        return [4 /*yield*/, resp.json()];
+                    case 2:
+                        reminder = _a.sent();
+                        list = this.store.getLatestValue().reminders.slice();
+                        list.push({ reminder: reminder });
+                        this.store.dispatch({ reminders: list });
+                        this.initTimers();
+                        return [2 /*return*/, reminder];
+                }
+            });
+        });
+    };
     return ReminderManager;
 }());
 exports.ReminderManager = ReminderManager;

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -928,9 +928,19 @@ export const isVoteAnswer = (vote: PollVote | PollAnswer): vote is PollAnswer =>
 /* ------------------------------ reminders ------------------------------ */
 
 export interface Reminder {
-  id: string;
-  text: string;
+  id: number | string;
   remind_at: string;
+  message_id?: number | null;
+  note?: string | null;
+  created_by?: number;
+  created_at?: string;
+}
+
+export interface ReminderCreateParams {
+  cid: string;
+  remind_at: string;
+  message_id?: number;
+  note?: string;
 }
 
 export interface ReminderState {
@@ -972,14 +982,17 @@ export class ReminderManager {
   }
 
   /** Create a reminder via the backend and store it */
-  async createReminder(text: string, remind_at: string): Promise<Reminder> {
-    const resp = await fetch("/api/reminders/", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, remind_at }),
-    });
-    const data = await resp.json();
-    const reminder: Reminder = data.reminder;
+  async createReminder(params: ReminderCreateParams): Promise<Reminder> {
+    const { cid, ...body } = params;
+    const resp = await fetch(
+      `/api/rooms/${encodeURIComponent(cid)}/reminders/`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    const reminder: Reminder = await resp.json();
     const list = this.store.getLatestValue().reminders.slice();
     list.push({ reminder });
     this.store.dispatch({ reminders: list });

--- a/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
@@ -1,23 +1,38 @@
+import { chatAPI } from '../src/api/chatAPI';
 import { remindersUpsertReminder } from '../src/chatSDKShim';
 
+jest.mock('../src/api/chatAPI', () => ({
+  chatAPI: {
+    createReminder: jest.fn().mockResolvedValue('ok'),
+  },
+}));
+
 describe('remindersUpsertReminder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('calls reminders.upsertReminder when available', async () => {
     const fn = jest.fn().mockResolvedValue('ok');
-    const res = await remindersUpsertReminder({ upsertReminder: fn } as any, '42', '2024-01-01T00:00:00Z');
+    const res = await remindersUpsertReminder(
+      { upsertReminder: fn } as any,
+      { cid: 'messaging:test', message_id: 42, remind_at: '2024-01-01T00:00:00Z' },
+    );
     expect(fn).toHaveBeenCalledWith('42', '2024-01-01T00:00:00Z');
     expect(res).toBe('ok');
   });
 
   it('falls back to HTTP request when not implemented', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve('ok') });
-    // @ts-ignore
-    global.fetch = fetchMock;
-    const res = await remindersUpsertReminder(undefined, '42', '2024-01-01T00:00:00Z');
-    expect(fetchMock).toHaveBeenCalledWith('/api/reminders/', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ messageId: '42', remind_at: '2024-01-01T00:00:00Z' }),
+    (chatAPI.createReminder as jest.Mock).mockResolvedValueOnce('ok');
+    const res = await remindersUpsertReminder(undefined, {
+      cid: 'messaging:test',
+      message_id: 42,
+      remind_at: '2024-01-01T00:00:00Z',
+    });
+    expect(chatAPI.createReminder).toHaveBeenCalledWith({
+      cid: 'messaging:test',
+      message_id: 42,
+      remind_at: '2024-01-01T00:00:00Z',
     });
     expect(res).toBe('ok');
   });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -3,6 +3,26 @@ export type DeleteMessageParams = {
   message_id: number;
 };
 
+export type CreateReminderInput = {
+  cid: string;
+  remind_at: string;
+  message_id?: number;
+  note?: string;
+};
+
+export type Reminder = {
+  id: number;
+  remind_at: string;
+  message_id?: number | null;
+  note?: string | null;
+  created_by: number;
+  created_at: string;
+};
+
+interface ErrorWithStatus extends Error {
+  status?: number;
+}
+
 async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<void> {
   const response = await fetch(
     `/api/rooms/${encodeURIComponent(cid)}/messages/${encodeURIComponent(String(message_id))}/`,
@@ -16,9 +36,33 @@ async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<
     const error = new Error(
       `Failed to delete message (status ${response.status})`,
     );
-    (error as Record<string, unknown>).status = response.status;
-    throw error;
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
   }
+}
+
+async function createReminder({ cid, ...body }: CreateReminderInput): Promise<Reminder> {
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(cid)}/reminders/`,
+    {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to create reminder (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  return (await response.json()) as Reminder;
 }
 
 async function endSession(): Promise<void> {
@@ -31,12 +75,14 @@ async function endSession(): Promise<void> {
     const error = new Error(
       `Failed to end session (status ${response.status})`,
     );
-    (error as Record<string, unknown>).status = response.status;
-    throw error;
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
   }
 }
 
 export const chatAPI = {
+  createReminder,
   deleteMessage,
   endSession,
 };

--- a/libs/stream-chat-shim/src/api/messages.ts
+++ b/libs/stream-chat-shim/src/api/messages.ts
@@ -2,6 +2,10 @@ export type CreateMessagePayload = { text: string } & Record<string, unknown>;
 
 export type CreateMessageResult = Record<string, unknown>;
 
+interface ErrorWithStatus extends Error {
+  status?: number;
+}
+
 /**
  * Persist a new message for the given channel identifier.
  */
@@ -28,8 +32,9 @@ export async function createMessage(
     const error = new Error(
       `Failed to create message (status ${response.status})`,
     );
-    (error as Record<string, unknown>).status = response.status;
-    throw error;
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
   }
 
   return (await response.json()) as CreateMessageResult;

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,8 +1,7 @@
-import { noopStore } from 'chat-shim/noopStore';
-import type { StateStore } from 'chat-shim';
-import { stopTyping as stopTypingImpl } from 'chat-shim/typing';
+import { StateStore } from '../../chat-shim';
+import { stopTyping as stopTypingImpl } from '../../chat-shim/typing';
 
-import { chatAPI } from './api/chatAPI';
+import { chatAPI, type CreateReminderInput } from './api/chatAPI';
 import {
   createMessage,
   type CreateMessagePayload,
@@ -544,39 +543,43 @@ export async function clientQueryUsers(
 export async function clientRemindersCreateReminder(
   client: {
     reminders?: {
-      createReminder?: (text: string, remind_at: string) => Promise<any>;
+      createReminder?: ((params: CreateReminderInput) => Promise<any>) & {
+        length?: number;
+      };
     };
   },
-  text: string,
-  remind_at: string,
+  params: CreateReminderInput,
 ): Promise<any> {
-  if (client.reminders?.createReminder) {
-    return client.reminders.createReminder(text, remind_at);
+  const createReminder = client.reminders?.createReminder as any;
+  if (createReminder) {
+    if (typeof createReminder.length === 'number' && createReminder.length >= 2) {
+      const note = params.note ?? '';
+      return createReminder(note, params.remind_at);
+    }
+    return createReminder(params);
   }
-  const resp = await fetch("/api/reminders/", {
-    method: "POST",
-    credentials: "same-origin",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ text, remind_at }),
-  });
-  return resp.json();
+  return chatAPI.createReminder(params);
 }
 
 export async function remindersCreateReminder(
-  reminders: { createReminder?: (text: string, remind_at: string) => Promise<any> } | undefined,
-  text: string,
-  remind_at: string,
+  reminders:
+    | {
+        createReminder?: ((params: CreateReminderInput) => Promise<any>) & {
+          length?: number;
+        };
+      }
+    | undefined,
+  params: CreateReminderInput,
 ): Promise<any> {
   if (reminders?.createReminder) {
-    return reminders.createReminder(text, remind_at);
+    const createReminder = reminders.createReminder as any;
+    if (typeof createReminder.length === 'number' && createReminder.length >= 2) {
+      const note = params.note ?? '';
+      return createReminder(note, params.remind_at);
+    }
+    return createReminder(params);
   }
-  const resp = await fetch('/api/reminders/', {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text, remind_at }),
-  });
-  return resp.json();
+  return chatAPI.createReminder(params);
 }
 
 export async function clientRemindersDeleteReminder(
@@ -642,11 +645,7 @@ export async function clientThreadsReload(client: {
   return resp.json();
 }
 
-export function clientThreadsState(client: {
-  threads?: { state?: StateStore<any> };
-}): StateStore<any> {
-  return client.threads?.state ?? noopStore;
-}
+const fallbackThreadStateStore = new StateStore<any>({} as any);
 
 export async function deleteReaction(
   messageId: string,
@@ -783,10 +782,20 @@ export async function getDraft(roomUuid: string): Promise<{ text?: string }> {
 }
 
 
+const fallbackNotificationsStore = new StateStore<{ notifications: any[] }>({
+  notifications: [],
+});
+
+export function clientThreadsState(client: {
+  threads?: { state?: StateStore<any> };
+}): StateStore<any> {
+  return client.threads?.state ?? fallbackThreadStateStore;
+}
+
 export function notificationsStore(client: {
   notifications?: { store?: StateStore<{ notifications: any[] }> };
 }): StateStore<{ notifications: any[] }> {
-  return client.notifications?.store ?? (noopStore as StateStore<any>);
+  return client.notifications?.store ?? fallbackNotificationsStore;
 }
 
 export async function muteUser(username: string): Promise<void> {
@@ -883,25 +892,23 @@ export function remindersScheduledOffsetsMs(client?: {
 }
 
 export async function remindersUpsertReminder(
-  reminders: {
-    upsertReminder?: (
-      messageId: string,
-      remind_at: string,
-    ) => Promise<any>;
-  } | undefined,
-  messageId: string,
-  remind_at: string,
+  reminders:
+    | {
+        upsertReminder?: (
+          messageId: string,
+          remind_at: string,
+        ) => Promise<any>;
+      }
+    | undefined,
+  params: CreateReminderInput,
 ): Promise<any> {
   if (reminders?.upsertReminder) {
-    return reminders.upsertReminder(messageId, remind_at);
+    return reminders.upsertReminder(
+      String(params.message_id ?? ''),
+      params.remind_at,
+    );
   }
-  const resp = await fetch('/api/reminders/', {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messageId, remind_at }),
-  });
-  return resp.json();
+  return chatAPI.createReminder(params);
 }
 
 export async function search(

--- a/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
@@ -12,6 +12,7 @@ import {
   useTranslationContext,
 } from '../../context';
 import { MESSAGE_ACTIONS } from '../Message/utils';
+import { chatAPI, type CreateReminderInput } from '../../api/chatAPI';
 import type { MessageContextValue } from '../../context';
 
 type PropsDrilledToMessageActionsBox =
@@ -53,7 +54,7 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
   const { customMessageActions, message, threadList } =
     useMessageContext('MessageActionsBox');
   const { t } = useTranslationContext('MessageActionsBox');
-  const { client } = useChatContext('MessageActionsBox');
+  const { client, channel } = useChatContext('MessageActionsBox');
   const messageComposer = useMessageComposer();
   const reminder = useMessageReminder(message.id);
 
@@ -169,14 +170,37 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
           <button
             aria-selected='false'
             className={buttonClassName}
-            onClick={() => {
+            onClick={async () => {
               if (reminder) {
-                client.reminders.deleteReminder(reminder.id);
+                await client.reminders.deleteReminder(reminder.id);
+                return;
+              }
+              const cid = channel?.cid ?? (message.cid as string | undefined);
+              if (!cid) return;
+              const remindAt = new Date().toISOString();
+              const rawMessageId =
+                typeof message.id === 'number'
+                  ? message.id
+                  : typeof message.id === 'string'
+                  ? Number.parseInt(message.id, 10)
+                  : undefined;
+              const params: CreateReminderInput = {
+                cid,
+                remind_at: remindAt,
+                note: message.text || undefined,
+              };
+              if (typeof rawMessageId === 'number' && !Number.isNaN(rawMessageId)) {
+                params.message_id = rawMessageId;
+              }
+              const createReminder = client.reminders?.createReminder;
+              if (createReminder) {
+                if (typeof createReminder.length === 'number' && createReminder.length >= 2) {
+                  await createReminder(params.note ?? '', params.remind_at);
+                } else {
+                  await createReminder(params);
+                }
               } else {
-                client.reminders.createReminder(
-                  message.text || '',
-                  new Date().toISOString(),
-                );
+                await chatAPI.createReminder(params);
               }
             }}
             role='option'

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useChatContext, useMessageContext, useTranslationContext } from '../../context';
+import type { CreateReminderInput } from '../../api/chatAPI';
 import {
   remindersScheduledOffsetsMs,
   remindersUpsertReminder,
@@ -27,9 +28,10 @@ export const RemindMeActionButton = ({
 
 export const RemindMeSubmenu = () => {
   const { t } = useTranslationContext();
-  const { client } = useChatContext();
+  const { client, channel } = useChatContext();
   const { message } = useMessageContext();
   const scheduledOffsetsMs = remindersScheduledOffsetsMs(client);
+  const cid = channel?.cid ?? (message.cid as string | undefined);
   return (
     <div
       aria-label={t('aria/Remind Me Options')}
@@ -41,11 +43,22 @@ export const RemindMeSubmenu = () => {
           className='str-chat__message-actions-list-item-button'
           key={`reminder-offset-option--${offsetMs}`}
           onClick={() => {
-            remindersUpsertReminder(
-              client.reminders,
-              message.id,
-              new Date(Date.now() + offsetMs).toISOString(),
-            );
+            if (!cid) return;
+            const remindAt = new Date(Date.now() + offsetMs).toISOString();
+            const rawMessageId =
+              typeof message.id === 'number'
+                ? message.id
+                : typeof message.id === 'string'
+                ? Number.parseInt(message.id, 10)
+                : undefined;
+            const reminderInput: CreateReminderInput = {
+              cid,
+              remind_at: remindAt,
+            };
+            if (typeof rawMessageId === 'number' && !Number.isNaN(rawMessageId)) {
+              reminderInput.message_id = rawMessageId;
+            }
+            remindersUpsertReminder(client.reminders, reminderInput);
           }}
         >
           {t('duration/Remind Me', { milliseconds: offsetMs })}

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -114,6 +114,30 @@ paths:
         '204':
           description: ''
       tags: [api]
+  /api/rooms/{cid}/reminders/:
+    post:
+      description: Create a reminder in a room.
+      operationId: createReminder
+      parameters:
+        - in: path
+          name: cid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReminderCreate'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reminder'
+      tags: [api]
   /messages/{messageId}/:
     parameters:
       - name: messageId
@@ -728,3 +752,38 @@ paths:
                 properties:
                   status:
                     type: string
+components:
+  schemas:
+    ReminderCreate:
+      type: object
+      properties:
+        remind_at:
+          type: string
+          format: date-time
+        message_id:
+          type: integer
+        note:
+          type: string
+      required: [remind_at]
+    Reminder:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        remind_at:
+          type: string
+          format: date-time
+        message_id:
+          type: integer
+          nullable: true
+        note:
+          type: string
+          nullable: true
+        created_by:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true


### PR DESCRIPTION
## Summary
- add room reminder creation endpoint, serializer, and websocket fan-out for reminder.created events
- update reminder shim models and API types to support POST /api/rooms/{cid}/reminders/
- extend OpenAPI and frontend reminder flows to call the new helper and stub map entries

## Testing
- pnpm exec jest --runInBand --runTestsByPath ./libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts ./libs/chat-shim/__tests__/createReminder.test.ts
- cd backend && python manage.py test chat.tests.test_reminders


------
https://chatgpt.com/codex/tasks/task_e_68d54371d72c83269dfe871b1a911da0