### PR TITLE
feat(channel.unpin): wire up shim-only operation

### DIFF
--- a/libs/stream-chat-shim/__tests__/channel.unpin.test.ts
+++ b/libs/stream-chat-shim/__tests__/channel.unpin.test.ts
@@ -1,14 +1,74 @@
-import { channelUnpin } from '../src/chatSDKShim';
+import { StateStore } from 'chat-shim';
 
-describe('channelUnpin', () => {
-  it('calls channel.unpin when available', async () => {
-    const fn = jest.fn().mockResolvedValue('ok');
-    const res = await channelUnpin({ unpin: fn });
-    expect(fn).toHaveBeenCalled();
-    expect(res).toBe('ok');
+import { chatAPI } from '../src/api/chatAPI';
+
+describe('chatAPI.channel.unpin', () => {
+  it('invokes channel.unpin when available and normalizes the response', async () => {
+    const at = '2024-01-01T00:00:00.000Z';
+    const channel = {
+      unpin: jest.fn().mockResolvedValue({ at }),
+      state: {},
+      stateStore: { dispatch: jest.fn() },
+    };
+
+    const result = await chatAPI.channel.unpin({ channel });
+
+    expect(channel.unpin).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ pinned: false, at });
   });
 
-  it('resolves undefined when not implemented', async () => {
-    await expect(channelUnpin({} as any)).resolves.toBeUndefined();
+  it('resets local membership state when unpinning', async () => {
+    const membership = {
+      pinned: true,
+      pinned_at: '2024-01-01T12:00:00.000Z',
+      pin_expires: '2024-01-02T00:00:00.000Z',
+      pinned_by: { id: 'user-1' },
+    } as Record<string, unknown>;
+
+    const members: Record<string, Record<string, unknown>> = {
+      'user-1': {
+        pinned: true,
+        pinned_at: '2024-01-01T12:00:00.000Z',
+        pin_expires: '2024-01-02T00:00:00.000Z',
+        pinned_by: { id: 'user-1' },
+        extra: 'value',
+      },
+      'user-2': {
+        pinned: true,
+        pinned_at: '2024-01-01T12:00:00.000Z',
+      },
+    };
+
+    const state = { membership, members };
+    const stateStore = new StateStore(state);
+
+    const channel = {
+      state,
+      stateStore,
+      getClient: () => ({ user: { id: 'user-1' } }),
+    };
+
+    const result = await chatAPI.channel.unpin({ channel });
+
+    expect(result.pinned).toBe(false);
+    expect(typeof result.at).toBe('string');
+
+    expect(state.membership?.pinned).toBe(false);
+    expect(state.membership?.pinned_at).toBeNull();
+    expect(state.membership?.pin_expires).toBeNull();
+    expect(state.membership?.pinned_by).toBeNull();
+
+    expect(state.members['user-1'].pinned).toBe(false);
+    expect(state.members['user-1'].pinned_at).toBeNull();
+    expect(state.members['user-1'].pin_expires).toBeNull();
+    expect(state.members['user-1'].pinned_by).toBeNull();
+    expect(state.members['user-1'].extra).toBe('value');
+
+    expect(state.members['user-2'].pinned).toBe(true);
+    expect(state.members['user-2'].pinned_at).toBe('2024-01-01T12:00:00.000Z');
+
+    const storeSnapshot = stateStore.getLatestValue();
+    expect(storeSnapshot.membership).toEqual(state.membership);
+    expect(storeSnapshot.members).toEqual(state.members);
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -182,6 +182,23 @@ export const channelQuery = async ({
   return { messages, next };
 };
 
+type ChannelMembershipRecord = Record<string, unknown>;
+
+type ChannelStateStoreLike = {
+  dispatch?: (patch: Record<string, unknown>) => void;
+};
+
+type ChannelUnpinChannel = {
+  state?: Record<string, unknown> | null;
+  stateStore?: ChannelStateStoreLike | null;
+  getClient?: () => { user?: { id?: string | number | null } | null } | null;
+  unpin?: () => Promise<unknown>;
+};
+
+export type ChannelUnpinParams = { channel: ChannelUnpinChannel | undefined };
+
+export type ChannelUnpinResult = { pinned: false; at: string };
+
 export interface RoomDraft {
   id?: number;
   text?: string;
@@ -197,6 +214,101 @@ interface ErrorWithStatus extends Error {
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null;
+};
+
+const normalizeUserId = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+};
+
+const toUnpinnedMembership = (
+  membership: ChannelMembershipRecord | undefined,
+): ChannelMembershipRecord => {
+  const next: ChannelMembershipRecord = { ...(membership ?? {}) };
+
+  next.pinned = false;
+  next.pinned_at = null;
+
+  if ("pin_expires" in next) {
+    next.pin_expires = null;
+  }
+  if ("pinned_by" in next) {
+    next.pinned_by = null;
+  }
+
+  return next;
+};
+
+const applyChannelUnpinLocally = (channel: ChannelUnpinChannel): void => {
+  const state = channel.state;
+  if (!isRecord(state)) {
+    return;
+  }
+
+  const rawMembership = state.membership;
+  const nextMembership = toUnpinnedMembership(
+    isRecord(rawMembership) ? (rawMembership as ChannelMembershipRecord) : undefined,
+  );
+
+  (state as Record<string, unknown>).membership = nextMembership;
+
+  const patch: Record<string, unknown> = { membership: nextMembership };
+
+  const rawMembers = state.members;
+  if (isRecord(rawMembers)) {
+    const client = typeof channel.getClient === "function" ? channel.getClient() : undefined;
+    const ownUserId = normalizeUserId(client?.user?.id);
+
+    if (ownUserId) {
+      const rawMember = rawMembers[ownUserId];
+      if (isRecord(rawMember)) {
+        const nextMember = toUnpinnedMembership(rawMember as ChannelMembershipRecord);
+        (rawMembers as Record<string, unknown>)[ownUserId] = nextMember;
+        patch.members = { ...(rawMembers as Record<string, unknown>) };
+      }
+    }
+  }
+
+  const store = channel.stateStore;
+  if (store && typeof store.dispatch === "function") {
+    store.dispatch(patch);
+  }
+};
+
+const extractUnpinAt = (result: unknown, fallback: string): string => {
+  if (isRecord(result)) {
+    const at = result.at;
+    if (typeof at === "string") {
+      return at;
+    }
+    const pinnedAt = result.pinned_at;
+    if (typeof pinnedAt === "string") {
+      return pinnedAt;
+    }
+  }
+  return fallback;
+};
+
+const channelUnpin = async ({ channel }: ChannelUnpinParams): Promise<ChannelUnpinResult> => {
+  const fallbackAt = new Date().toISOString();
+
+  if (!channel) {
+    return { pinned: false as const, at: fallbackAt };
+  }
+
+  const result =
+    typeof channel.unpin === "function" ? await channel.unpin() : undefined;
+
+  applyChannelUnpinLocally(channel);
+
+  const at = extractUnpinAt(result, fallbackAt);
+
+  return { pinned: false as const, at };
 };
 
 const parseWebPushKeys = (value: unknown): WebPushKeys => {
@@ -721,6 +833,7 @@ export const chatAPI = {
   channel: {
     countUnread: channelCountUnread,
     query: channelQuery,
+    unpin: channelUnpin,
   },
   addAnswer,
   createReminder,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -16,6 +16,7 @@ import {
   type RoomDraft,
   type User,
   type UserAgentInfo,
+  type ChannelUnpinResult,
   type SyncUserRequest,
   type SyncUserResponse,
 } from './api/chatAPI';
@@ -724,6 +725,7 @@ export const chatSDK = {
     archive: channelArchive,
     unarchive: channelUnarchive,
     pin: channelPin,
+    unpin: channelUnpin,
   },
 };
 
@@ -1044,13 +1046,10 @@ export async function channelPin(
   return undefined;
 }
 
-export async function channelUnpin(channel: {
-  unpin?: () => Promise<any>;
-}): Promise<any> {
-  if (typeof channel.unpin === "function") {
-    return channel.unpin();
-  }
-  return undefined;
+export async function channelUnpin(
+  channel: ChannelWithLocalState & { unpin?: () => Promise<unknown> },
+): Promise<ChannelUnpinResult> {
+  return chatAPI.channel.unpin({ channel });
 }
 
 export async function connectUser(

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreviewActionButtons.tsx
@@ -6,7 +6,8 @@ import { useChannelMembershipState } from '../ChannelList';
 import { Icon } from './icons';
 import { useTranslationContext } from '../../context';
 
-import { channelUnpin, chatSDK } from '../../chatSDKShim';
+import { chatAPI } from '../../api/chatAPI';
+import { chatSDK } from '../../chatSDKShim';
 export type ChannelPreviewActionButtonsProps = {
   channel: Channel;
 };
@@ -29,7 +30,7 @@ export function ChannelPreviewActionButtons({
         onClick={(e) => {
           e.stopPropagation();
           if (membership.pinned_at) {
-            channelUnpin(channel);
+            void chatAPI.channel.unpin({ channel });
           } else {
             void chatSDK.channel.pin(channel);
           }


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.channel.unpin` helper that normalizes results and clears channel membership pin state locally
- route chat SDK and the ChannelPreview pin action through the new helper
- expand `channel.unpin` unit coverage to assert local state updates

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/channel.unpin.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6b61dabb0832683d9e3ebef4676bb