### PR TITLE
feat(unmuteUser): wire up POST /api/user-mutes/unmute/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -16,9 +16,23 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .mixins import RoomFromCIDMixin
-from .models import (Channel, Draft, Flag, Message, Notification, Pin, Poll,
-                     PollOption, Reaction, ReadState, Reminder, Room, RoomMemberMute,
-                     RoomMute, UserMute)
+from .models import (
+    Channel,
+    Draft,
+    Flag,
+    Message,
+    Notification,
+    Pin,
+    Poll,
+    PollOption,
+    Reaction,
+    ReadState,
+    Reminder,
+    Room,
+    RoomMemberMute,
+    RoomMute,
+    UserMute,
+)
 from .serializers import (
     DraftSerializer,
     FlagSerializer,
@@ -35,6 +49,7 @@ from .serializers import (
     RoomMemberMuteCreateSerializer,
     RoomMemberMuteSerializer,
     RoomSerializer,
+    UserMuteUnmuteSerializer,
 )
 
 
@@ -976,15 +991,20 @@ class MuteUserView(APIView):
 
 
 class UnmuteUserView(APIView):
-    """Remove mute record for the given user."""
+    """Remove a global mute for the given target user."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
+    serializer_class = UserMuteUnmuteSerializer
 
-    def post(self, request, target_username):
-        target = get_object_or_404(get_user_model(), username=target_username)
-        UserMute.objects.filter(user=request.user, target=target).delete()
-        return Response({"status": "ok"})
+    def post(self, request):
+        serializer = self.serializer_class(
+            data=request.data,
+            context={"request": request},
+        )
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.save()
+        return Response(payload, status=status.HTTP_200_OK)
 
 
 class AttachmentUploadView(APIView):

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -15,6 +15,7 @@ from .models import (
     Reminder,
     Room,
     RoomMemberMute,
+    UserMute,
     WebPushSubscription,
 )
 
@@ -316,3 +317,24 @@ class RoomMemberMuteSerializer(serializers.ModelSerializer):
         model = RoomMemberMute
         fields = ["id", "user_id", "muted_until", "muted_by", "created_at"]
         read_only_fields = ["id", "user_id", "muted_by", "created_at"]
+
+
+class UserMuteUnmuteSerializer(serializers.Serializer):
+    """Validate and process a global user unmute request."""
+
+    target_user_id = serializers.PrimaryKeyRelatedField(
+        queryset=get_user_model().objects.all(),
+        source="target",
+    )
+
+    def validate_target(self, value):
+        request = self.context.get("request")
+        if request and request.user == value:
+            raise serializers.ValidationError("You cannot unmute yourself.")
+        return value
+
+    def save(self, **kwargs):  # type: ignore[override]
+        request = self.context["request"]
+        target = self.validated_data["target"]
+        UserMute.objects.filter(user=request.user, target=target).delete()
+        return {"target_user_id": target.pk, "muted": False}

--- a/backend/chat/tests/test_unmute_user.py
+++ b/backend/chat/tests/test_unmute_user.py
@@ -6,30 +6,61 @@ import jwt
 from accounts_supabase.models import CustomUser
 from chat.models import UserMute
 
+
 class UnmuteUserAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
-        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        return jwt.encode(
+            {"sub": sub, "email": email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
 
     def setUp(self):
-        self.user1 = CustomUser.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
-        self.user2 = CustomUser.objects.create_user(username="u2", email="u2@example.com", password="x", supabase_uid="u2")
+        self.user1 = CustomUser.objects.create_user(
+            username="u1", email="u1@example.com", password="x", supabase_uid="u1"
+        )
+        self.user2 = CustomUser.objects.create_user(
+            username="u2", email="u2@example.com", password="x", supabase_uid="u2"
+        )
         UserMute.objects.create(user=self.user1, target=self.user2)
 
     def test_unmute_user_deletes_record(self):
         token = self.make_token()
-        url = reverse("user-unmute", kwargs={"target_username": "u2"})
-        res = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        url = reverse("user-unmute")
+        res = self.client.post(
+            url,
+            {"target_user_id": self.user2.id},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
         self.assertEqual(res.status_code, 200)
-        self.assertFalse(UserMute.objects.filter(user=self.user1, target=self.user2).exists())
-        self.assertEqual(res.data["status"], "ok")
+        self.assertFalse(
+            UserMute.objects.filter(user=self.user1, target=self.user2).exists()
+        )
+        self.assertEqual(res.data["target_user_id"], self.user2.id)
+        self.assertFalse(res.data["muted"])
 
     def test_unmute_user_requires_auth(self):
-        url = reverse("user-unmute", kwargs={"target_username": "u2"})
-        res = self.client.post(url)
+        url = reverse("user-unmute")
+        res = self.client.post(url, {"target_user_id": self.user2.id}, format="json")
         self.assertEqual(res.status_code, 403)
 
     def test_unmute_user_wrong_method(self):
         token = self.make_token()
-        url = reverse("user-unmute", kwargs={"target_username": "u2"})
+        url = reverse("user-unmute")
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 405)
+
+    def test_unmute_user_cannot_target_self(self):
+        token = self.make_token()
+        url = reverse("user-unmute")
+        res = self.client.post(
+            url,
+            {"target_user_id": self.user1.id},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertTrue(
+            UserMute.objects.filter(user=self.user1, target=self.user2).exists()
+        )

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -266,7 +266,7 @@ urlpatterns = [
         name="user-mute",
     ),
     path(
-        "api/unmute/<str:target_username>/",
+        "api/user-mutes/unmute/",
         UnmuteUserView.as_view(),
         name="user-unmute",
     ),

--- a/frontend/__tests__/adapter/unmuteUser.test.js
+++ b/frontend/__tests__/adapter/unmuteUser.test.js
@@ -41,7 +41,10 @@ var ChatClient_1 = require("../../src/lib/stream-adapter/ChatClient");
 var constants_1 = require("../../src/lib/stream-adapter/constants");
 var originalFetch = global.fetch;
 (0, vitest_1.beforeEach)(function () {
-    global.fetch = vitest_1.vi.fn(function () { return Promise.resolve({ ok: true }); });
+    global.fetch = vitest_1.vi.fn(function () { return Promise.resolve({
+        ok: true,
+        json: function () { return Promise.resolve({ target_user_id: 2, muted: false }); },
+    }); });
 });
 (0, vitest_1.afterEach)(function () {
     global.fetch = originalFetch;
@@ -53,13 +56,17 @@ var originalFetch = global.fetch;
         switch (_a.label) {
             case 0:
                 client = new ChatClient_1.ChatClient('u1', 'jwt-test');
-                return [4 /*yield*/, client.unmuteUser('u2')];
+                return [4 /*yield*/, client.unmuteUser(2)];
             case 1:
                 _a.sent();
-                (0, vitest_1.expect)(global.fetch).toHaveBeenCalledWith("".concat(constants_1.API.UNMUTE_USER, "u2/"), {
+                (0, vitest_1.expect)(global.fetch).toHaveBeenCalledWith("/api".concat(constants_1.API.UNMUTE_USER), vitest_1.expect.objectContaining({
                     method: 'POST',
-                    headers: { Authorization: 'Bearer jwt-test' },
-                });
+                    headers: vitest_1.expect.objectContaining({
+                        Authorization: 'Bearer jwt-test',
+                        'Content-Type': 'application/json',
+                    }),
+                    body: JSON.stringify({ target_user_id: 2 }),
+                }));
                 return [2 /*return*/];
         }
     });

--- a/frontend/__tests__/adapter/unmuteUser.test.ts
+++ b/frontend/__tests__/adapter/unmuteUser.test.ts
@@ -5,7 +5,12 @@ import { API } from '../../src/lib/stream-adapter/constants';
 const originalFetch = global.fetch;
 
 beforeEach(() => {
-  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ target_user_id: 2, muted: false }),
+    }),
+  );
 });
 
 afterEach(() => {
@@ -15,9 +20,16 @@ afterEach(() => {
 
 test('unmuteUser posts to backend endpoint', async () => {
   const client = new ChatClient('u1', 'jwt-test');
-  await client.unmuteUser('u2');
-  expect(global.fetch).toHaveBeenCalledWith(`${API.UNMUTE_USER}u2/`, {
-    method: 'POST',
-    headers: { Authorization: 'Bearer jwt-test' },
-  });
+  await client.unmuteUser(2);
+  expect(global.fetch).toHaveBeenCalledWith(
+    `/api${API.UNMUTE_USER}`,
+    expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer jwt-test',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({ target_user_id: 2 }),
+    }),
+  );
 });

--- a/frontend/src/lib/stream-adapter/ChatClient.js
+++ b/frontend/src/lib/stream-adapter/ChatClient.js
@@ -781,18 +781,87 @@ var ChatClient = /** @class */ (function () {
     };
     /** Unmute a user */
     ChatClient.prototype.unmuteUser = function (userId) {
+        var _this = this;
         return __awaiter(this, void 0, void 0, function () {
-            var res;
+            var numericId, res, filterMuteList, assignFilteredMutes, nextUserMutes;
             return __generator(this, function (_a) {
                 switch (_a.label) {
-                    case 0: return [4 /*yield*/, (0, api_1.apiFetch)("".concat(constants_1.API.UNMUTE_USER).concat(userId, "/"), {
-                            method: 'POST',
-                            headers: { Authorization: "Bearer ".concat(this.authToken) },
-                        })];
+                    case 0:
+                        numericId = typeof userId === 'number' ? userId : Number(userId);
+                        if (!Number.isInteger(numericId)) {
+                            throw new Error('unmuteUser requires numeric user id');
+                        }
+                        return [4 /*yield*/, (0, api_1.apiFetch)(constants_1.API.UNMUTE_USER, {
+                                method: 'POST',
+                                headers: _this.buildHeaders({ 'Content-Type': 'application/json' }),
+                                body: JSON.stringify({ target_user_id: numericId }),
+                            })];
                     case 1:
                         res = _a.sent();
                         if (!res.ok)
                             throw new Error('unmuteUser failed');
+                        return [4 /*yield*/, res.json().catch(function () { return null; })];
+                    case 2:
+                        _a.sent();
+                        filterMuteList = function (value) {
+                            if (!Array.isArray(value))
+                                return [];
+                            return value.filter(function (mute) {
+                                var entry = mute;
+                                var directId = typeof entry.user_id === 'number'
+                                    ? entry.user_id
+                                    : typeof entry.user_id === 'string'
+                                        ? Number.parseInt(entry.user_id, 10)
+                                        : null;
+                                if (typeof directId === 'number' && !Number.isNaN(directId)) {
+                                    return directId !== numericId;
+                                }
+                                var target = entry.target;
+                                var targetId = typeof (target === null || target === void 0 ? void 0 : target.id) === 'number'
+                                    ? target.id
+                                    : typeof (target === null || target === void 0 ? void 0 : target.id) === 'string'
+                                        ? Number.parseInt(target.id, 10)
+                                        : null;
+                                if (typeof targetId === 'number' && !Number.isNaN(targetId)) {
+                                    return targetId !== numericId;
+                                }
+                                var genericId = typeof entry.id === 'number'
+                                    ? entry.id
+                                    : typeof entry.id === 'string'
+                                        ? Number.parseInt(entry.id, 10)
+                                        : null;
+                                if (typeof genericId === 'number' && !Number.isNaN(genericId)) {
+                                    return genericId !== numericId;
+                                }
+                                return true;
+                            });
+                        };
+                        assignFilteredMutes = function (userLike) {
+                            if (!userLike || typeof userLike !== 'object')
+                                return undefined;
+                            var next = filterMuteList(userLike.mutes);
+                            userLike.mutes = next;
+                            return next;
+                        };
+                        nextUserMutes = assignFilteredMutes(_this.user);
+                        if (nextUserMutes === undefined) {
+                            nextUserMutes = assignFilteredMutes(_this._user);
+                        }
+                        if (nextUserMutes === undefined) {
+                            nextUserMutes = filterMuteList(undefined);
+                        }
+                        _this.mutedUsers = _this.mutedUsers.filter(function (mute) {
+                            var value = typeof (mute === null || mute === void 0 ? void 0 : mute.id) === 'number'
+                                ? mute.id
+                                : typeof (mute === null || mute === void 0 ? void 0 : mute.id) === 'string'
+                                    ? Number.parseInt(mute.id, 10)
+                                    : null;
+                            if (typeof value === 'number' && !Number.isNaN(value)) {
+                                return value !== numericId;
+                            }
+                            return true;
+                        });
+                        _this.emit('notification.mutes_updated', { me: { mutes: nextUserMutes } });
                         return [2 /*return*/];
                 }
             });

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -490,12 +490,92 @@ export class ChatClient {
     }
 
     /** Unmute a user */
-    async unmuteUser(userId: string) {
-        const res = await apiFetch(`${API.UNMUTE_USER}${userId}/`, {
+    async unmuteUser(userId: string | number) {
+        const numericId = typeof userId === 'number' ? userId : Number(userId);
+        if (!Number.isInteger(numericId)) {
+            throw new Error('unmuteUser requires numeric user id');
+        }
+
+        const res = await apiFetch(API.UNMUTE_USER, {
             method: 'POST',
-            headers: { Authorization: `Bearer ${this.authToken}` },
+            headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ target_user_id: numericId }),
         });
         if (!res.ok) throw new Error('unmuteUser failed');
+        await res.json().catch(() => null);
+
+        const filterMuteList = (value: unknown): any[] => {
+            if (!Array.isArray(value)) return [];
+            return value.filter((mute) => {
+                const entry = mute as Record<string, unknown>;
+                const directId =
+                    typeof entry.user_id === 'number'
+                        ? entry.user_id
+                        : typeof entry.user_id === 'string'
+                            ? Number.parseInt(entry.user_id, 10)
+                            : null;
+                if (typeof directId === 'number' && !Number.isNaN(directId)) {
+                    return directId !== numericId;
+                }
+
+                const target = entry.target as Record<string, unknown> | undefined;
+                const targetId =
+                    typeof target?.id === 'number'
+                        ? target.id
+                        : typeof target?.id === 'string'
+                            ? Number.parseInt(target.id, 10)
+                            : null;
+                if (typeof targetId === 'number' && !Number.isNaN(targetId)) {
+                    return targetId !== numericId;
+                }
+
+                const genericId =
+                    typeof entry.id === 'number'
+                        ? entry.id
+                        : typeof entry.id === 'string'
+                            ? Number.parseInt(entry.id, 10)
+                            : null;
+                if (typeof genericId === 'number' && !Number.isNaN(genericId)) {
+                    return genericId !== numericId;
+                }
+
+                return true;
+            });
+        };
+
+        const assignFilteredMutes = (userLike: unknown): any[] | undefined => {
+            if (!userLike || typeof userLike !== 'object') return undefined;
+            const next = filterMuteList((userLike as Record<string, unknown>).mutes);
+            (userLike as Record<string, unknown>).mutes = next;
+            return next;
+        };
+
+        let nextUserMutes = assignFilteredMutes(
+            (this as unknown as Record<string, unknown>).user,
+        );
+        if (nextUserMutes === undefined) {
+            nextUserMutes = assignFilteredMutes(
+                this._user as unknown as Record<string, unknown>,
+            );
+        }
+        if (nextUserMutes === undefined) {
+            nextUserMutes = filterMuteList(undefined);
+        }
+
+        this.mutedUsers = this.mutedUsers.filter((mute: any) => {
+            const value =
+                typeof mute?.id === 'number'
+                    ? mute.id
+                    : typeof mute?.id === 'string'
+                        ? Number.parseInt(mute.id, 10)
+                        : null;
+            if (typeof value === 'number' && !Number.isNaN(value)) {
+                return value !== numericId;
+            }
+            return true;
+        });
+
+        this.emit('notification.mutes_updated', { me: { mutes: nextUserMutes } });
     }
 
     /** Pin a message globally */

--- a/frontend/src/lib/stream-adapter/constants.js
+++ b/frontend/src/lib/stream-adapter/constants.js
@@ -24,7 +24,7 @@ exports.API = {
     MUTED_USERS: '/muted-users/',
     MUTED_CHANNELS: '/muted-channels/',
     MUTE_USER: '/mute/',
-    UNMUTE_USER: '/unmute/',
+    UNMUTE_USER: '/user-mutes/unmute/',
     RECOVER_STATE: '/recover-state/',
     REFRESH_TOKEN: '/refresh-token/',
     SUBARRAY: '/subarray/',

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -21,7 +21,7 @@ export const API = {
   MUTED_USERS: '/muted-users/',
   MUTED_CHANNELS: '/muted-channels/',
   MUTE_USER: '/mute/',
-  UNMUTE_USER: '/unmute/',
+  UNMUTE_USER: '/user-mutes/unmute/',
   RECOVER_STATE: '/recover-state/',
   REFRESH_TOKEN: '/refresh-token/',
   SUBARRAY: '/subarray/',

--- a/libs/stream-chat-shim/__tests__/unmuteUser.test.ts
+++ b/libs/stream-chat-shim/__tests__/unmuteUser.test.ts
@@ -2,13 +2,18 @@ import { unmuteUser } from '../src/chatSDKShim';
 
 describe('unmuteUser', () => {
   it('posts to backend endpoint', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({});
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ target_user_id: 2, muted: false }),
+    });
     // @ts-ignore
     global.fetch = fetchMock;
-    await unmuteUser('u2');
-    expect(fetchMock).toHaveBeenCalledWith('/api/unmute/u2/', {
+    await unmuteUser(2);
+    expect(fetchMock).toHaveBeenCalledWith('/api/user-mutes/unmute/', {
       method: 'POST',
       credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_user_id: 2 }),
     });
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -36,6 +36,9 @@ export type Mute = {
 
 export type MuteUserInput = { cid: string; user_id: number; muted_until?: string };
 
+export type UnmuteUserRequest = { target_user_id: number };
+export type UnmuteUserResponse = { target_user_id: number; muted: false };
+
 export type User = { id: number; username: string } & Record<string, unknown>;
 
 export type SyncUserRequest = Partial<Record<string, unknown>>;
@@ -425,6 +428,37 @@ export const muteUser = async ({
   };
 };
 
+export const unmuteUser = async ({
+  target_user_id,
+}: UnmuteUserRequest): Promise<UnmuteUserResponse> => {
+  const response = await fetch("/api/user-mutes/unmute/", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ target_user_id }),
+  });
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to unmute user (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  const data = (await response.json()) as Partial<UnmuteUserResponse>;
+
+  if (
+    typeof data?.target_user_id !== "number" ||
+    ("muted" in data && data.muted !== false)
+  ) {
+    throw new Error("Invalid unmute user response");
+  }
+
+  return { target_user_id: data.target_user_id, muted: false };
+};
+
 export const muteStatus = async ({ cid }: { cid: string }): Promise<MuteStatus> => {
   const response = await fetch(
     `/api/rooms/${encodeURIComponent(cid)}/mute/`,
@@ -549,6 +583,7 @@ export const chatAPI = {
   createReminder,
   deleteMessage,
   muteUser,
+  unmuteUser,
   registerSubscriptions,
   endSession,
   getMessage,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -7,6 +7,7 @@ import {
   type CreateReminderInput,
   type Message as APIMessage,
   type MuteUserInput,
+  type UnmuteUserResponse,
   type RegisterSubscriptionsInput,
   type WebPushSubscription,
   type RoomDraft,
@@ -914,11 +915,17 @@ export async function muteUser(
   });
 }
 
-export async function unmuteUser(username: string): Promise<void> {
-  await fetch(`/api/unmute/${encodeURIComponent(username)}/`, {
-    method: 'POST',
-    credentials: 'same-origin',
-  });
+export async function unmuteUser(
+  userId: string | number,
+): Promise<UnmuteUserResponse> {
+  const numericId =
+    typeof userId === 'number' ? userId : Number.parseInt(String(userId), 10);
+
+  if (!Number.isInteger(numericId)) {
+    throw new Error('unmuteUser requires a numeric user id');
+  }
+
+  return chatAPI.unmuteUser({ target_user_id: numericId });
 }
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -87,8 +87,15 @@ export const useChat = ({
       setMutes(event.me?.mutes || []);
     };
 
-    /* TODO backend-wire-up */
-return () => { /* noop */ };
+    const subscription = client.on?.('notification.mutes_updated', handleEvent);
+
+    return () => {
+      if (subscription?.unsubscribe) {
+        subscription.unsubscribe();
+      } else if (typeof client?.off === 'function') {
+        client.off('notification.mutes_updated', handleEvent);
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clientMutes?.length]);
 

--- a/libs/stream-chat-shim/src/components/Message/hooks/useMuteHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useMuteHandler.ts
@@ -4,7 +4,7 @@ import { useChannelStateContext } from '../../../context/ChannelStateContext';
 import { useChatContext } from '../../../context/ChatContext';
 import { useTranslationContext } from '../../../context/TranslationContext';
 
-import type { LocalMessage, UserResponse } from 'chat-shim';
+import type { LocalMessage, Mute, UserResponse } from 'chat-shim';
 
 import type { ReactEventHandler } from '../types';
 
@@ -24,6 +24,88 @@ export const useMuteHandler = (
   const { channel, mutes } = useChannelStateContext('useMuteHandler');
   const { client } = useChatContext('useMuteHandler');
   const { t } = useTranslationContext('useMuteHandler');
+
+  const removeMuteLocally = (targetUserId: number) => {
+    if (!client) return;
+
+    const filterMuteList = (value: unknown): Mute[] => {
+      if (!Array.isArray(value)) return [];
+      return value.filter((mute) => {
+        const item = mute as Record<string, unknown>;
+        const directId =
+          typeof item.user_id === 'number'
+            ? item.user_id
+            : typeof item.user_id === 'string'
+              ? Number.parseInt(item.user_id, 10)
+              : null;
+        if (typeof directId === 'number' && !Number.isNaN(directId)) {
+          return directId !== targetUserId;
+        }
+
+        const target = item.target as Record<string, unknown> | undefined;
+        const targetId =
+          typeof target?.id === 'number'
+            ? target.id
+            : typeof target?.id === 'string'
+              ? Number.parseInt(target.id, 10)
+              : null;
+        if (typeof targetId === 'number' && !Number.isNaN(targetId)) {
+          return targetId !== targetUserId;
+        }
+
+        const genericId =
+          typeof item.id === 'number'
+            ? item.id
+            : typeof item.id === 'string'
+              ? Number.parseInt(item.id, 10)
+              : null;
+        if (typeof genericId === 'number' && !Number.isNaN(genericId)) {
+          return genericId !== targetUserId;
+        }
+
+        return true;
+      }) as Mute[];
+    };
+
+    const assignFilteredMutes = (userLike: unknown): Mute[] | undefined => {
+      if (!userLike || typeof userLike !== 'object') return undefined;
+      const nextMutes = filterMuteList((userLike as Record<string, unknown>).mutes);
+      (userLike as Record<string, unknown>).mutes = nextMutes;
+      return nextMutes;
+    };
+
+    const nextUserMutes =
+      assignFilteredMutes((client as Record<string, unknown>).user) ??
+      assignFilteredMutes((client as Record<string, unknown>)._user) ??
+      filterMuteList(undefined);
+
+    if (Array.isArray((client as Record<string, unknown>).mutedUsers)) {
+      (client as Record<string, unknown>).mutedUsers = (
+        (client as Record<string, unknown>).mutedUsers as Array<Record<string, unknown>>
+      ).filter((mute) => {
+        const muteId =
+          typeof mute.id === 'number'
+            ? mute.id
+            : typeof mute.id === 'string'
+              ? Number.parseInt(mute.id, 10)
+              : null;
+        if (typeof muteId === 'number' && !Number.isNaN(muteId)) {
+          return muteId !== targetUserId;
+        }
+        return true;
+      });
+    }
+
+    const eventPayload = { me: { mutes: nextUserMutes } };
+    if (typeof (client as { dispatchEvent?: (event: Record<string, unknown>) => void }).dispatchEvent === 'function') {
+      client.dispatchEvent({
+        type: 'notification.mutes_updated',
+        ...eventPayload,
+      });
+    } else if (typeof (client as { emit?: (event: string, data: unknown) => void }).emit === 'function') {
+      client.emit('notification.mutes_updated', eventPayload);
+    }
+  };
 
   return async (event) => {
     event.preventDefault();
@@ -65,7 +147,18 @@ export const useMuteHandler = (
       }
     } else {
       try {
-        await client.unmuteUser(message.user.id);
+        const rawUserId = message.user.id;
+        const numericUserId =
+          typeof rawUserId === 'number'
+            ? rawUserId
+            : Number.parseInt(String(rawUserId), 10);
+
+        if (!Number.isInteger(numericUserId)) {
+          throw new Error('unmuteUser requires a numeric user id');
+        }
+
+        await client.unmuteUser(rawUserId);
+        removeMuteLocally(numericUserId);
 
         const fallbackMessage = t(`{{ user }} has been unmuted`, {
           user: message.user.name || message.user.id,

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -656,26 +656,35 @@ paths:
                 $ref: '#/components/schemas/Mute'
       tags:
       - api
-  /api/unmute/{target_username}/:
-    parameters:
-      - name: target_username
-        in: path
-        required: true
-        schema:
-          type: string
+  /api/user-mutes/unmute/:
     post:
+      description: Unmute a previously muted user (global).
       operationId: unmuteUser
-      description: Remove mute record for the given user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - target_user_id
+              properties:
+                target_user_id:
+                  type: integer
       responses:
         '200':
-          description: ok
+          description: Unmuted
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
+                  target_user_id:
+                    type: integer
+                  muted:
+                    type: boolean
+                    enum:
+                      - false
       tags:
       - api
 components:

--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -526,26 +526,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Mute'
-  /unmute/{username}/:
-    parameters:
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
+  /user-mutes/unmute/:
     post:
       operationId: unmuteUser
       tags: [mutes]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - target_user_id
+              properties:
+                target_user_id:
+                  type: integer
       responses:
         '200':
-          description: ok
+          description: Unmuted
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
+                  target_user_id:
+                    type: integer
+                  muted:
+                    type: boolean
+                    enum:
+                      - false
   /recover-state/:
     get:
       operationId: recoverState


### PR DESCRIPTION
## Summary
- implement serializer and API view for POST /api/user-mutes/unmute/ and adjust tests plus OpenAPI docs
- wire chat API shim and ChatClient unmute helpers to the new endpoint and update in-memory mute state
- refresh shim and adapter tests to assert the new unmute request/response contract

## Testing
- pytest backend/chat/tests/test_unmute_user.py *(fails: missing Django settings fixture in current environment)*
- pnpm --filter frontend test -- unmuteUser *(fails: vitest not installed in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bec660b48326b1cf0d4c45bfe6ec