### PR TITLE
feat(createReminder): wire up POST /api/reminders/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -54,6 +54,42 @@ from .serializers import (
 )
 
 
+def _user_can_access_room(user, room) -> bool:
+    """Return whether ``user`` has access to the given ``room``."""
+
+    username = getattr(user, "username", "")
+    return any(
+        (
+            room.agent_id == getattr(user, "id", None),
+            room.client == username,
+            room.messages.filter(sent_by=username).exists(),
+            getattr(user, "is_staff", False),
+            getattr(user, "is_superuser", False),
+        )
+    )
+
+
+def _broadcast_reminder_created(room, cid: str, reminder_data: dict) -> None:
+    """Notify channel subscribers that a reminder was created."""
+
+    try:
+        channel_layer = get_channel_layer()
+        cid_value = cid if ":" in cid else f"messaging:{room.uuid}"
+        async_to_sync(channel_layer.group_send)(
+            f"channel_{room.uuid}",
+            {
+                "type": "chat.message",
+                "payload": {
+                    "type": "reminder.created",
+                    "cid": cid_value,
+                    "reminder": reminder_data,
+                },
+            },
+        )
+    except Exception:
+        pass
+
+
 class RoomListCreateView(generics.ListCreateAPIView):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
@@ -911,7 +947,7 @@ class NotificationListView(APIView):
         return Response(serializer.data)
 
 
