### PR TITLE
feat(setUserAgent): wire up POST /api/user-agent/

### DIFF
--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -1,8 +1,8 @@
 # backend/accounts_supabase/views.py
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
-from rest_framework import generics, serializers
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework import generics, serializers, status
 from django.contrib.auth import get_user_model
 from accounts_supabase.authentication import SupabaseJWTAuthentication
 from accounts_supabase.models import UserProfile
@@ -43,13 +43,36 @@ class ClientIDView(APIView):
         return Response({"client_id": uuid.uuid4().hex})
 
 
+class UserAgentSerializer(serializers.Serializer):
+    user_agent = serializers.CharField(required=False, allow_blank=True)
+
+
 class UserAgentView(APIView):
     authentication_classes = [SupabaseJWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    def get_authenticators(self):
+        if self.request.method == "GET":
+            return []
+        return super().get_authenticators()
+
+    def get_permissions(self):
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return super().get_permissions()
+
     def post(self, request):
-        request.session['user_agent'] = request.data.get('user_agent', '')
-        return Response({"status": "ok"})
+        serializer = UserAgentSerializer(data=request.data or {})
+        serializer.is_valid(raise_exception=True)
+        user_agent = serializer.validated_data.get(
+            "user_agent",
+            request.META.get("HTTP_USER_AGENT", ""),
+        )
+        if user_agent is None:
+            user_agent = request.META.get("HTTP_USER_AGENT", "")
+
+        request.session['user_agent'] = user_agent
+        return Response({"user_agent": user_agent}, status=status.HTTP_201_CREATED)
 
     def get(self, request):
         user_agent = request.META.get("HTTP_USER_AGENT", "")

--- a/backend/chat/tests/test_set_user_agent.py
+++ b/backend/chat/tests/test_set_user_agent.py
@@ -9,21 +9,25 @@ class UserAgentAPITests(APITestCase):
 
     def test_set_and_get_user_agent(self):
         token = self.make_token()
-        post_url = reverse("core-user-agent")
-        res = self.client.post(post_url, {"user_agent": "ua1"}, HTTP_AUTHORIZATION=f"Bearer {token}")
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["status"], "ok")
+        url = reverse("user-agent")
+        res = self.client.post(
+            url,
+            {"user_agent": "ua1"},
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data["user_agent"], "ua1")
 
-        get_url = reverse("user-agent")
-        res = self.client.get(
-            get_url,
+        res = self.client.post(
+            url,
+            {},
             HTTP_AUTHORIZATION=f"Bearer {token}",
             HTTP_USER_AGENT="ua2",
         )
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, 201)
         self.assertEqual(res.data["user_agent"], "ua2")
 
     def test_user_agent_requires_auth(self):
-        url = reverse("core-user-agent")
+        url = reverse("user-agent")
         res = self.client.post(url, {"user_agent": "ua"})
         self.assertEqual(res.status_code, 403)

--- a/backend/core/tests/test_get_user_agent.py
+++ b/backend/core/tests/test_get_user_agent.py
@@ -8,7 +8,7 @@ class GetUserAgentTests(APITestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data, {'user_agent': 'Vitest'})
 
-    def test_wrong_method(self):
+    def test_post_requires_auth(self):
         url = reverse('core:user-agent')
         res = self.client.post(url)
-        self.assertEqual(res.status_code, 405)
+        self.assertEqual(res.status_code, 403)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 
 from accounts_supabase.views import UserAgentView
-from .views import AppSettingsView, about, get_tag, index
+from .views import AppSettingsView, about, get_tag, get_user_agent, index
 
 app_name = "core"
 
