### PR TITLE
feat(updateMessage): wire up PATCH /api/rooms/{cid}/messages/{message_id}/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -37,6 +37,7 @@ from .serializers import (
     DraftSerializer,
     FlagSerializer,
     MessageSerializer,
+    MessageUpdateSerializer,
     MuteStatusSerializer,
     NotificationSerializer,
     PinSerializer,
@@ -165,7 +166,7 @@ class RoomMessageDetailView(RoomFromCIDMixin, APIView):
             room_uuid = cid
         return get_object_or_404(Room, uuid=room_uuid)
 
-    def _can_delete(self, user, room: Room, message: Message) -> bool:
+    def _can_manage(self, user, room: Room, message: Message) -> bool:
         if message.sent_by == user.username:
             return True
         if room.agent_id and room.agent_id == user.id:
@@ -174,10 +175,48 @@ class RoomMessageDetailView(RoomFromCIDMixin, APIView):
             return True
         return False
 
+    def _can_delete(self, user, room: Room, message: Message) -> bool:
+        return self._can_manage(user, room, message)
+
+    def _can_update(self, user, room: Room, message: Message) -> bool:
+        return self._can_manage(user, room, message)
+
     def get(self, request, cid: str, message_id: int):
         room = self._get_room(cid)
         message = get_object_or_404(room.messages, id=message_id)
         serializer = MessageSerializer(message)
+        return Response(serializer.data)
+
+    def patch(self, request, cid: str, message_id: int):
+        room = self._get_room(cid)
+        message = get_object_or_404(room.messages, id=message_id)
+
+        if not self._can_update(request.user, room, message):
+            return Response(status=403)
+
+        serializer = MessageUpdateSerializer(
+            message, data=request.data, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        try:
+            channel_layer = get_channel_layer()
+            message_payload = serializer.data
+            async_to_sync(channel_layer.group_send)(
+                f"channel_{room.uuid}",
+                {
+                    "type": "chat.message",
+                    "payload": {
+                        "type": "message.updated",
+                        "cid": f"messaging:{room.uuid}",
+                        "message": message_payload,
+                    },
+                },
+            )
+        except Exception:
+            pass
+
         return Response(serializer.data)
 
     def delete(self, request, cid: str, message_id: int):

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -46,6 +46,18 @@ class MessageSerializer(serializers.ModelSerializer):
         ]
 
 
+class MessageUpdateSerializer(serializers.ModelSerializer):
+    """Serializer used for message updates via the room-scoped endpoint."""
+
+    text = serializers.CharField(source="body", allow_blank=True, write_only=True)
+
+    class Meta:
+        model = Message
+        fields = ["id", "text", "body", "sent_by", "created_at"]
+        read_only_fields = ["id", "body", "sent_by", "created_at"]
+
+
+
 class DraftSerializer(serializers.ModelSerializer):
     body = serializers.SerializerMethodField()
 

--- a/backend/chat/tests/test_update_message_api.py
+++ b/backend/chat/tests/test_update_message_api.py
@@ -1,0 +1,101 @@
+from unittest.mock import AsyncMock, patch
+
+from chat.models import Channel, Message, Room
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+@override_settings(ROOT_URLCONF="chat.urls")
+class UpdateMessageAPITests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="u1", password="pw")
+        self.agent = User.objects.create_user(username="agent", password="pw")
+        self.room = Room.objects.create(uuid="room-1", client="client-1")
+        self.channel = Channel.objects.create(
+            uuid=self.room.uuid,
+            client=self.room.client,
+        )
+        self.message = Message.objects.create(
+            channel=self.channel,
+            body="hello",
+            sent_by=self.user.username,
+        )
+        self.room.messages.add(self.message)
+
+    def _url(self) -> str:
+        return reverse(
+            "room-message-delete",
+            kwargs={
+                "cid": f"messaging:{self.room.uuid}",
+                "message_id": self.message.id,
+            },
+        )
+
+    def test_author_can_update_message(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(
+            self._url(), {"text": "updated"}, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.message.refresh_from_db()
+        self.assertEqual(self.message.body, "updated")
+
+        self.assertEqual(response.data["id"], self.message.id)
+        self.assertEqual(response.data["body"], "updated")
+        self.assertEqual(response.data["sent_by"], self.user.username)
+        self.assertIn("created_at", response.data)
+
+    def test_non_author_cannot_update(self):
+        other = get_user_model().objects.create_user(username="u2", password="pw")
+        self.client.force_authenticate(other)
+        response = self.client.patch(
+            self._url(), {"text": "updated"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.message.refresh_from_db()
+        self.assertEqual(self.message.body, "hello")
+
+    def test_room_agent_can_update(self):
+        self.room.agent = self.agent
+        self.room.save(update_fields=["agent"])
+
+        self.client.force_authenticate(self.agent)
+        response = self.client.patch(
+            self._url(), {"text": "updated"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.message.refresh_from_db()
+        self.assertEqual(self.message.body, "updated")
+
+    @patch("chat.api_views.get_channel_layer")
+    def test_broadcasts_updated_event(self, mock_get_channel_layer):
+        mock_layer = mock_get_channel_layer.return_value
+        mock_layer.group_send = AsyncMock()
+
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(
+            self._url(), {"text": "updated"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_layer.group_send.assert_awaited_once()
+
+        group_name, payload = mock_layer.group_send.await_args.args
+        self.assertEqual(group_name, f"channel_{self.room.uuid}")
+        self.assertEqual(payload["type"], "chat.message")
+
+        event = payload["payload"]
+        self.assertEqual(event["type"], "message.updated")
+        self.assertEqual(event["cid"], f"messaging:{self.room.uuid}")
+
+        message_payload = event["message"]
+        self.assertEqual(message_payload["id"], self.message.id)
+        self.assertEqual(message_payload["body"], "updated")
+        self.assertEqual(message_payload["sent_by"], self.user.username)
+        self.assertIn("created_at", message_payload)

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -3,6 +3,12 @@ export type DeleteMessageParams = {
   message_id: number;
 };
 
+export type UpdateMessageInput = {
+  cid: string;
+  message_id: number;
+  text: string;
+};
+
 export type CreateReminderInput = {
   cid: string;
   remind_at: string;
@@ -372,6 +378,33 @@ async function deleteMessage({ cid, message_id }: DeleteMessageParams): Promise<
   }
 }
 
+async function updateMessage({
+  cid,
+  message_id,
+  text,
+}: UpdateMessageInput): Promise<Message> {
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(cid)}/messages/${encodeURIComponent(String(message_id))}/`,
+    {
+      method: "PATCH",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to update message (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  return (await response.json()) as Message;
+}
+
 export const muteUser = async ({
   cid,
   user_id,
@@ -582,6 +615,7 @@ async function endSession(): Promise<void> {
 export const chatAPI = {
   createReminder,
   deleteMessage,
+  updateMessage,
   muteUser,
   unmuteUser,
   registerSubscriptions,

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useEditMessageHandler.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useEditMessageHandler.ts
@@ -6,6 +6,7 @@ import type {
 } from 'chat-shim';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { chatAPI, type Message as APIMessage } from '../../../api/chatAPI';
 
 type UpdateHandler = (
   cid: string,
@@ -14,7 +15,7 @@ type UpdateHandler = (
 ) => ReturnType<StreamChat['updateMessage']>;
 
 export const useEditMessageHandler = (doUpdateMessageRequest?: UpdateHandler) => {
-  const { channel, client } = useChatContext('useEditMessageHandler');
+  const { channel } = useChatContext('useEditMessageHandler');
 
   return (
     updatedMessage: LocalMessage | MessageResponse,
@@ -26,9 +27,67 @@ export const useEditMessageHandler = (doUpdateMessageRequest?: UpdateHandler) =>
       );
     }
     return (async () => {
-      const id = (updatedMessage as any).id;
-      const text = (updatedMessage as any).text ?? '';
-      return client.updateMessage(id, text);
+      if (!channel?.cid) {
+        throw new Error('Cannot update a message - missing channel.');
+      }
+
+      const rawId = (updatedMessage as { id?: string | number }).id;
+      if (rawId === undefined || rawId === null) {
+        throw new Error('Cannot update a message - missing message ID.');
+      }
+
+      const messageId = Number(rawId);
+      if (Number.isNaN(messageId)) {
+        throw new Error(
+          `Cannot update a message - invalid message ID "${String(rawId)}".`,
+        );
+      }
+
+      const textValue = (updatedMessage as { text?: string }).text;
+      const text = typeof textValue === 'string' ? textValue : '';
+
+      const apiMessage: APIMessage = await chatAPI.updateMessage({
+        cid: channel.cid,
+        message_id: messageId,
+        text,
+      });
+
+      const createdAt = new Date(apiMessage.created_at);
+      const existingMessage = channel.state?.messages?.find?.(
+        (msg) =>
+          String((msg as { id?: string | number }).id) ===
+          String(apiMessage.id),
+      ) as MessageResponse | undefined;
+
+      const defaults: Record<string, unknown> = existingMessage
+        ? {}
+        : {
+            latest_reactions: [] as unknown[],
+            own_reactions: [] as unknown[],
+            reaction_groups: {},
+          };
+
+      const normalizedMessage = {
+        ...defaults,
+        ...(existingMessage as Record<string, unknown> | undefined),
+        id: String(apiMessage.id),
+        cid: channel.cid,
+        created_at: createdAt,
+        updated_at: new Date(),
+        type: (existingMessage as { type?: unknown })?.type ?? 'regular',
+        status: (existingMessage as { status?: unknown })?.status ?? 'received',
+        text: apiMessage.body,
+        html: apiMessage.body,
+        body: apiMessage.body,
+        user:
+          (existingMessage as { user?: unknown })?.user ??
+          ({ id: apiMessage.sent_by } as Record<string, unknown>),
+        user_id: apiMessage.sent_by,
+      } as MessageResponse;
+
+      return { message: normalizedMessage } as ReturnType<
+        StreamChat['updateMessage']
+      >;
     })();
   };
 };


### PR DESCRIPTION
## Summary
- implement a dedicated serializer and room message view PATCH handler that updates the message, enforces author/mod permissions, and emits the `message.updated` websocket payload
- cover the new endpoint with API tests for author, moderator, and broadcast behaviour
- add `chatAPI.updateMessage` and route the edit message handler through it so the shim normalizes the persisted response

## Testing
- python manage.py test chat.tests.test_update_message_api
- pnpm --filter stream-chat-shim exec tsc --noEmit *(fails: existing story/test fixtures contain unfinished TODO placeholders that break parsing)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c8eb81208326b4df17f0d052def4