### PR TITLE
feat(getMessage): wire up GET /api/rooms/{cid}/messages/{message_id}/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -132,8 +132,8 @@ class RoomMessageListCreateView(RoomFromCIDMixin, generics.ListCreateAPIView):
 # New Stream Chat API endpoints below
 
 
-class RoomMessageDeleteView(RoomFromCIDMixin, APIView):
-    """Delete a message in a room."""
+class RoomMessageDetailView(RoomFromCIDMixin, APIView):
+    """Retrieve or delete a message in a room."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
@@ -153,6 +153,12 @@ class RoomMessageDeleteView(RoomFromCIDMixin, APIView):
         if getattr(user, "is_staff", False) or getattr(user, "is_superuser", False):
             return True
         return False
+
+    def get(self, request, cid: str, message_id: int):
+        room = self._get_room(cid)
+        message = get_object_or_404(room.messages, id=message_id)
+        serializer = MessageSerializer(message)
+        return Response(serializer.data)
 
     def delete(self, request, cid: str, message_id: int):
         room = self._get_room(cid)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -4,7 +4,7 @@ from .api_views import (
     RoomListCreateView,
     RoomDetailView,
     RoomMessageListCreateView,
-    RoomMessageDeleteView,
+    RoomMessageDetailView,
     RoomMarkReadView,
     RoomMarkUnreadView,
     RoomCountUnreadView,
@@ -83,7 +83,7 @@ urlpatterns = [
     ),
     path(
         "api/rooms/<path:cid>/messages/<int:message_id>/",
-        RoomMessageDeleteView.as_view(),
+        RoomMessageDetailView.as_view(),
         name="room-message-delete",
     ),
     path(

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -21,6 +21,13 @@ export type Reminder = {
 
 export type AppSettings = Record<string, unknown>;
 
+export type Message = {
+  id: number;
+  body: string;
+  created_at: string;
+  sent_by: string;
+};
+
 interface ErrorWithStatus extends Error {
   status?: number;
 }
@@ -61,6 +68,33 @@ async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<
     throw errorWithStatus;
   }
 }
+
+export const getMessage = async ({
+  cid,
+  message_id,
+}: {
+  cid: string;
+  message_id: number;
+}): Promise<Message> => {
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(cid)}/messages/${encodeURIComponent(String(message_id))}/`,
+    {
+      method: "GET",
+      credentials: "same-origin",
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to fetch message (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  return (await response.json()) as Message;
+};
 
 async function createReminder({ cid, ...body }: CreateReminderInput): Promise<Reminder> {
   const response = await fetch(
@@ -105,5 +139,6 @@ export const chatAPI = {
   createReminder,
   deleteMessage,
   endSession,
+  getMessage,
   getAppSettings,
 };

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,7 +1,12 @@
 import { StateStore } from '../../chat-shim';
 import { stopTyping as stopTypingImpl } from '../../chat-shim/typing';
 
-import { chatAPI, type AppSettings, type CreateReminderInput } from './api/chatAPI';
+import {
+  chatAPI,
+  type AppSettings,
+  type CreateReminderInput,
+  type Message as APIMessage,
+} from './api/chatAPI';
 import {
   createMessage,
   type CreateMessagePayload,
@@ -320,12 +325,19 @@ export async function channelSendMessage(
 
 export async function channelStateLoadMessageIntoState(
   channel: {
+    cid: string;
     state?: {
       loadMessageIntoState?: (
         id: string,
         around?: string,
         limit?: number,
       ) => Promise<any>;
+      addMessageSorted?: (
+        message: Record<string, unknown>,
+        timestampChanged?: boolean,
+      ) => void;
+      messages?: Array<Record<string, unknown>>;
+      messagePagination?: { hasNext?: boolean; hasPrev?: boolean };
     };
   },
   messageId: string,
@@ -335,7 +347,81 @@ export async function channelStateLoadMessageIntoState(
   if (channel.state?.loadMessageIntoState) {
     return channel.state.loadMessageIntoState(messageId, around, messageLimit);
   }
-  return undefined;
+
+  const numericMessageId = Number(messageId);
+  if (!channel.cid || Number.isNaN(numericMessageId)) {
+    return undefined;
+  }
+
+  const apiMessage = await chatAPI.getMessage({
+    cid: channel.cid,
+    message_id: numericMessageId,
+  });
+
+  const normalizeMessage = (
+    message: APIMessage,
+  ): Record<string, unknown> & { id: string } => {
+    const createdAt = new Date(message.created_at);
+    const baseMessage = {
+      id: String(message.id),
+      cid: channel.cid,
+      created_at: createdAt,
+      updated_at: createdAt,
+      type: 'regular',
+      status: 'received',
+      text: message.body,
+      html: message.body,
+      body: message.body,
+      user: { id: message.sent_by },
+      user_id: message.sent_by,
+      latest_reactions: [] as unknown[],
+      own_reactions: [] as unknown[],
+      reaction_groups: {},
+    } as Record<string, unknown> & { id: string };
+
+    const existingMessage = channel.state?.messages?.find?.(
+      (msg) => String((msg as { id?: string | number }).id) === baseMessage.id,
+    );
+
+    return existingMessage ? { ...existingMessage, ...baseMessage } : baseMessage;
+  };
+
+  const normalizedMessage = normalizeMessage(apiMessage);
+
+  if (channel.state) {
+    channel.state.messagePagination ??= {};
+    channel.state.messagePagination.hasPrev ??= false;
+    channel.state.messagePagination.hasNext ??= false;
+
+    if (typeof channel.state.addMessageSorted === 'function') {
+      channel.state.addMessageSorted(normalizedMessage, true);
+    } else if (Array.isArray(channel.state.messages)) {
+      const existingIndex = channel.state.messages.findIndex(
+        (msg) => String((msg as { id?: string | number }).id) === normalizedMessage.id,
+      );
+
+      if (existingIndex >= 0) {
+        channel.state.messages.splice(existingIndex, 1, normalizedMessage);
+      } else {
+        channel.state.messages.push(normalizedMessage);
+        channel.state.messages.sort((a, b) => {
+          const aDate = new Date(
+            ((a as { created_at?: string | Date }).created_at ?? 0) as
+              | string
+              | Date,
+          ).getTime();
+          const bDate = new Date(
+            ((b as { created_at?: string | Date }).created_at ?? 0) as
+              | string
+              | Date,
+          ).getTime();
+          return aDate - bDate;
+        });
+      }
+    }
+  }
+
+  return normalizedMessage;
 }
 
 export async function channelWatch(

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -96,6 +96,30 @@ paths:
                 items:
                   $ref: '#/paths/~1rooms~1/get/responses/200/content/application~1json/schema/items'
   /api/rooms/{cid}/messages/{message_id}/:
+    get:
+      description: Retrieve a single message by id within a room.
+      operationId: getMessage
+      parameters:
+        - in: path
+          name: cid
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: message_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+        '404':
+          description: Not Found
+      tags: [api]
     delete:
       description: Delete a message in a room.
       operationId: deleteMessage

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -78,7 +78,7 @@
     "stubName": "findMessage",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add RoomMessageDetailView to serve both retrieval and deletion for room messages
- expose chatAPI.getMessage helper and load message data into channel state when SDK methods are unavailable
- document the new GET endpoint in the OpenAPI spec and update wireup metadata

## Testing
- pnpm --filter stream-chat-shim test

------
https://chatgpt.com/codex/tasks/task_e_68d559ea97788326a1643d7194260202