### PR TITLE
feat(muteStatus): wire up GET /api/rooms/{cid}/mute/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -23,6 +23,7 @@ from .serializers import (
     DraftSerializer,
     FlagSerializer,
     MessageSerializer,
+    MuteStatusSerializer,
     NotificationSerializer,
     PinSerializer,
     PollOptionSerializer,
@@ -615,6 +616,22 @@ class RoomConfigView(RoomFromCIDMixin, APIView):
         muted = RoomMute.objects.filter(user=request.user, room=room).exists()
 
         return Response({"name": name, "type": room_type, "muted": muted})
+
+
+class RoomMuteStatusView(RoomFromCIDMixin, APIView):
+    """Return mute status for the current user in the given room."""
+
+    authentication_classes = [DevTokenOrJWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, cid: str):
+        room = self.get_room(cid)
+        mute = RoomMute.objects.filter(user=request.user, room=room).first()
+        muted_until = getattr(mute, "muted_until", None)
+        serializer = MuteStatusSerializer(
+            {"muted": mute is not None, "muted_until": muted_until}
+        )
+        return Response(serializer.data)
 
 
 class RoomConfigStateView(RoomFromCIDMixin, APIView):

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -1,7 +1,19 @@
+from datetime import datetime
+
 from rest_framework import serializers
 
-from .models import (Draft, Flag, Message, Notification, Pin, Poll, PollOption,
-                     Reaction, Reminder, Room)
+from .models import (
+    Draft,
+    Flag,
+    Message,
+    Notification,
+    Pin,
+    Poll,
+    PollOption,
+    Reaction,
+    Reminder,
+    Room,
+)
 
 
 class MessageSerializer(serializers.ModelSerializer):
@@ -184,3 +196,17 @@ class ReminderCreateSerializer(serializers.Serializer):
             remind_at=validated_data["remind_at"],
         )
         return reminder
+
+
+class MuteStatusSerializer(serializers.Serializer):
+    muted = serializers.BooleanField()
+    muted_until = serializers.DateTimeField(allow_null=True, required=False)
+
+    def to_representation(self, instance):
+        muted = bool(instance.get("muted")) if isinstance(instance, dict) else False
+        muted_until = None
+        if isinstance(instance, dict):
+            muted_until = instance.get("muted_until")
+            if isinstance(muted_until, datetime):
+                muted_until = muted_until.isoformat()
+        return {"muted": muted, "muted_until": muted_until}

