### PR TITLE
feat(addAnswer): implement shim-only addAnswer and wire to chatAPI helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1,6 +1,25 @@
+import { chatSDKShim } from '../chatSDKShim';
+
 export type DeleteMessageParams = {
   cid: string;
   message_id: number;
+};
+
+export type AddAnswerInput = {
+  poll_id: string;
+  option_id?: string | number;
+  text?: string;
+  extras?: Record<string, unknown>;
+};
+
+export type AddAnswer = {
+  id: string | number;
+  poll_id: string;
+  option_id?: string | number | null;
+  text?: string | null;
+  created_by: string | number;
+  created_at: string;
+  [k: string]: unknown;
 };
 
 export type UpdateMessageInput = {
@@ -73,6 +92,11 @@ export type Message = {
   created_at: string;
   sent_by: string;
 };
+
+// shim-only: no network; delegate to SDK shim
+export async function addAnswer(input: AddAnswerInput): Promise<AddAnswer> {
+  return chatSDKShim.addAnswer(input);
+}
 
 export interface RoomDraft {
   id?: number;

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -3,6 +3,8 @@ import { stopTyping as stopTypingImpl } from '../../chat-shim/typing';
 
 import {
   chatAPI,
+  type AddAnswer,
+  type AddAnswerInput,
   type AppSettings,
   type CreateReminderInput,
   type Message as APIMessage,
@@ -24,8 +26,31 @@ import {
 
 type SendMessageResponse = { message: CreateMessageResult };
 
-export async function addAnswer(): Promise<void> {
-  // Placeholder implementation until backend endpoint is available
+let localAnswerIdCounter = 0;
+
+const createLocalAnswerId = () => {
+  localAnswerIdCounter += 1;
+  return `local-answer-${localAnswerIdCounter}`;
+};
+
+export const chatSDKShim = {
+  async addAnswer(input: AddAnswerInput): Promise<AddAnswer> {
+    const now = new Date().toISOString();
+    const result: AddAnswer = {
+      id: createLocalAnswerId(),
+      poll_id: input.poll_id,
+      option_id: input.option_id ?? null,
+      text: input.text ?? null,
+      created_by: 'me',
+      created_at: now,
+    };
+
+    return input.extras ? { ...result, ...input.extras } : result;
+  },
+};
+
+export async function addAnswer(input: AddAnswerInput): Promise<AddAnswer> {
+  return chatSDKShim.addAnswer(input);
 }
 
 export async function castVote(

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/AddCommentForm.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/AddCommentForm.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { FormDialog } from '../../Dialog/FormDialog';
 import { useStateStore } from '../../../store';
-import { usePollContext, useTranslationContext } from '../../../context';
+import * as chatAPI from '../../../api/chatAPI';
+import {
+  useChatContext,
+  usePollContext,
+  useTranslationContext,
+} from '../../../context';
 import type { PollAnswer, PollState } from 'chat-shim';
 
 type PollStateSelectorReturnValue = { ownAnswer: PollAnswer | undefined };
@@ -9,16 +14,28 @@ const pollStateSelector = (nextValue: PollState): PollStateSelectorReturnValue =
   ownAnswer: nextValue.ownAnswer,
 });
 
+type PollStateWithAnswers = PollState & {
+  answers_count?: number;
+  ownAnswer?: PollAnswer;
+};
+
+type PollStateStore = {
+  dispatch?: (patch: Partial<PollStateWithAnswers>) => void;
+  getLatestValue?: () => PollStateWithAnswers;
+};
+
 export type AddCommentFormProps = {
   close: () => void;
   messageId: string;
 };
 
 export const AddCommentForm = ({ close, messageId }: AddCommentFormProps) => {
+  const { client } = useChatContext('AddCommentForm');
   const { t } = useTranslationContext('AddCommentForm');
 
   const { poll } = usePollContext();
   const { ownAnswer } = useStateStore(poll.state, pollStateSelector);
+  const pollStateStore = poll.state as unknown as PollStateStore;
 
   return (
     <FormDialog<{ comment: '' }>
@@ -37,8 +54,79 @@ export const AddCommentForm = ({ close, messageId }: AddCommentFormProps) => {
         },
       }}
       onSubmit={async (value) => {
-        /* TODO backend-wire-up: addAnswer */
-        return Promise.resolve();
+        const commentText = value.comment.trim();
+        const addAnswerResponse = await chatAPI.addAnswer({
+          poll_id: poll.id,
+          text: commentText,
+          extras: {
+            answer_text: commentText,
+            is_answer: true,
+            message_id: messageId,
+          },
+        });
+
+        const currentState = pollStateStore.getLatestValue?.();
+        const previousOwnAnswer = currentState?.ownAnswer;
+        const createdBy = (() => {
+          if (typeof addAnswerResponse.created_by === 'number') {
+            return String(addAnswerResponse.created_by);
+          }
+          if (typeof addAnswerResponse.created_by === 'string') {
+            return addAnswerResponse.created_by;
+          }
+          if (typeof client.user?.id === 'number') {
+            return String(client.user.id);
+          }
+          return client.user?.id;
+        })();
+
+        const responseDetails = addAnswerResponse as {
+          answer_text?: unknown;
+          is_answer?: unknown;
+          updated_at?: string;
+        };
+
+        const answerTextValue =
+          typeof responseDetails.answer_text === 'string'
+            ? responseDetails.answer_text
+            : commentText;
+
+        const isAnswerValue =
+          typeof responseDetails.is_answer === 'boolean'
+            ? responseDetails.is_answer
+            : true;
+
+        const updatedAt = responseDetails.updated_at ?? addAnswerResponse.created_at;
+
+        const updatedOwnAnswer: PollAnswer = {
+          id: String(addAnswerResponse.id),
+          poll_id: String(addAnswerResponse.poll_id),
+          created_at: addAnswerResponse.created_at,
+          updated_at: updatedAt,
+          answer_text: answerTextValue,
+          is_answer: isAnswerValue,
+          user_id: createdBy,
+        };
+
+        if (client.user) {
+          updatedOwnAnswer.user = client.user;
+        }
+
+        const answersCount = currentState?.answers_count;
+        let nextAnswersCount: number | undefined = answersCount;
+
+        if (typeof answersCount === 'number') {
+          nextAnswersCount = previousOwnAnswer ? answersCount : answersCount + 1;
+        } else if (!previousOwnAnswer) {
+          nextAnswersCount = 1;
+        }
+
+        pollStateStore.dispatch?.({
+          answers_count: nextAnswersCount,
+          ownAnswer: updatedOwnAnswer,
+        });
+
+        return addAnswerResponse;
       }}
       shouldDisableSubmitButton={(value) =>
         !value.comment || value.comment === ownAnswer?.answer_text


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.addAnswer` helper that delegates to the shim implementation
- implement `chatSDKShim.addAnswer` to locally echo poll answers without network access
- update the poll add-comment form to call the helper and reconcile the local poll state

## Testing
- pnpm --filter stream-chat-shim test -- --runTestsByPath libs/stream-chat-shim/__tests__/polls.fromState.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d5da65d39c83269fa0649565f7ee91