### PR TITLE
feat: wire up listRoomDrafts endpoint

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -20,6 +20,7 @@ from .models import (Channel, Draft, Flag, Message, Notification, Pin, Poll,
                      PollOption, Reaction, ReadState, Reminder, Room, RoomMute,
                      UserMute)
 from .serializers import (
+    DraftSerializer,
     FlagSerializer,
     MessageSerializer,
     NotificationSerializer,
@@ -277,8 +278,20 @@ class RoomDraftView(RoomFromCIDMixin, APIView):
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
+    def _user_has_access(self, request, room: Room) -> bool:
+        username = request.user.username
+        return (
+            room.agent_id == request.user.id
+            or room.client == username
+            or room.messages.filter(sent_by=username).exists()
+            or getattr(request.user, "is_staff", False)
+            or getattr(request.user, "is_superuser", False)
+        )
+
     def post(self, request, room_uuid):
         room = self.get_room(room_uuid)
+        if not self._user_has_access(request, room):
+            return Response(status=403)
         text = request.data.get("text", "")
         Draft.objects.update_or_create(
             user=request.user,
@@ -298,23 +311,34 @@ class RoomDraftView(RoomFromCIDMixin, APIView):
 
     def get(self, request, room_uuid):
         room = self.get_room(room_uuid)
-        text = None
+        if not self._user_has_access(request, room):
+            return Response(status=403)
+        cached_text = None
         try:
             r = redis.Redis(
                 host=settings.REDIS_HOST,
                 port=settings.REDIS_PORT,
                 decode_responses=True,
             )
-            text = r.get(f"draft:{request.user.username}:{room.uuid}")
+            cached_text = r.get(f"draft:{request.user.username}:{room.uuid}")
         except Exception:
             pass
-        if text is None:
-            draft = Draft.objects.filter(user=request.user, room=room).first()
-            text = draft.text if draft else ""
-        return Response({"text": text})
+        draft = Draft.objects.filter(user=request.user, room=room).first()
+        drafts = []
+        if draft:
+            draft_data = DraftSerializer(draft).data
+            if cached_text is not None:
+                draft_data["text"] = cached_text
+                draft_data["body"] = cached_text
+            drafts.append(draft_data)
+        elif cached_text is not None:
+            drafts.append({"text": cached_text, "body": cached_text})
+        return Response(drafts)
 
     def delete(self, request, room_uuid):
         room = self.get_room(room_uuid)
+        if not self._user_has_access(request, room):
+            return Response(status=403)
         Draft.objects.filter(user=request.user, room=room).delete()
         try:
             r = redis.Redis(

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import (Flag, Message, Notification, Pin, Poll, PollOption,
+from .models import (Draft, Flag, Message, Notification, Pin, Poll, PollOption,
                      Reaction, Reminder, Room)
 
 
@@ -28,6 +28,18 @@ class MessageSerializer(serializers.ModelSerializer):
             "updated_at",
             "deleted_at",
         ]
+
+
+class DraftSerializer(serializers.ModelSerializer):
+    body = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Draft
+        fields = ["id", "text", "body", "updated_at"]
+        read_only_fields = ["id", "text", "body", "updated_at"]
+
+    def get_body(self, obj: Draft) -> str:
+        return obj.text
 
 
 class RoomSerializer(serializers.ModelSerializer):

--- a/backend/chat/tests/test_create_draft.py
+++ b/backend/chat/tests/test_create_draft.py
@@ -10,7 +10,7 @@ class CreateDraftAPITests(APITestCase):
         return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
 
     def test_create_and_get_draft(self):
-        room = Room.objects.create(uuid="r1", client="c1")
+        room = Room.objects.create(uuid="r1", client="u1")
         token = self.make_token()
         url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
         res = self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
@@ -20,7 +20,8 @@ class CreateDraftAPITests(APITestCase):
 
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["text"], "hello")
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]["text"], "hello")
 
     def test_draft_requires_auth(self):
         room = Room.objects.create(uuid="r1", client="c1")
@@ -29,16 +30,27 @@ class CreateDraftAPITests(APITestCase):
         self.assertEqual(res.status_code, 403)
 
     def test_draft_wrong_method(self):