@@ -11,6 +11,8 @@ urlpatterns = [
     path("about/", about, name="about"),
     path("api/app-settings/", AppSettingsView.as_view(), name="app-settings"),
     re_path(r"^api/app-settings/?$", AppSettingsView.as_view()),
+    path("api/user-agent/", get_user_agent, name="user-agent"),
+    re_path(r"^api/user-agent/?$", get_user_agent),
     path("api/core-user-agent/", UserAgentView.as_view(), name="core-user-agent"),
     re_path(r"^api/core-user-agent/?$", UserAgentView.as_view()),
     path("api/tag/", get_tag, name="tag"),

--- a/libs/stream-chat-shim/__tests__/setUserAgent.test.ts
+++ b/libs/stream-chat-shim/__tests__/setUserAgent.test.ts
@@ -4,16 +4,20 @@ describe('setUserAgent', () => {
   it('POSTs user agent to backend', async () => {
     const fetchMock = jest
       .fn()
-      .mockResolvedValue({ json: () => Promise.resolve({ status: 'ok' }) });
+      .mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: () => Promise.resolve({ user_agent: 'ua/1' }),
+      });
     // @ts-ignore
     global.fetch = fetchMock;
     const res = await setUserAgent('ua/1');
-    expect(fetchMock).toHaveBeenCalledWith('/api/core-user-agent/', {
+    expect(fetchMock).toHaveBeenCalledWith('/api/user-agent/', {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ user_agent: 'ua/1' }),
     });
-    expect(res).toEqual({ status: 'ok' });
+    expect(res).toEqual({ user_agent: 'ua/1' });
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -22,6 +22,7 @@ export type Reminder = {
 export type AppSettings = Record<string, unknown>;
 
 export type UserAgentInfo = { user_agent: string };
+export type SetUserAgentInput = Partial<UserAgentInfo>;
 
 export type MuteStatus = { muted: boolean; muted_until: string | null };
 
@@ -92,6 +93,40 @@ export const listUserAgents = async (): Promise<UserAgentInfo> => {
   return {
     user_agent: typeof data.user_agent === "string" ? data.user_agent : "",
   };
+};
+
+export const setUserAgent = async (
+  body: SetUserAgentInput = {},
+): Promise<UserAgentInfo> => {
+  const payload = { ...body };
+  const hasBody = Object.keys(payload).length > 0;
+  const options: RequestInit = {
+    method: "POST",
+    credentials: "same-origin",
+  };
+
+  if (hasBody) {
+    options.headers = { "Content-Type": "application/json" };
+    options.body = JSON.stringify(payload);
+  }
+
+  const response = await fetch("/api/user-agent/", options);
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to set user agent (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  const data = (await response.json()) as Partial<UserAgentInfo>;
+  if (typeof data.user_agent !== "string") {
+    throw new Error("Invalid user agent response");
+  }
+
+  return { user_agent: data.user_agent };
 };
 
 async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<void> {
@@ -299,4 +334,5 @@ export const chatAPI = {
   muteStatus,
   listRoomDrafts,
   listUserAgents,
+  setUserAgent,
 };

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -8,6 +8,7 @@ import {
   type Message as APIMessage,
   type MuteUserInput,
   type RoomDraft,
+  type UserAgentInfo,
 } from './api/chatAPI';
 import {
   createMessage,
@@ -845,14 +846,10 @@ export async function getUserAgent(): Promise<string> {
   return user_agent;
 }
 
-export async function setUserAgent(userAgent: string): Promise<{ status: string }> {
-  const resp = await fetch('/api/core-user-agent/', {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_agent: userAgent }),
-  });
-  return resp.json();
+export async function setUserAgent(userAgent: string): Promise<UserAgentInfo> {
+  return chatAPI.setUserAgent(
+    typeof userAgent === 'string' ? { user_agent: userAgent } : {},
+  );
 }
 
 export async function getDraft(roomUuid: string): Promise<RoomDraft> {

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -56,12 +56,25 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  user_agent:
-                    type: string
-                required:
-                  - user_agent
+                $ref: '#/components/schemas/UserAgentInfo'
+      tags:
+      - api
+    post:
+      operationId: setUserAgent
+      description: Set or report the client User-Agent for the current user/session.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserAgentInfo'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAgentInfo'
       tags:
       - api
   /api/user/:
@@ -167,31 +180,6 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-      tags:
-      - api
-  /api/core-user-agent/:
-    post:
-      operationId: setUserAgent
-      description: ''
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user_agent:
-                  type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-          description: ok
       tags:
       - api
   /api/tag/:
@@ -751,6 +739,13 @@ components:
           maxLength: 150
       required:
       - username
+    UserAgentInfo:
+      type: object
+      properties:
+        user_agent:
+          type: string
+      required:
+      - user_agent
     Message:
       type: object
       properties:

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -303,28 +303,6 @@ paths:
                     type: integer
                   username:
                     type: string
-  /core-user-agent/:
-    post:
-      operationId: setUserAgent
-      tags: [users]
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user_agent:
-                  type: string
-      responses:
-        '200':
-          description: ok
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
   /user-agent/:
     get:
       operationId: listUserAgents
@@ -335,10 +313,24 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  user_agent:
-                    type: string
+                $ref: '#/components/schemas/UserAgentInfo'
+    post:
+      operationId: setUserAgent
+      description: Set or report the client User-Agent for the current user/session.
+      tags: [users]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserAgentInfo'
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAgentInfo'
   /notifications/:
     get:
       operationId: listNotifications
@@ -838,6 +830,12 @@ components:
           type: string
           format: date-time
           readOnly: true
+    UserAgentInfo:
+      type: object
+      properties:
+        user_agent:
+          type: string
+      required: [user_agent]
     ReminderCreate:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- add a serializer-backed POST /api/user-agent/ that records the session user agent and returns the stored value
- exercise the new behavior in Django tests and wire the shim helper to call the typed chatAPI.setUserAgent
- document the endpoint in the OpenAPI specs for both backend and frontend

## Testing
- python manage.py test chat.tests.test_set_user_agent core.tests.test_get_user_agent
- pnpm exec jest libs/stream-chat-shim/__tests__/setUserAgent.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d596e4b84083268bfac2da6989a7cc