### PR TITLE
feat(registerSubscriptions): wire up POST /api/register-subscriptions/

### DIFF
--- a/backend/chat/api.py
+++ b/backend/chat/api.py
@@ -11,6 +11,7 @@ import jwt
 from accounts_supabase.authentication import DevTokenOrJWTAuthentication
 
 from .serializers import RegisterSubscriptionsSerializer
+from .webpush import broadcast_subscriptions_registered
 
 @api_view(["GET"])
 def ws_auth(request):
@@ -121,7 +122,9 @@ def register_subscriptions(request):
     """Register web push subscriptions and echo them back."""
     serializer = RegisterSubscriptionsSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
+    client_id = serializer.validated_data.get("client_id")
     data = serializer.save(user=request.user)
+    broadcast_subscriptions_registered(request.user, client_id, data)
     return Response(data, status=status.HTTP_201_CREATED)
 
 

--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -52,6 +52,7 @@ from .serializers import (
     RoomSerializer,
     UserMuteUnmuteSerializer,
 )
+from .webpush import broadcast_subscriptions_registered
 
 
 def _user_can_access_room(user, room) -> bool:
@@ -1464,5 +1465,7 @@ class RegisterSubscriptionsView(APIView):
     def post(self, request):
         serializer = RegisterSubscriptionsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        client_id = serializer.validated_data.get("client_id")
         data = serializer.save(user=request.user)
+        broadcast_subscriptions_registered(request.user, client_id, data)
         return Response(data, status=status.HTTP_201_CREATED)

--- a/backend/chat/tests/test_register_subscriptions.py
+++ b/backend/chat/tests/test_register_subscriptions.py
@@ -1,16 +1,26 @@
-from django.conf import settings
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from django.conf import settings as django_settings
 from django.urls import reverse
 import jwt
 from rest_framework.test import APITestCase
 
-from chat.models import WebPushSubscription
+from chat.models import Room, WebPushSubscription
+
+
+@pytest.fixture
+def settings():  # type: ignore[override]
+    from django.conf import settings as django_settings
+
+    return django_settings
 
 
 class RegisterSubscriptionsAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
         return jwt.encode(
             {"sub": sub, "email": email},
-            settings.SUPABASE_JWT_SECRET,
+            django_settings.SUPABASE_JWT_SECRET,
             algorithm="HS256",
         )
 
@@ -92,6 +102,45 @@ class RegisterSubscriptionsAPITests(APITestCase):
         self.assertEqual(stored.auth, "changed")
         self.assertEqual(stored.expiration_time, 123.0)
         self.assertEqual(stored.platform, "ios")
+
+    @patch("chat.webpush.get_channel_layer")
+    def test_broadcasts_subscription_event(self, mock_get_channel_layer):
+        token = self.make_token()
+        room = Room.objects.create(uuid="room-1", client="c1")
+
+        channel_layer = Mock()
+        channel_layer.group_send = AsyncMock()
+        mock_get_channel_layer.return_value = channel_layer
+
+        url = reverse("register-subscriptions")
+        payload = {
+            "subscriptions": [
+                {
+                    "endpoint": "https://push.example/1",
+                    "keys": {"p256dh": "pkey", "auth": "akey"},
+                }
+            ],
+            "client_id": f"messaging:{room.uuid}",
+        }
+
+        response = self.client.post(
+            url,
+            payload,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        channel_layer.group_send.assert_awaited_once()
+        group_name, event = channel_layer.group_send.await_args.args
+        self.assertEqual(group_name, f"channel_{room.uuid}")
+        self.assertEqual(event["type"], "chat.message")
+        payload_sent = event["payload"]
+        self.assertEqual(payload_sent["type"], "push.subscription.registered")
+        self.assertEqual(payload_sent["cid"], f"messaging:{room.uuid}")
+        self.assertEqual(payload_sent.get("subscriptions"), response.data["subscriptions"])
+        self.assertEqual(payload_sent.get("client_id"), f"messaging:{room.uuid}")
+        self.assertEqual(payload_sent.get("user"), "u1")
 
     def test_requires_auth(self):
         url = reverse("register-subscriptions")

--- a/backend/chat/webpush.py
+++ b/backend/chat/webpush.py
@@ -1,0 +1,81 @@
+"""Utilities for web push subscription fan-out."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from .models import Room
+
+
+def _resolve_room_from_client_id(client_id: Any) -> Optional[Tuple[str, Room]]:
+    """Return the room associated with ``client_id`` if it resembles a cid."""
+
+    if not isinstance(client_id, str):
+        return None
+
+    candidate = client_id.strip()
+    if not candidate:
+        return None
+
+    potential_uuid: Optional[str]
+    if ":" in candidate:
+        _prefix, suffix = candidate.split(":", 1)
+        potential_uuid = suffix or None
+    else:
+        potential_uuid = candidate
+
+    if not potential_uuid:
+        return None
+
+    room = Room.objects.filter(uuid=potential_uuid).first()
+    if not room:
+        return None
+
+    canonical_cid = candidate if ":" in candidate else f"messaging:{room.uuid}"
+    return canonical_cid, room
+
+
+def broadcast_subscriptions_registered(
+    user: Any,
+    client_id: Any,
+    response_payload: dict[str, Any],
+) -> None:
+    """Emit a WS event notifying peers of a registered push subscription."""
+
+    resolved = _resolve_room_from_client_id(client_id)
+    if not resolved:
+        return
+
+    cid_value, room = resolved
+
+    try:
+        channel_layer = get_channel_layer()
+        if channel_layer is None:
+            return
+
+        payload: dict[str, Any] = {
+            "type": "push.subscription.registered",
+            "cid": cid_value,
+            "subscriptions": response_payload.get("subscriptions", []),
+        }
+
+        if "client_id" in response_payload:
+            payload["client_id"] = response_payload.get("client_id")
+
+        if "platform" in response_payload:
+            payload["platform"] = response_payload.get("platform")
+
+        username = getattr(user, "username", None)
+        if username:
+            payload["user"] = username
+
+        async_to_sync(channel_layer.group_send)(
+            f"channel_{room.uuid}",
+            {"type": "chat.message", "payload": payload},
+        )
+    except Exception:
+        # Fan-out failures should not prevent the HTTP response.
+        pass

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -131,7 +131,7 @@
     "operationId": "registerSubscriptions",
     "stubName": "threads.registerSubscriptions",
     "ticketType": "api",
-    "todoCount": 1,
+    "todoCount": 0,
     "status": "ok"
   },
   {
@@ -140,7 +140,7 @@
     "operationId": "registerSubscriptions",
     "stubName": "polls.registerSubscriptions",
     "ticketType": "api",
-    "todoCount": 1,
+    "todoCount": 0,
     "status": "ok"
   },
   {
@@ -149,7 +149,7 @@
     "operationId": "registerSubscriptions",
     "stubName": "reminders.registerSubscriptions",
     "ticketType": "api",
-    "todoCount": 1,
+    "todoCount": 0,
     "status": "ok"
   },
   {


### PR DESCRIPTION
## Summary
- add a web push broadcast helper that resolves client ids to rooms and emits `push.subscription.registered` events
- wire the register-subscriptions endpoints to reuse the helper when persisting subscriptions
- cover the websocket fan-out with a dedicated API test and mark the wire-up manifest entries complete

## Testing
- python manage.py test chat.tests.test_register_subscriptions --verbosity 2

------
https://chatgpt.com/codex/tasks/task_e_68d600b1581483268bd09ca81722c54c