-class ReminderListCreateView(APIView):
+class ReminderListCreateView(RoomFromCIDMixin, APIView):
     """List or create reminders for the current user."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
@@ -922,6 +958,37 @@ class ReminderListCreateView(APIView):
         serializer = ReminderSerializer(reminders, many=True)
         return Response(serializer.data)
 
+    def post(self, request):
+        cid = request.data.get("cid")
+        if not cid:
+            return Response({"cid": ["This field is required."]}, status=400)
+        if not isinstance(cid, str):
+            return Response({"cid": ["A valid string is required."]}, status=400)
+        cid_value = cid.strip()
+        if not cid_value:
+            return Response({"cid": ["This field may not be blank."]}, status=400)
+
+        room = self.get_room(cid_value)
+        if not _user_can_access_room(request.user, room):
+            return Response(status=403)
+
+        payload = request.data.copy()
+        if hasattr(payload, "pop"):
+            payload.pop("cid", None)
+        else:
+            payload = {k: v for k, v in payload.items() if k != "cid"}
+
+        serializer = ReminderCreateSerializer(
+            data=payload, context={"room": room, "user": request.user}
+        )
+        serializer.is_valid(raise_exception=True)
+        reminder = serializer.save()
+        reminder_data = ReminderSerializer(reminder).data
+
+        _broadcast_reminder_created(room, cid_value, reminder_data)
+
+        return Response(reminder_data, status=201)
+
 
 class RoomReminderCreateView(RoomFromCIDMixin, APIView):
     """Create a reminder scoped to a room."""
@@ -931,15 +998,7 @@ class RoomReminderCreateView(RoomFromCIDMixin, APIView):
 
     def post(self, request, cid: str):
         room = self.get_room(cid)
-        username = request.user.username
-        is_member = (
-            room.agent_id == request.user.id
-            or room.client == username
-            or room.messages.filter(sent_by=username).exists()
-            or getattr(request.user, "is_staff", False)
-            or getattr(request.user, "is_superuser", False)
-        )
-        if not is_member:
+        if not _user_can_access_room(request.user, room):
             return Response(status=403)
         serializer = ReminderCreateSerializer(
             data=request.data, context={"room": room, "user": request.user}
@@ -948,22 +1007,7 @@ class RoomReminderCreateView(RoomFromCIDMixin, APIView):
         reminder = serializer.save()
         reminder_data = ReminderSerializer(reminder).data
 
-        try:
-            channel_layer = get_channel_layer()
-            cid_value = f"messaging:{room.uuid}" if ":" not in cid else cid
-            async_to_sync(channel_layer.group_send)(
-                f"channel_{room.uuid}",
-                {
-                    "type": "chat.message",
-                    "payload": {
-                        "type": "reminder.created",
-                        "cid": cid_value,
-                        "reminder": reminder_data,
-                    },
-                },
-            )
-        except Exception:
-            pass
+        _broadcast_reminder_created(room, cid, reminder_data)
 
         return Response(reminder_data, status=201)
 

--- a/backend/chat/tests/test_reminders.py
+++ b/backend/chat/tests/test_reminders.py
@@ -96,3 +96,60 @@ class ReminderAPITests(APITestCase):
         self.assertEqual(group_name, f"channel_{self.room.uuid}")
         self.assertEqual(event["payload"]["type"], "reminder.created")
 
+    @patch("chat.api_views.get_channel_layer")
+    def test_create_reminder_via_global_endpoint(self, mock_get_channel_layer):
+        channel_layer = Mock()
+        channel_layer.group_send = AsyncMock()
+        mock_get_channel_layer.return_value = channel_layer
+        token = self.make_token()
+        url = reverse("reminders")
+        payload = {
+            "cid": f"messaging:{self.room.uuid}",
+            "remind_at": "2025-01-04T00:00:00Z",
+            "message_id": self.message.id,
+            "note": "global",
+        }
+        res = self.client.post(
+            url,
+            payload,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data["note"], "global")
+        channel_layer.group_send.assert_awaited_once()
+        group_name, event = channel_layer.group_send.await_args.args
+        self.assertEqual(group_name, f"channel_{self.room.uuid}")
+        self.assertEqual(event["payload"]["type"], "reminder.created")
+
+    def test_create_reminder_requires_cid(self):
+        token = self.make_token()
+        url = reverse("reminders")
+        payload = {
+            "remind_at": "2025-01-05T00:00:00Z",
+        }
+        res = self.client.post(
+            url,
+            payload,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("cid", res.data)
+
+    def test_create_reminder_requires_membership(self):
+        Room.objects.create(uuid="r2", client="c2")
+        token = self.make_token()
+        url = reverse("reminders")
+        payload = {
+            "cid": "messaging:r2",
+            "remind_at": "2025-01-06T00:00:00Z",
+        }
+        res = self.client.post(
+            url,
+            payload,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(res.status_code, 403)
+

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -597,16 +597,13 @@ export const listRoomDrafts = async ({
   return Array.isArray(data) ? (data as RoomDraft[]) : [];
 };
 
-async function createReminder({ cid, ...body }: CreateReminderInput): Promise<Reminder> {
-  const response = await fetch(
-    `/api/rooms/${encodeURIComponent(cid)}/reminders/`,
-    {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    },
-  );
+async function createReminder(body: CreateReminderInput): Promise<Reminder> {
+  const response = await fetch("/api/reminders/", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 
   if (!response.ok) {
     const error = new Error(

--- a/openapi/backend-openapi-spec.yml
+++ b/openapi/backend-openapi-spec.yml
@@ -578,7 +578,8 @@ paths:
             application/json:
               schema:
                 type: array
-                items: {}
+                items:
+                  $ref: '#/components/schemas/Reminder'
           description: ''
       tags:
       - api
@@ -592,20 +593,24 @@ paths:
             schema:
               type: object
               properties:
-                text:
+                cid:
                   type: string
                 remind_at:
                   type: string
                   format: date-time
+                message_id:
+                  type: integer
+                note:
+                  type: string
+              required:
+              - cid
+              - remind_at
       responses:
         '201':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  reminder:
-                    type: object
+                $ref: '#/components/schemas/Reminder'
           description: ''
       tags:
       - api
@@ -842,11 +847,19 @@ components:
         id:
           type: integer
           readOnly: true
-        text:
-          type: string
         remind_at:
           type: string
           format: date-time
+        message_id:
+          type: integer
+          nullable: true
+          readOnly: true
+        note:
+          type: string
+          nullable: true
+        created_by:
+          type: integer
+          readOnly: true
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- implement POST /api/reminders/ with membership checks and shared websocket fan-out helper
- exercise the new flow via reminder API tests and align the OpenAPI schema
- point the chat shim reminder helper at the new endpoint

## Testing
- python manage.py test chat.tests.test_reminders

------
https://chatgpt.com/codex/tasks/task_e_68d5e7fa8e748326a801feb401593304