### PR TITLE
feat: wire up channel.countUnread shim helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -93,9 +93,21 @@ export type Message = {
   sent_by: string;
 };
 
+export type ChannelCountUnreadParams = {
+  channel: { countUnread?: (lastRead?: Date) => number };
+  lastRead?: Date;
+};
+
 // shim-only: no network; delegate to SDK shim
 export async function addAnswer(input: AddAnswerInput): Promise<AddAnswer> {
   return chatSDKShim.addAnswer(input);
+}
+
+function channelCountUnread({
+  channel,
+  lastRead,
+}: ChannelCountUnreadParams): number {
+  return chatSDKShim.channelCountUnread(channel, lastRead);
 }
 
 export interface RoomDraft {
@@ -634,6 +646,9 @@ async function endSession(): Promise<void> {
 }
 
 export const chatAPI = {
+  channel: {
+    countUnread: channelCountUnread,
+  },
   createReminder,
   deleteMessage,
   updateMessage,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -512,10 +512,10 @@ export async function truncate(channel: { cid: string }): Promise<void> {
 }
 
 export function channelCountUnread(
-  channel: { countUnread: () => number },
-  _lastRead?: Date,
+  channel: { countUnread?: (lastRead?: Date) => number },
+  lastRead?: Date,
 ): number {
-  return channel.countUnread();
+  return countUnread(channel, lastRead);
 }
 
 export function countUnread(

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -471,7 +471,10 @@ const ChannelInner = (
           channelConfig?.read_events &&
           !channel.muteStatus().muted
         ) {
-          const unread = channel.countUnread(lastRead.current);
+          const unread = chatAPI.channel.countUnread({
+            channel,
+            lastRead: lastRead.current,
+          });
 
           if (activeUnreadHandler) {
             activeUnreadHandler(unread, originalTitle.current);
@@ -588,7 +591,7 @@ const ChannelInner = (
          *
          * const lastRead = channel.state.read[client.userID as string].last_read;
          */
-        if (channel.countUnread() > 0 && markReadOnMount)
+        if (chatAPI.channel.countUnread({ channel }) > 0 && markReadOnMount)
           markRead({ updateChannelUiUnreadState: false });
         // The more complex sync logic is done in Chat
       }

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
@@ -7,6 +7,7 @@ import { ChannelPreviewMessenger } from './ChannelPreviewMessenger';
 import { useIsChannelMuted } from './hooks/useIsChannelMuted';
 import { useChannelPreviewInfo } from './hooks/useChannelPreviewInfo';
 import { getLatestMessagePreview as defaultGetLatestMessagePreview } from './utils';
+import { chatAPI } from '../../api/chatAPI';
 import { useChatContext } from '../../context/ChatContext';
 import { useTranslationContext } from '../../context/TranslationContext';
 import { useMessageDeliveryStatus } from './hooks/useMessageDeliveryStatus';
@@ -113,7 +114,7 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
     const handleEvent = (event: Event) => {
       if (channel.cid !== event.cid) return;
       if (event.user?.id !== client.user?.id) return;
-      setUnread(channel.countUnread());
+      setUnread(chatAPI.channel.countUnread({ channel }));
     };
     return () => {
     };
@@ -125,7 +126,7 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
         if (muted) {
           setUnread(0);
         } else {
-          setUnread(channel.countUnread());
+          setUnread(chatAPI.channel.countUnread({ channel }));
         }
       }, 400),
     [channel, muted],

--- a/libs/stream-chat-shim/src/components/MessageList/ScrollToBottomButton.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/ScrollToBottomButton.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { ArrowDown } from './icons';
 
 import { useChannelStateContext, useChatContext } from '../../context';
+import { chatAPI } from '../../api/chatAPI';
 
 import type { Event } from 'chat-shim';
 import type { MessageNotificationProps } from './MessageNotification';
@@ -18,11 +19,20 @@ const UnMemoizedScrollToBottomButton = (
 
   const { channel: activeChannel, client } = useChatContext();
   const { thread } = useChannelStateContext();
-  const [countUnread, setCountUnread] = useState(
-    /* TODO backend-wire-up: countUnread */ 0,
-  );
+  const [countUnread, setCountUnread] = useState(() => {
+    if (!activeChannel) return 0;
+    return chatAPI.channel.countUnread({ channel: activeChannel });
+  });
   const [replyCount, setReplyCount] = useState(thread?.reply_count || 0);
   const observedEvent = threadList ? 'message.updated' : 'message.new';
+
+  useEffect(() => {
+    if (!activeChannel) {
+      setCountUnread(0);
+      return;
+    }
+    setCountUnread(chatAPI.channel.countUnread({ channel: activeChannel }));
+  }, [activeChannel]);
 
   useEffect(() => {
     const handleEvent = (event: Event) => {


### PR DESCRIPTION
## Summary
- add a typed chatAPI.channel.countUnread helper backed by the shim implementation
- update channel preview, channel, and scroll-to-bottom UI to consume the helper instead of direct SDK calls

## Testing
- pnpm --filter frontend lint *(fails: Next.js CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fd0b8f008326aee2ab387536b965