### PR TITLE
feat: wire up session termination endpoint

### DIFF
--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -6,7 +6,6 @@ from rest_framework import generics, serializers
 from django.contrib.auth import get_user_model
 from accounts_supabase.authentication import SupabaseJWTAuthentication
 from accounts_supabase.models import UserProfile
-from django.utils import timezone
 from django.conf import settings
 import jwt
 import uuid
@@ -29,8 +28,6 @@ class SessionView(APIView):
     permission_classes = [IsAuthenticated]
 
     def delete(self, request):
-        # Log timestamp for debugging stale tokens
-        print(f"disconnect at {timezone.now()} for {request.user}")
         request.session['disconnected'] = True
         request.session['initialized'] = False
         return Response(status=204)

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useCreateChatClient.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useCreateChatClient.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-
 import { StreamChat } from 'chat-shim';
+
+import { chatAPI } from '../../../api/chatAPI';
 
 import type {
   OwnUserResponse,
@@ -46,9 +47,18 @@ export const useCreateChatClient = ({
       didUserConnectInterrupt = true;
       setChatClient(null);
       connectionPromise
-        .then(() => client.disconnectUser())
+        .then(async () => {
+          client.disconnectUser();
+          await chatAPI.endSession();
+        })
         .then(() => {
           console.log(`Connection for user "${cachedUserData.id}" has been closed`);
+        })
+        .catch((error) => {
+          console.error(
+            `Failed to disconnect session for user "${cachedUserData.id}"`,
+            error,
+          );
         });
     };
   }, [apiKey, cachedUserData, cachedOptions, tokenOrProvider]);


### PR DESCRIPTION
## Summary
- mark the authenticated session as disconnected when DELETE /api/session/ is called
- invoke chatAPI.endSession when tearing down the chat client so backend state is cleared

## Testing
- python backend/manage.py test chat.tests.test_disconnect_user chat.tests.test_disconnected

------
https://chatgpt.com/codex/tasks/task_e_68d54f03696c8326bc3c60137ebb73c3