-        room = Room.objects.create(uuid="r1", client="c1")
+        room = Room.objects.create(uuid="r1", client="u1")
         token = self.make_token()
         url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
         res = self.client.put(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 405)
 
     def test_get_empty_draft(self):
-        room = Room.objects.create(uuid="r2", client="c1")
+        room = Room.objects.create(uuid="r2", client="u1")
         token = self.make_token()
         url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["text"], "")
+        self.assertEqual(res.data, [])
+
+    def test_draft_forbidden_for_non_member(self):
+        room = Room.objects.create(uuid="r3", client="someone-else")
+        token = self.make_token()
+        url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
+
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 403)
+
+        res = self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(res.status_code, 403)

--- a/backend/chat/tests/test_delete_draft.py
+++ b/backend/chat/tests/test_delete_draft.py
@@ -10,7 +10,7 @@ class DeleteDraftAPITests(APITestCase):
         return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
 
     def test_delete_draft(self):
-        room = Room.objects.create(uuid="r1", client="c1")
+        room = Room.objects.create(uuid="r1", client="u1")
         token = self.make_token()
         url = reverse("room-draft", kwargs={"room_uuid": room.uuid})
         self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")

--- a/frontend/__tests__/adapter/getDraft.test.js
+++ b/frontend/__tests__/adapter/getDraft.test.js
@@ -54,7 +54,7 @@ var originalFetch = global.fetch;
                 global.fetch.mockResolvedValue({
                     ok: true,
                     json: function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
-                        return [2 /*return*/, ({ text: 'hello' })];
+                        return [2 /*return*/, [{ text: 'hello' }]];
                     }); }); },
                 });
                 client = new ChatClient_1.ChatClient('u1', 'jwt-test');