--- a/backend/chat/tests/test_room_mute_status.py
+++ b/backend/chat/tests/test_room_mute_status.py
@@ -1,0 +1,63 @@
+from django.conf import settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+import jwt
+
+from chat.models import Room, RoomMute
+from accounts_supabase.models import CustomUser
+
+
+class RoomMuteStatusAPITests(APITestCase):
+    def make_token(self, sub="u1", email="u1@example.com"):
+        return jwt.encode(
+            {"sub": sub, "email": email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            username="u1",
+            email="u1@example.com",
+            password="x",
+            supabase_uid="u1",
+        )
+
+    def test_returns_false_when_not_muted(self):
+        room = Room.objects.create(uuid="r1", client="stream")
+        token = self.make_token()
+        url = reverse("room-mute-status", kwargs={"cid": f"messaging:{room.uuid}"})
+
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, {"muted": False, "muted_until": None})
+
+    def test_returns_true_when_muted(self):
+        room = Room.objects.create(uuid="r2", client="stream")
+        RoomMute.objects.create(user=self.user, room=room)
+        token = self.make_token()
+        url = reverse("room-mute-status", kwargs={"cid": f"messaging:{room.uuid}"})
+
+        res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.data["muted"])
+        self.assertIsNone(res.data["muted_until"])
+
+    def test_requires_authentication(self):
+        room = Room.objects.create(uuid="r3", client="stream")
+        url = reverse("room-mute-status", kwargs={"cid": f"messaging:{room.uuid}"})
+
+        res = self.client.get(url)
+
+        self.assertEqual(res.status_code, 403)
+
+    def test_rejects_wrong_method(self):
+        room = Room.objects.create(uuid="r4", client="stream")
+        token = self.make_token()
+        url = reverse("room-mute-status", kwargs={"cid": f"messaging:{room.uuid}"})
+
+        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        self.assertEqual(res.status_code, 405)

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -11,6 +11,7 @@ from .api_views import (
     RoomLastReadView,
     RoomReadView,
     RoomConfigView,
+    RoomMuteStatusView,
     MessageDetailView,
     MessageRepliesView,
     MessageReactionsView,
@@ -120,6 +121,11 @@ urlpatterns = [
         "api/rooms/<path:cid>/config/",
         RoomConfigView.as_view(),
         name="room-config",
+    ),
+    path(
+        "api/rooms/<path:cid>/mute/",
+        RoomMuteStatusView.as_view(),
+        name="room-mute-status",
     ),
     path("api/rooms/<str:room_uuid>/config-state/", RoomConfigStateView.as_view(), name="room-config-state"),
     path(

--- a/libs/chat-shim/__tests__/localChannel.test.ts
+++ b/libs/chat-shim/__tests__/localChannel.test.ts
@@ -22,13 +22,17 @@ describe('LocalChannel', () => {
     expect(channel.stateStore.getState().messages).toEqual([]);
   });
 
-  test('muteStatus reflects client state', async () => {
+  test('setMuteStatus updates mute cache', async () => {
     const client = new LocalChatClient();
     await client.connectUser({ id: 'u1' }, 'jwt');
     const channel = client.channel('messaging', 'general');
     await channel.watch();
-    expect(channel.muteStatus().muted).toBe(false);
-    (client as any).mutedChannels.push(channel.cid);
+    expect(channel.muteStatus()).toEqual({ muted: false, muted_until: null });
+    channel.setMuteStatus({ muted: true, muted_until: null });
     expect(channel.muteStatus().muted).toBe(true);
+    expect(client.mutedChannels).toContain(channel.cid);
+    channel.setMuteStatus({ muted: false, muted_until: null });
+    expect(channel.muteStatus().muted).toBe(false);
+    expect(client.mutedChannels).not.toContain(channel.cid);
   });
 });

--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -67,7 +67,8 @@ declare module 'stream-chat' {
     off(evt: string, cb: (ev: any) => void): void;
     markRead(): void;
     countUnread(): number;
-    muteStatus(): { muted: boolean };
+    muteStatus(): { muted: boolean; muted_until: string | null };
+    setMuteStatus(status: { muted: boolean; muted_until: string | null }): void;
     getClient(): LocalChatClient;
     getConfig(): { typing_events: boolean; read_events: boolean };
   }

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -62,6 +62,8 @@ export class FixedSizeQueueCache<T = any> {
 
 /* -------------------------------- Channel -------------------------------- */
 
+type ChannelMuteStatus = { muted: boolean; muted_until: string | null };
+
 export class ChannelState {
   messages: any[] = [];
   messagePagination = { hasPrev: false, hasNext: false };
@@ -107,6 +109,7 @@ export class LocalChannel {
   /** Store wrapper used by Stream UI hooks */
   readonly stateStore: StateStore<ChannelState>;
   private getUserId: () => string;
+  private muteStatusState: ChannelMuteStatus = { muted: false, muted_until: null };
 
   constructor(
     readonly cid: string,
@@ -176,9 +179,32 @@ export class LocalChannel {
   }
 
   /** Return whether this channel is muted for the current user */
-  muteStatus() {
-    const muted = this.client.mutedChannels.includes(this.cid);
-    return { muted };
+  muteStatus(): ChannelMuteStatus {
+    return { ...this.muteStatusState };
+  }
+
+  setMuteStatus(status: ChannelMuteStatus) {
+    const rawUntil = status?.muted_until;
+    let muted_until: string | null = null;
+    if (typeof rawUntil === "string") {
+      muted_until = rawUntil;
+    } else if (rawUntil instanceof Date) {
+      muted_until = rawUntil.toISOString();
+    }
+
+    this.muteStatusState = {
+      muted: Boolean(status?.muted),
+      muted_until,
+    };
+
+    const index = this.client.mutedChannels.indexOf(this.cid);
+    if (this.muteStatusState.muted) {
+      if (index === -1) {
+        this.client.mutedChannels.push(this.cid);
+      }
+    } else if (index !== -1) {
+      this.client.mutedChannels.splice(index, 1);
+    }
   }
 
   /** Expose the parent client instance */
@@ -205,7 +231,7 @@ export class LocalChatClient {
   clientID = "";
   activeChannels: Record<string, LocalChannel> = {};
   listeners: Record<string, Handler[]> = {};
-  mutedChannels: any[] = [];
+  mutedChannels: string[] = [];
 
   /** Minimal threads helper expected by Stream UI */
   threads = {

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -23,6 +23,8 @@ export type AppSettings = Record<string, unknown>;
 
 export type UserAgentInfo = { user_agent: string };
 
+export type MuteStatus = { muted: boolean; muted_until: string | null };
+
 export type Message = {
   id: number;
   body: string;
@@ -100,6 +102,34 @@ async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<
     throw errorWithStatus;
   }
 }
+
+export const muteStatus = async ({ cid }: { cid: string }): Promise<MuteStatus> => {
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(cid)}/mute/`,
+    {
+      method: "GET",
+      credentials: "same-origin",
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to fetch mute status (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  const data = (await response.json()) as Partial<MuteStatus>;
+  return {
+    muted: Boolean(data?.muted),
+    muted_until:
+      typeof data?.muted_until === "string" || data?.muted_until === null
+        ? (data?.muted_until ?? null)
+        : null,
+  };
+};
 
 export const getMessage = async ({
   cid,
@@ -199,6 +229,7 @@ export const chatAPI = {
   endSession,
   getMessage,
   getAppSettings,
+  muteStatus,
   listRoomDrafts,
   listUserAgents,
 };

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
@@ -1,22 +1,114 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import { chatAPI, type MuteStatus } from '../../../api/chatAPI';
 import { useChatContext } from '../../../context/ChatContext';
 
 import type { Channel } from 'chat-shim';
 
-export const useIsChannelMuted = (channel: Channel) => {
+const DEFAULT_STATUS: MuteStatus = { muted: false, muted_until: null };
+
+const normalizeStatus = (status: unknown): MuteStatus => {
+  if (!status || typeof status !== 'object') {
+    return DEFAULT_STATUS;
+  }
+
+  const maybe = status as Partial<MuteStatus> & Record<string, unknown>;
+  let muted_until: string | null = null;
+
+  if (typeof maybe.muted_until === 'string') {
+    muted_until = maybe.muted_until;
+  } else if (maybe.muted_until instanceof Date) {
+    muted_until = maybe.muted_until.toISOString();
+  } else if (maybe.muted_until === null) {
+    muted_until = null;
+  }
+
+  return {
+    muted: Boolean(maybe.muted),
+    muted_until,
+  };
+};
+
+export const useIsChannelMuted = (channel: Channel): MuteStatus => {
   const { client } = useChatContext('useIsChannelMuted');
 
-  const [muted, setMuted] = useState(channel.muteStatus().muted);
+  const initialStatus = useMemo(() => {
+    const existing = typeof channel.muteStatus === 'function'
+      ? channel.muteStatus()
+      : undefined;
+    const normalized = normalizeStatus(existing);
+    const channelWithSetter = channel as Channel & {
+      setMuteStatus?: (s: MuteStatus) => void;
+    };
+    if (typeof channelWithSetter.setMuteStatus === 'function') {
+      channelWithSetter.setMuteStatus(normalized);
+    }
+    return normalized;
+  }, [channel]);
+
+  const [status, setStatus] = useState<MuteStatus>(initialStatus);
 
   useEffect(() => {
-    const handleEvent = () => setMuted(channel.muteStatus().muted);
+    setStatus(normalizeStatus(
+      typeof channel.muteStatus === 'function' ? channel.muteStatus() : undefined,
+    ));
+  }, [channel]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const applyStatus = (next: MuteStatus) => {
+      if (!isMounted) return;
+      setStatus(next);
+
+      const channelWithSetter = channel as Channel & {
+        setMuteStatus?: (s: MuteStatus) => void;
+        getClient?: () => { mutedChannels?: string[] };
+      };
+
+      if (typeof channelWithSetter.setMuteStatus === 'function') {
+        channelWithSetter.setMuteStatus(next);
+      } else {
+        const fallbackStatus: MuteStatus = { ...next };
+        channelWithSetter.muteStatus = () => fallbackStatus;
+        const clientInstance = channelWithSetter.getClient?.();
+        if (clientInstance && Array.isArray(clientInstance.mutedChannels)) {
+          const index = clientInstance.mutedChannels.indexOf(channel.cid);
+          if (next.muted && index === -1) {
+            clientInstance.mutedChannels.push(channel.cid);
+          } else if (!next.muted && index !== -1) {
+            clientInstance.mutedChannels.splice(index, 1);
+          }
+        }
+      }
+    };
+
+    const fetchStatus = async () => {
+      try {
+        const data = await chatAPI.muteStatus({ cid: channel.cid });
+        applyStatus(data);
+      } catch (error) {
+        // Swallow errors to keep optimistic UI behaviour consistent with Stream UI.
+      }
+    };
+
+    void fetchStatus();
+
+    const handleEvent = () => {
+      void fetchStatus();
+    };
+
+    const subscription = client.on?.('notification.mutes_updated', handleEvent);
 
     return () => {
-      /* TODO backend-wire-up: client.off */
+      isMounted = false;
+      if (subscription?.unsubscribe) {
+        subscription.unsubscribe();
+      } else if (typeof client?.off === 'function') {
+        client.off('notification.mutes_updated', handleEvent);
+      }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [muted]);
+  }, [channel, client]);
 
-  return muted;
+  return status;
 };

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -380,6 +380,26 @@ paths:
           description: ''
       tags:
       - api
+  /api/rooms/{cid}/mute/:
+    get:
+      operationId: muteStatus
+      description: Return whether the current user has muted this room.
+      parameters:
+      - name: cid
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MuteStatus'
+          description: ''
+      tags:
+      - api
   /api/rooms/{cid}/config/:
     get:
       operationId: listRoomConfigs
@@ -674,6 +694,17 @@ paths:
       - api
 components:
   schemas:
+    MuteStatus:
+      type: object
+      properties:
+        muted:
+          type: boolean
+        muted_until:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - muted
     User:
       type: object
       properties:

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -120,6 +120,24 @@ paths:
         '404':
           description: Not Found
       tags: [api]
+  /api/rooms/{cid}/mute/:
+    get:
+      description: Return whether the current user has muted this room.
+      operationId: muteStatus
+      parameters:
+        - in: path
+          name: cid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MuteStatus'
+      tags: [api]
     delete:
       description: Delete a message in a room.
       operationId: deleteMessage
@@ -778,6 +796,16 @@ paths:
                     type: string
 components:
   schemas:
+    MuteStatus:
+      type: object
+      properties:
+        muted:
+          type: boolean
+        muted_until:
+          type: string
+          format: date-time
+          nullable: true
+      required: [muted]
     ReminderCreate:
       type: object
       properties:

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -108,13 +108,13 @@
     "status": "missing"
   },
   {
-    "method": "",
-    "path": "",
+    "method": "get",
+    "path": "/api/rooms/{cid}/mute/",
     "operationId": "muteStatus",
     "stubName": "channel.muteStatus",
     "ticketType": "api",
-    "todoCount": 2,
-    "status": "missing"
+    "todoCount": 0,
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a read-only mute status serializer, DRF view, URL, and tests for GET `/api/rooms/{cid}/mute/`
- expose the new endpoint via chatAPI, channel mute state helpers, and the ChannelPreview hook
- document the operation in the OpenAPI specs and mark the wire-up manifest entry as complete

## Testing
- `python -m pytest chat/tests/test_room_mute_status.py` *(fails: missing pytest-django settings fixture in this environment)*
- `pnpm exec jest libs/chat-shim/__tests__/localChannel.test.ts` *(fails: workspace jest binary unavailable without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d574604d6883268dedcb6f481d8048