### PR TITLE
feat(addAnswer): implement shim-only addAnswer and wire to chatAPI helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -649,6 +649,7 @@ export const chatAPI = {
   channel: {
     countUnread: channelCountUnread,
   },
+  addAnswer,
   createReminder,
   deleteMessage,
   updateMessage,

--- a/libs/stream-chat-shim/src/components/Poll/PollActions/AddCommentForm.tsx
+++ b/libs/stream-chat-shim/src/components/Poll/PollActions/AddCommentForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormDialog } from '../../Dialog/FormDialog';
 import { useStateStore } from '../../../store';
-import * as chatAPI from '../../../api/chatAPI';
+import { chatAPI } from '../../../api/chatAPI';
 import {
   useChatContext,
   usePollContext,


### PR DESCRIPTION
## Summary
- expose the shimmed addAnswer implementation through the chatAPI facade
- update the poll add comment form to consume the new chatAPI.addAnswer helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d620115cf48326b81929eee59ba4ba