--- a/frontend/__tests__/adapter/getDraft.test.ts
+++ b/frontend/__tests__/adapter/getDraft.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 test('getDraft fetches saved draft and updates text', async () => {
   (global.fetch as any).mockResolvedValue({
     ok: true,
-    json: async () => ({ text: 'hello' }),
+    json: async () => [{ text: 'hello' }],
   });
   const client = new ChatClient('u1', 'jwt-test');
   const channel = client.channel('messaging', 'room1');

--- a/frontend/src/lib/stream-adapter/Channel.js
+++ b/frontend/src/lib/stream-adapter/Channel.js
@@ -440,7 +440,7 @@ var Channel = /** @class */ (function () {
                     /** Fetch draft from the backend and sync local state */
                     getDraft: function () {
                         return __awaiter(this, void 0, void 0, function () {
-                            var token, res, data, text;
+                            var token, res, data, drafts, firstDraft, text;
                             return __generator(this, function (_a) {
                                 switch (_a.label) {
                                     case 0:
@@ -454,10 +454,16 @@ var Channel = /** @class */ (function () {
                                         res = _a.sent();
                                         if (!res.ok)
                                             throw new Error('getDraft failed');
-                                        return [4 /*yield*/, res.json().catch(function () { return ({ text: '' }); })];
+                                        return [4 /*yield*/, res.json().catch(function () { return []; })];
                                     case 2:
                                         data = _a.sent();
-                                        text = typeof data.text === 'string' ? data.text : '';
+                                        drafts = Array.isArray(data) ? data : [];
+                                        firstDraft = drafts[0] || {};
+                                        text = typeof firstDraft.text === 'string'
+                                            ? firstDraft.text
+                                            : typeof firstDraft.body === 'string'
+                                                ? firstDraft.body || ''
+                                                : '';
                                         textStore._set({ text: text });
                                         return [2 /*return*/, text];
                                 }

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -354,8 +354,15 @@ export class Channel {
                         headers: { Authorization: `Bearer ${token}` },
                     });
                     if (!res.ok) throw new Error('getDraft failed');
-                    const data = await res.json().catch(() => ({ text: '' }));
-                    const text = typeof data.text === 'string' ? data.text : '';
+                    const data = await res.json().catch(() => []);
+                    const drafts = Array.isArray(data) ? data : [];
+                    const firstDraft = drafts[0] ?? {};
+                    const text =
+                        typeof firstDraft.text === 'string'
+                            ? firstDraft.text
+                            : typeof firstDraft.body === 'string'
+                              ? firstDraft.body ?? ''
+                              : '';
                     textStore._set({ text });
                     return text;
                 },

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -28,6 +28,15 @@ export type Message = {
   sent_by: string;
 };
 
+export interface RoomDraft {
+  id?: number;
+  text?: string;
+  body?: string;
+  created_at?: string;
+  updated_at?: string;
+  [k: string]: unknown;
+}
+
 interface ErrorWithStatus extends Error {
   status?: number;
 }
@@ -96,6 +105,32 @@ export const getMessage = async ({
   return (await response.json()) as Message;
 };
 
+export const listRoomDrafts = async ({
+  room_uuid,
+}: {
+  room_uuid: string;
+}): Promise<RoomDraft[]> => {
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(room_uuid)}/draft/`,
+    {
+      method: 'GET',
+      credentials: 'same-origin',
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to fetch room drafts (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  const data = await response.json().catch(() => []);
+  return Array.isArray(data) ? (data as RoomDraft[]) : [];
+};
+
 async function createReminder({ cid, ...body }: CreateReminderInput): Promise<Reminder> {
   const response = await fetch(
     `/api/rooms/${encodeURIComponent(cid)}/reminders/`,
@@ -141,4 +176,5 @@ export const chatAPI = {
   endSession,
   getMessage,
   getAppSettings,
+  listRoomDrafts,
 };

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -6,6 +6,7 @@ import {
   type AppSettings,
   type CreateReminderInput,
   type Message as APIMessage,
+  type RoomDraft,
 } from './api/chatAPI';
 import {
   createMessage,
@@ -856,12 +857,19 @@ export async function setUserAgent(userAgent: string): Promise<{ status: string 
   return resp.json();
 }
 
-export async function getDraft(roomUuid: string): Promise<{ text?: string }> {
-  const resp = await fetch(
-    `/api/rooms/${encodeURIComponent(roomUuid)}/draft/`,
-    { credentials: 'same-origin' },
-  );
-  return resp.json();
+export async function getDraft(roomUuid: string): Promise<RoomDraft> {
+  const drafts = await chatAPI.listRoomDrafts({ room_uuid: roomUuid });
+  const firstDraft = drafts[0];
+  if (firstDraft) {
+    const text =
+      typeof firstDraft.text === 'string'
+        ? firstDraft.text
+        : typeof firstDraft.body === 'string'
+          ? (firstDraft.body as string) ?? ''
+          : '';
+    return { ...firstDraft, text, body: firstDraft.body ?? text };
+  }
+  return { text: '' };
 }
 
 

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -14,7 +14,19 @@ paths:
             application/json:
               schema:
                 type: array
-                items: {}
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    text:
+                      type: string
+                    body:
+                      type: string
+                    updated_at:
+                      type: string
+                      format: date-time
+                  additionalProperties: true
           description: ''
       tags:
       - api
@@ -45,7 +57,19 @@ paths:
             application/json:
               schema:
                 type: array
-                items: {}
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    text:
+                      type: string
+                    body:
+                      type: string
+                    updated_at:
+                      type: string
+                      format: date-time
+                  additionalProperties: true
           description: ''
       tags:
       - api
@@ -256,7 +280,19 @@ paths:
             application/json:
               schema:
                 type: array
-                items: {}
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    text:
+                      type: string
+                    body:
+                      type: string
+                    updated_at:
+                      type: string
+                      format: date-time
+                  additionalProperties: true
           description: ''
       tags:
       - api


### PR DESCRIPTION
## Summary
- restrict room draft access to members, expose a draft serializer, and return a list of drafts from GET /api/rooms/{room_uuid}/draft/
- add a typed chatAPI.listRoomDrafts helper and route the shim getDraft call through it
- hydrate the frontend message composer from the array response and document the OpenAPI draft schema

## Testing
- `pytest backend/chat/tests/test_create_draft.py backend/chat/tests/test_delete_draft.py` *(fails: fixture 'settings' not found)*
- `pnpm --filter frontend test -- --runTestsByPath frontend/__tests__/adapter/getDraft.test.ts` *(fails: vitest command missing; install dependencies to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d567ceb06483268266c4efa6477ee3