### PR TITLE
feat: wire up reminder creation endpoint

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -81,7 +81,7 @@ def _broadcast_reminder_created(room, cid: str, reminder_data: dict) -> None:
             {
                 "type": "chat.message",
                 "payload": {
-                    "type": "reminder.created",
+                    "type": "reminder.new",
                     "cid": cid_value,
                     "reminder": reminder_data,
                 },

--- a/backend/chat/tests/test_reminders.py
+++ b/backend/chat/tests/test_reminders.py
@@ -94,7 +94,7 @@ class ReminderAPITests(APITestCase):
         channel_layer.group_send.assert_awaited_once()
         group_name, event = channel_layer.group_send.await_args.args
         self.assertEqual(group_name, f"channel_{self.room.uuid}")
-        self.assertEqual(event["payload"]["type"], "reminder.created")
+        self.assertEqual(event["payload"]["type"], "reminder.new")
 
     @patch("chat.api_views.get_channel_layer")
     def test_create_reminder_via_global_endpoint(self, mock_get_channel_layer):
@@ -120,7 +120,7 @@ class ReminderAPITests(APITestCase):
         channel_layer.group_send.assert_awaited_once()
         group_name, event = channel_layer.group_send.await_args.args
         self.assertEqual(group_name, f"channel_{self.room.uuid}")
-        self.assertEqual(event["payload"]["type"], "reminder.created")
+        self.assertEqual(event["payload"]["type"], "reminder.new")
 
     def test_create_reminder_requires_cid(self):
         token = self.make_token()

--- a/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/MessageActionsBox.tsx
@@ -12,7 +12,8 @@ import {
   useTranslationContext,
 } from '../../context';
 import { MESSAGE_ACTIONS } from '../Message/utils';
-import { chatAPI, type CreateReminderInput } from '../../api/chatAPI';
+import { type CreateReminderInput } from '../../api/chatAPI';
+import { clientRemindersCreateReminder } from '../../chatSDKShim';
 import type { MessageContextValue } from '../../context';
 
 type PropsDrilledToMessageActionsBox =
@@ -192,16 +193,7 @@ const UnMemoizedMessageActionsBox = (props: MessageActionsBoxProps) => {
               if (typeof rawMessageId === 'number' && !Number.isNaN(rawMessageId)) {
                 params.message_id = rawMessageId;
               }
-              const createReminder = client.reminders?.createReminder;
-              if (createReminder) {
-                if (typeof createReminder.length === 'number' && createReminder.length >= 2) {
-                  await createReminder(params.note ?? '', params.remind_at);
-                } else {
-                  await createReminder(params);
-                }
-              } else {
-                await chatAPI.createReminder(params);
-              }
+              await clientRemindersCreateReminder(client, params);
             }}
             role='option'
           >


### PR DESCRIPTION
## Summary
- broadcast `reminder.new` to channel subscribers when a reminder is created and cover it with tests
- route the MessageActionsBox “Save for later” action through `clientRemindersCreateReminder` so it always uses the typed chat API helper

## Testing
- pipenv run python manage.py test chat.tests.test_reminders
- pnpm test -- --runTestsByPath libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts *(fails: missing turbo binary in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d623a40e808326b0ca3595fec963e3