### PR TITLE
feat(getAppSettings): wire up GET /api/app-settings/

### DIFF
--- a/backend/core/tests/__init__.py
+++ b/backend/core/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jatte.settings")
+django.setup()

--- a/backend/core/tests/test_get_app_settings.py
+++ b/backend/core/tests/test_get_app_settings.py
@@ -1,14 +1,39 @@
+import jwt
+from django.conf import settings
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
+
 class GetAppSettingsTests(APITestCase):
+    def make_token(self, sub="user-1", email="user1@example.com"):
+        return jwt.encode(
+            {"sub": sub, "email": email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+
     def test_returns_settings(self):
-        url = reverse('core:app-settings')
-        res = self.client.get(url)
+        url = reverse("core:app-settings")
+        token = self.make_token()
+        res = self.client.get(
+            url,
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+            HTTP_HOST="localhost",
+        )
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data, {"file_uploads": True})
 
+    def test_requires_auth(self):
+        url = reverse("core:app-settings")
+        res = self.client.get(url, HTTP_HOST="localhost")
+        self.assertEqual(res.status_code, 403)
+
     def test_wrong_method(self):
-        url = reverse('core:app-settings')
-        res = self.client.post(url)
+        url = reverse("core:app-settings")
+        token = self.make_token()
+        res = self.client.post(
+            url,
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+            HTTP_HOST="localhost",
+        )
         self.assertEqual(res.status_code, 405)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,18 +1,18 @@
 from django.urls import path, re_path
 
-from . import views
 from accounts_supabase.views import UserAgentView
+from .views import AppSettingsView, about, get_tag, index
 
 app_name = "core"
 
 
 urlpatterns = [
-    path("", views.index, name="index"),
-    path("about/", views.about, name="about"),
-    path("api/app-settings/", views.get_app_settings, name="app-settings"),
-    re_path(r"^api/app-settings/?$", views.get_app_settings),
+    path("", index, name="index"),
+    path("about/", about, name="about"),
+    path("api/app-settings/", AppSettingsView.as_view(), name="app-settings"),
+    re_path(r"^api/app-settings/?$", AppSettingsView.as_view()),
     path("api/core-user-agent/", UserAgentView.as_view(), name="core-user-agent"),
     re_path(r"^api/core-user-agent/?$", UserAgentView.as_view()),
-    path("api/tag/", views.get_tag, name="tag"),
-    re_path(r"^api/tag/?$", views.get_tag),
+    path("api/tag/", get_tag, name="tag"),
+    re_path(r"^api/tag/?$", get_tag),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,5 +1,8 @@
+from accounts_supabase.authentication import SupabaseJWTAuthentication
 from rest_framework.decorators import api_view
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 
 @api_view(["GET"])
@@ -12,9 +15,14 @@ def about(request):
     return Response({"about": "Jatte headless backend"})
 
 
-@api_view(["GET"])
-def get_app_settings(request):
-    return Response({"file_uploads": True})
+class AppSettingsView(APIView):
+    """Return application-wide settings for the authenticated user."""
+
+    authentication_classes = [SupabaseJWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({"file_uploads": True})
 
 
 @api_view(["GET"])

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -19,9 +19,29 @@ export type Reminder = {
   created_at: string;
 };
 
+export type AppSettings = Record<string, unknown>;
+
 interface ErrorWithStatus extends Error {
   status?: number;
 }
+
+export const getAppSettings = async (): Promise<AppSettings> => {
+  const response = await fetch("/api/app-settings/", {
+    method: "GET",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to fetch app settings (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  return (await response.json()) as AppSettings;
+};
 
 async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<void> {
   const response = await fetch(
@@ -85,4 +105,5 @@ export const chatAPI = {
   createReminder,
   deleteMessage,
   endSession,
+  getAppSettings,
 };

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,7 +1,7 @@
 import { StateStore } from '../../chat-shim';
 import { stopTyping as stopTypingImpl } from '../../chat-shim/typing';
 
-import { chatAPI, type CreateReminderInput } from './api/chatAPI';
+import { chatAPI, type AppSettings, type CreateReminderInput } from './api/chatAPI';
 import {
   createMessage,
   type CreateMessagePayload,
@@ -748,11 +748,8 @@ export async function queryReactions(
   return resp.json();
 }
 
-export async function getAppSettings(): Promise<any> {
-  const resp = await fetch('/api/app-settings/', {
-    credentials: 'same-origin',
-  });
-  return resp.json();
+export async function getAppSettings(): Promise<AppSettings> {
+  return chatAPI.getAppSettings();
 }
 
 export async function getUserAgent(): Promise<string> {

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -9,15 +9,9 @@ import {
   Streami18n,
 } from '../../../i18n';
 
-import type {
-  AppSettingsAPIResponse,
-  Channel,
-  Event,
-  Mute,
-  OwnUserResponse,
-  StreamChat,
-} from 'chat-shim';
+import type { Channel, Event, Mute, OwnUserResponse, StreamChat } from 'chat-shim';
 import { query } from '../../../chatSDKShim';
+import { chatAPI, type AppSettings } from '../../../api/chatAPI';
 
 export type UseChatParams = {
   client: StreamChat;
@@ -48,16 +42,13 @@ export const useChat = ({
   const closeMobileNav = () => setNavOpen(false);
   const openMobileNav = () => setTimeout(() => setNavOpen(true), 100);
 
-  const appSettings = useRef<Promise<AppSettingsAPIResponse> | null>(null);
+  const appSettings = useRef<Promise<AppSettings> | null>(null);
 
   const getAppSettings = () => {
     if (appSettings.current) {
       return appSettings.current;
     }
-    appSettings.current = fetch('/api/app-settings/', {
-      method: 'GET',
-      credentials: 'same-origin',
-    }).then((res) => res.json() as Promise<AppSettingsAPIResponse>);
+    appSettings.current = chatAPI.getAppSettings();
     return appSettings.current;
   };
 

--- a/libs/stream-chat-shim/src/context/ChatContext.tsx
+++ b/libs/stream-chat-shim/src/context/ChatContext.tsx
@@ -1,11 +1,7 @@
 import React, { useContext } from 'react';
 import type { PropsWithChildren } from 'react';
-import type {
-  AppSettingsAPIResponse,
-  Channel,
-  Mute,
-  SearchController,
-} from 'chat-shim';
+import type { Channel, Mute, SearchController } from 'chat-shim';
+import type { AppSettings } from '../api/chatAPI';
 
 import { getDisplayName } from './utils/getDisplayName';
 import type { ChatProps } from '../components/Chat/Chat';
@@ -34,7 +30,7 @@ export type ChatContextValue = {
    */
   channelsQueryState: ChannelsQueryState;
   closeMobileNav: () => void;
-  getAppSettings: () => Promise<AppSettingsAPIResponse> | null;
+  getAppSettings: () => Promise<AppSettings> | null;
   latestMessageDatesByChannels: Record<ChannelConfId, Date>;
   mutes: Array<Mute>;
   openMobileNav: () => void;

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -141,17 +141,17 @@ paths:
       - about
   /api/app-settings/:
     get:
-      operationId: listget_app_settings
+      operationId: getAppSettings
       description: ''
       parameters: []
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
-                type: array
-                items: {}
-          description: ''
+                type: object
+                additionalProperties: true
       tags:
       - api
   /api/core-user-agent/:

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -69,7 +69,7 @@
     "stubName": "getAppSettings",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- enforce Supabase-authenticated access for `/api/app-settings/` and expose it through `AppSettingsView`
- expand core tests to exercise JWT flows (with Django setup helper) for the app settings endpoint
- add a typed `chatAPI.getAppSettings` helper and route shim/hooks through it, updating OpenAPI metadata

## Testing
- python backend/manage.py test core.tests.test_get_app_settings
- pnpm --filter frontend test -- --runTestsByPath frontend/__tests__/adapter/getAppSettings.test.ts *(fails: vitest not installed in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d55486a3188326ac20ae70acb84b33