### PR TITLE
feat(channel.pin): wire up shim-only helper

### DIFF
--- a/libs/stream-chat-shim/__tests__/channel.pin.test.ts
+++ b/libs/stream-chat-shim/__tests__/channel.pin.test.ts
@@ -1,0 +1,50 @@
+jest.mock('../../chat-shim', () => {
+  class StateStore<T> {
+    constructor(_init?: T) {}
+    getLatestValue(): T | undefined {
+      return undefined;
+    }
+    dispatch(): void {}
+    subscribe(): () => void {
+      return () => {};
+    }
+    subscribeWithSelector(): () => void {
+      return () => {};
+    }
+    next(): void {}
+    partialNext(): void {}
+  }
+
+  return { StateStore };
+});
+
+import { channelPin } from '../src/chatSDKShim';
+
+describe('channelPin', () => {
+  it('calls channel.pin when provided a message id', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const messageId = 'message-1';
+    const result = await channelPin({ pin: fn }, messageId);
+    expect(fn).toHaveBeenCalledWith(messageId);
+    expect(result).toBe('ok');
+  });
+
+  it('calls channel.pin when provided a message object', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const message = { id: 'message-2', text: 'Hello world' };
+    const result = await channelPin({ pin: fn }, message);
+    expect(fn).toHaveBeenCalledWith(message);
+    expect(result).toBe('ok');
+  });
+
+  it('calls channel.pin without a message when no target is provided', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await channelPin({ pin: fn });
+    expect(fn).toHaveBeenCalledWith(undefined);
+    expect(result).toBe('ok');
+  });
+
+  it('resolves undefined when channel.pin is unavailable', async () => {
+    await expect(channelPin({} as any)).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -477,6 +477,7 @@ export const chatSDKShim = {
 export const chatSDK = {
   channel: {
     archive: channelArchive,
+    pin: channelPin,
   },
 };
 
@@ -708,12 +709,21 @@ export function channelOn(
   return createSubscription(channel, eventType, handler as (...args: any[]) => void);
 }
 
+type ChannelPinTarget = string | ChannelMessageLike;
+
+type ChannelWithPin = { pin?: (message?: ChannelPinTarget) => Promise<any> };
+
+export async function channelPin(channel: ChannelWithPin): Promise<any>;
 export async function channelPin(
-  channel: { pin?: (messageId: string) => Promise<any> },
-  messageId: string,
+  channel: ChannelWithPin,
+  message: ChannelPinTarget,
+): Promise<any>;
+export async function channelPin(
+  channel: ChannelWithPin,
+  message?: ChannelPinTarget,
 ): Promise<any> {
   if (typeof channel.pin === "function") {
-    return channel.pin(messageId);
+    return channel.pin(message);
   }
   return undefined;
 }

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
@@ -31,7 +31,7 @@ export function ChannelPreviewActionButtons({
           if (membership.pinned_at) {
             channelUnpin(channel);
           } else {
-            /* TODO backend-wire-up: channel.pin */
+            void chatSDK.channel.pin(channel);
           }
         }}
         title={membership.pinned_at ? t('Unpin') : t('Pin')}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -285,7 +285,7 @@
     "stubName": "channel.pin",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- expose a typed `channel.pin` helper in the shim and surface it through `chatSDK.channel`
- update the channel preview action button to invoke the helper instead of the placeholder comment
- cover the helper with focused unit tests and mark the wireup manifest entry as complete

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/channel.pin.test.ts *(fails: ts-jest reports TS2339 for chatSDKShim.channelCountUnread in chatAPI.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d68fb5c4c88326937135587781f4f4