### PR TITLE
feat: wire channel.state.loadMessageIntoState helper

### DIFF
--- a/libs/stream-chat-shim/__tests__/channel.state.loadMessageIntoState.test.ts
+++ b/libs/stream-chat-shim/__tests__/channel.state.loadMessageIntoState.test.ts
@@ -1,0 +1,100 @@
+jest.mock(
+  'react',
+  () => ({ useSyncExternalStore: jest.fn() }),
+  { virtual: true },
+);
+
+import { loadMessageIntoChannelState } from '../src/chatSDKShim';
+
+describe('loadMessageIntoChannelState', () => {
+  const createChannel = () => {
+    const channelState = {
+      messages: [] as Array<Record<string, unknown>>,
+      messagePagination: {},
+    };
+    const dispatch = jest.fn();
+    return {
+      cid: 'messaging:123',
+      state: channelState,
+      stateStore: { dispatch },
+    } as any;
+  };
+
+  const baseApiMessage = {
+    id: 42,
+    body: 'hello world',
+    created_at: '2024-01-01T00:00:00.000Z',
+    sent_by: 'user-1',
+  };
+
+  it('adds messages to the channel state and dispatches updates', async () => {
+    const channel = createChannel();
+
+    const normalized = await loadMessageIntoChannelState(channel as any, baseApiMessage);
+
+    expect(normalized.id).toBe('42');
+    expect(channel.state?.messages).toHaveLength(1);
+    expect(channel.state?.messages?.[0]).toMatchObject({
+      id: '42',
+      text: 'hello world',
+      user: { id: 'user-1' },
+    });
+    expect(channel.stateStore?.dispatch).toHaveBeenCalledWith({
+      messages: channel.state?.messages,
+      messagePagination: {},
+    });
+  });
+
+  it('merges updates by message id without duplicating entries', async () => {
+    const channel = createChannel();
+
+    await loadMessageIntoChannelState(channel as any, baseApiMessage);
+
+    const updated = await loadMessageIntoChannelState(channel as any, {
+      ...baseApiMessage,
+      body: 'updated body',
+    });
+
+    expect(channel.state?.messages).toHaveLength(1);
+    expect(updated.text).toBe('updated body');
+    expect(channel.state?.messages?.[0]).toMatchObject({
+      id: '42',
+      text: 'updated body',
+    });
+  });
+
+  it('accepts normalized messages and preserves existing fields', async () => {
+    const channel = createChannel();
+
+    await loadMessageIntoChannelState(channel as any, baseApiMessage);
+
+    const normalizedInput = {
+      ...(channel.state?.messages?.[0] as Record<string, unknown>),
+      id: '42',
+      cid: channel.cid,
+      text: 'normalized update',
+      custom: 'value',
+    };
+
+    await loadMessageIntoChannelState(channel as any, normalizedInput);
+
+    expect(channel.state?.messages).toHaveLength(1);
+    expect(channel.state?.messages?.[0]).toMatchObject({
+      id: '42',
+      text: 'normalized update',
+      custom: 'value',
+    });
+    expect(typeof (channel.state as any)?.loadMessageIntoState).toBe('function');
+
+    const loader = (channel.state as any).loadMessageIntoState!;
+    await loader({
+      ...baseApiMessage,
+      body: 'loader body',
+    });
+
+    expect(channel.state?.messages?.[0]).toMatchObject({
+      id: '42',
+      text: 'loader body',
+    });
+  });
+});

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -92,14 +92,16 @@ type ChannelMessageLike = {
   user?: ChannelUserLike | null;
 } & Record<string, unknown>;
 
