### PR TITLE
feat(unmuteUser): wire up POST /api/user-mutes/unmute/

### DIFF
--- a/openapi/frontend-openapi-spec.yml
+++ b/openapi/frontend-openapi-spec.yml
@@ -528,8 +528,9 @@ paths:
                 $ref: '#/components/schemas/Mute'
   /user-mutes/unmute/:
     post:
+      description: Unmute a previously muted user (global).
       operationId: unmuteUser
-      tags: [mutes]
+      tags: [api]
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- document the unmuteUser endpoint in the frontend OpenAPI spec with an explicit description and api tag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6162aa0d08326a6c8ba22ad32e792