### PR TITLE
feat(listUsers): wire up GET /api/users/

### DIFF
--- a/backend/accounts_supabase/views.py
+++ b/backend/accounts_supabase/views.py
@@ -86,6 +86,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class QueryUsersView(generics.ListAPIView):
+    """List users."""
     authentication_classes = [SupabaseJWTAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = UserSerializer

--- a/libs/stream-chat-shim/__tests__/client.queryUsers.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.queryUsers.test.ts
@@ -3,11 +3,17 @@ import { clientQueryUsers } from '../src/chatSDKShim';
 describe('clientQueryUsers', () => {
   it('fetches users from backend', async () => {
     const users = [{ id: 1, username: 'test' }];
-    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve(users) });
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(users),
+    });
     // @ts-ignore
     global.fetch = fetchMock;
     const res = await clientQueryUsers();
-    expect(fetchMock).toHaveBeenCalledWith('/api/users/', { credentials: 'same-origin' });
+    expect(fetchMock).toHaveBeenCalledWith('/api/users/', {
+      credentials: 'same-origin',
+      method: 'GET',
+    });
     expect(res).toEqual({ users });
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -36,6 +36,8 @@ export type Mute = {
 
 export type MuteUserInput = { cid: string; user_id: number; muted_until?: string };
 
+export type User = { id: number; username: string };
+
 export type Message = {
   id: number;
   body: string;
@@ -127,6 +129,42 @@ export const setUserAgent = async (
   }
 
   return { user_agent: data.user_agent };
+};
+
+export const listUsers = async (): Promise<User[]> => {
+  const response = await fetch("/api/users/", {
+    method: "GET",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    const error = new Error(`Failed to fetch users (status ${response.status})`);
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  const data = (await response.json()) as unknown;
+
+  if (!Array.isArray(data)) {
+    throw new Error("Invalid users response");
+  }
+
+  return data.map((item) => {
+    if (!item || typeof item !== "object") {
+      throw new Error("Invalid users response item");
+    }
+
+    const candidate = item as Record<string, unknown>;
+    if (
+      typeof candidate.id !== "number" ||
+      typeof candidate.username !== "string"
+    ) {
+      throw new Error("Invalid users response item");
+    }
+
+    return { id: candidate.id, username: candidate.username };
+  });
 };
 
 async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<void> {
@@ -333,6 +371,7 @@ export const chatAPI = {
   getAppSettings,
   muteStatus,
   listRoomDrafts,
+  listUsers,
   listUserAgents,
   setUserAgent,
 };

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -8,6 +8,7 @@ import {
   type Message as APIMessage,
   type MuteUserInput,
   type RoomDraft,
+  type User,
   type UserAgentInfo,
 } from './api/chatAPI';
 import {
@@ -623,10 +624,9 @@ export async function clientQueryChannels(
 
 export async function clientQueryUsers(
   _client?: unknown,
-): Promise<{ users: any[] }> {
-  const resp = await fetch("/api/users/", { credentials: "same-origin" });
-  const data = await resp.json();
-  return { users: data };
+): Promise<{ users: User[] }> {
+  const users = await chatAPI.listUsers();
+  return { users };
 }
 
 export async function clientRemindersCreateReminder(

--- a/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -7,7 +7,11 @@ import type { ChannelOrUserResponse } from "../utils";
 import { isChannel } from "../utils";
 
 import { useChatContext } from "../../../context/ChatContext";
-import { clientChannel, clientQueryChannels } from "../../../chatSDKShim";
+import {
+  clientChannel,
+  clientQueryChannels,
+  clientQueryUsers,
+} from "../../../chatSDKShim";
 
 import type {
   Channel,
@@ -220,7 +224,16 @@ export const useChannelSearch = ({
         }
 
         if (searchForUsers) {
-          promises.push(client.queryUsers());
+          promises.push(
+            clientQueryUsers(client).then(({ users }) => ({
+              users: users.map((user) => ({
+                ...user,
+                id: String(user.id),
+                name: user.username,
+                type: channelType,
+              })),
+            })),
+          );
         }
 
         if (promises.length) {
@@ -228,6 +241,10 @@ export const useChannelSearch = ({
 
           const resolved = await Promise.all(promises);
 
+          const currentUserId =
+            client.user?.id === undefined || client.user?.id === null
+              ? undefined
+              : String(client.user.id);
           if (searchForChannels && searchForUsers) {
             const [channels, { users }] = resolved as [
               Channel[],
@@ -235,14 +252,20 @@ export const useChannelSearch = ({
             ];
             results = [
               ...channels,
-              ...users.filter((u) => u.id !== client.user?.id),
+              ...users.filter((user) =>
+                currentUserId ? user.id !== currentUserId : true,
+              ),
             ];
           } else if (searchForChannels) {
             const [channels] = resolved as [Channel[]];
             results = [...channels];
           } else if (searchForUsers) {
             const [{ users }] = resolved as [UsersAPIResponse];
-            results = [...users.filter((u) => u.id !== client.user?.id)];
+            results = [
+              ...users.filter((user) =>
+                currentUserId ? user.id !== currentUserId : true,
+              ),
+            ];
           }
         }
       } catch (error) {

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -33,7 +33,7 @@ paths:
   /api/users/:
     get:
       operationId: listUsers
-      description: ''
+      description: List users.
       parameters: []
       responses:
         '200':
@@ -43,7 +43,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
-          description: ''
+          description: OK
       tags:
       - api
   /api/user-agent/:

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -99,13 +99,13 @@
     "status": "ok"
   },
   {
-    "method": "",
-    "path": "",
+    "method": "get",
+    "path": "/api/users/",
     "operationId": "listUsers",
     "stubName": "client.queryUsers",
     "ticketType": "api",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "get",


### PR DESCRIPTION
## Summary
- add an explicit description for the existing `/api/users/` list view
- expose a typed `chatAPI.listUsers` helper and route the shim through it
- normalize channel search user results and refresh OpenAPI + manifest entries

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/client.queryUsers.test.ts
- pytest *(fails: sqlite3.OperationalError: no such table: accounts_supabase_customuser)*

------
https://chatgpt.com/codex/tasks/task_e_68d59d87f3dc8326a9ffaac093bea4ff