+type NormalizedChannelMessage = ChannelMessageLike & { id: string };
+type LoadMessageIntoStateInput = APIMessage | NormalizedChannelMessage;
+type ChannelStateLoadMessageIntoStateFn = (
+  message: LoadMessageIntoStateInput,
+) => Promise<NormalizedChannelMessage>;
+
 type ChannelStateLike = {
   messages?: ChannelMessageLike[];
   messagePagination?: { hasPrev?: boolean; hasNext?: boolean };
-  loadMessageIntoState?: (
-    id: string,
-    around?: string,
-    limit?: number,
-  ) => Promise<any>;
+  loadMessageIntoState?: ChannelStateLoadMessageIntoStateFn;
   addMessageSorted?: (
     message: Record<string, unknown>,
     timestampChanged?: boolean,
@@ -112,8 +114,6 @@ type ChannelWithLocalState = {
   state?: ChannelStateLike;
   stateStore?: StateStore<any>;
 };
-
-type NormalizedChannelMessage = ChannelMessageLike & { id: string };
 
 type ChannelQueryResult = {
   messages: NormalizedChannelMessage[];
@@ -213,11 +213,39 @@ const normalizeChannelMessage = (
   return existing ? { ...existing, ...base } : base;
 };
 
+const isNormalizedChannelMessageInput = (
+  message: LoadMessageIntoStateInput,
+): message is NormalizedChannelMessage => {
+  if (!message || typeof message !== "object") return false;
+
+  const candidate = message as Partial<NormalizedChannelMessage>;
+  return (
+    typeof candidate.id === "string" && typeof candidate.cid === "string"
+  );
+};
+
+function toNormalizedChannelMessage(
+  channel: ChannelWithLocalState,
+  message: LoadMessageIntoStateInput,
+): NormalizedChannelMessage {
+  if (isNormalizedChannelMessageInput(message)) {
+    const existing = channel.state?.messages?.find?.(
+      (msg) =>
+        String((msg as { id?: string | number }).id ?? "") === message.id,
+    ) as NormalizedChannelMessage | undefined;
+
+    return existing ? { ...existing, ...message } : { ...message };
+  }
+
+  return normalizeChannelMessage(channel, message);
+}
+
 const updateChannelStateWithMessages = (
   channel: ChannelWithLocalState,
   incoming: NormalizedChannelMessage[],
   paginationUpdate?: { hasPrev?: boolean; hasNext?: boolean },
 ) => {
+  ensureChannelStateLoadMessageIntoState(channel);
   if (!channel.state) return;
 
   const existingMessages = Array.isArray(channel.state.messages)
@@ -256,6 +284,40 @@ const updateChannelStateWithMessages = (
     });
   }
 };
+
+function ensureChannelStateLoadMessageIntoState(
+  channel: ChannelWithLocalState,
+): ChannelStateLoadMessageIntoStateFn | undefined {
+  const state = channel.state;
+  if (!state) return undefined;
+
+  if (typeof state.loadMessageIntoState === "function") {
+    return state.loadMessageIntoState;
+  }
+
+  const load: ChannelStateLoadMessageIntoStateFn = async (message) => {
+    const normalized = toNormalizedChannelMessage(channel, message);
+    updateChannelStateWithMessages(channel, [normalized]);
+    return normalized;
+  };
+
+  state.loadMessageIntoState = load;
+  return load;
+}
+
+export function loadMessageIntoChannelState(
+  channel: ChannelWithLocalState,
+  message: LoadMessageIntoStateInput,
+): Promise<NormalizedChannelMessage> {
+  const loader = ensureChannelStateLoadMessageIntoState(channel);
+  if (loader) {
+    return loader(message);
+  }
+
+  const normalized = toNormalizedChannelMessage(channel, message);
+  updateChannelStateWithMessages(channel, [normalized]);
+  return Promise.resolve(normalized);
+}
 
 const extractMessageOptions = (
   options?: ShimChannelQueryOptions,
@@ -654,6 +716,7 @@ export const chatSDKShim = {
   async castVote(params: CastVoteParams): Promise<CastVoteResult> {
     return castVoteInternal(params);
   },
+  channelCountUnread,
 };
 
 export const chatSDK = {
@@ -1051,9 +1114,18 @@ export async function channelStateLoadMessageIntoState(
   messageId: string,
   around?: string,
   messageLimit?: number,
-): Promise<any> {
-  if (channel.state?.loadMessageIntoState) {
-    return channel.state.loadMessageIntoState(messageId, around, messageLimit);
+): Promise<NormalizedChannelMessage | undefined> {
+  if (messageId === "latest") {
+    const latestMessage = channel.state?.messages?.[
+      (channel.state?.messages?.length ?? 1) - 1
+    ];
+    if (latestMessage) {
+      return loadMessageIntoChannelState(
+        channel,
+        latestMessage as LoadMessageIntoStateInput,
+      );
+    }
+    return undefined;
   }
 
   const numericMessageId = Number(messageId);
@@ -1066,10 +1138,7 @@ export async function channelStateLoadMessageIntoState(
     message_id: numericMessageId,
   });
 
-  const normalizedMessage = normalizeChannelMessage(channel, apiMessage);
-  updateChannelStateWithMessages(channel, [normalizedMessage]);
-
-  return normalizedMessage;
+  return loadMessageIntoChannelState(channel, apiMessage);
 }
 
 export async function channelWatch(

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -97,6 +97,7 @@ import {
   channelMarkRead,
   channelQuery,
   channelStateLoadMessageIntoState,
+  loadMessageIntoChannelState,
 } from "../../chatSDKShim";
 import { chatAPI } from "../../api/chatAPI";
 
@@ -996,8 +997,7 @@ const ChannelInner = (
   );
 
   const updateMessage = (updatedMessage: MessageResponse | LocalMessage) => {
-    // add the message to the local channel state
-    channel.state.addMessageSorted(updatedMessage, true);
+    void loadMessageIntoChannelState(channel, updatedMessage);
 
     dispatch({
       channel,

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -303,7 +303,7 @@
     "stubName": "channel.state.loadMessageIntoState",
     "ticketType": "shim",
     "todoCount": 4,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed `loadMessageIntoChannelState` helper that normalizes messages and updates channel state
- update the Channel component to use the helper instead of `addMessageSorted` and expose the shim entry on the manifest
- cover the helper with unit tests for idempotent updates

## Testing
- pnpm exec jest --runTestsByPath libs/stream-chat-shim/__tests__/channel.state.loadMessageIntoState.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d69bf65e2c8326820fb6ecb03a6908