### PR TITLE
feat: wire up channel.watch shim

### DIFF
--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1211,27 +1211,38 @@ export async function channelStateLoadMessageIntoState(
   return loadMessageIntoChannelState(channel, apiMessage);
 }
 
+type ChannelWatchable = ChannelWithLocalState & {
+  watch?: (options?: ChannelWatchOptions) => Promise<ChannelWatchResult>;
+  initialized?: boolean;
+};
+
+export type ChannelWatchOptions = ShimChannelQueryOptions & {
+  watchers?: { limit?: number; offset?: number };
+  presence?: boolean;
+  state?: Record<string, unknown>;
+};
+
+export type ChannelWatchResult =
+  | ChannelQueryResult
+  | { [key: string]: unknown }
+  | void;
+
 export async function channelWatch(
-  channel: { cid: string },
-  options?: Record<string, any>,
-): Promise<{ messages: any[] }> {
-  const searchParams = new URLSearchParams();
-  if (options) {
-    for (const [key, value] of Object.entries(options)) {
-      if (value !== undefined && value !== null) {
-        searchParams.set(key, String(value));
-      }
-    }
+  channel: ChannelWatchable,
+  options?: ChannelWatchOptions,
+): Promise<ChannelWatchResult> {
+  if (typeof channel.watch === "function") {
+    return channel.watch(options);
   }
-  const query = searchParams.toString();
-  const resp = await fetch(
-    `/api/rooms/${encodeURIComponent(channel.cid)}/messages/${
-      query ? `?${query}` : ""
-    }`,
-    { credentials: "same-origin" },
-  );
-  const data = await resp.json();
-  return { messages: data };
+
+  if (!channel.cid) {
+    channel.initialized = true;
+    return { messages: [] };
+  }
+
+  const result = await channelQuery(channel, options);
+  channel.initialized = true;
+  return result;
 }
 
 export function clientChannel(

--- a/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -8,6 +8,7 @@ import { isChannel } from "../utils";
 
 import { useChatContext } from "../../../context/ChatContext";
 import {
+  channelWatch,
   clientChannel,
   clientQueryChannels,
   clientQueryUsers,
@@ -187,9 +188,11 @@ export const useChannelSearch = ({
         const newChannel = clientChannel(
           client,
           result.type,
-          result.id,
-        ) as Channel;
-        await /* TODO backend-wire-up: channel.watch */ Promise.resolve();
+          undefined,
+          { members: [client.userID, result.id] },
+        ) as Channel | undefined;
+        if (!newChannel) return;
+        await channelWatch(newChannel);
 
         setActiveChannel(newChannel);
         selectedChannel = newChannel;

--- a/libs/stream-chat-shim/src/experimental/Search/SearchResults/SearchResultItem.tsx
+++ b/libs/stream-chat-shim/src/experimental/Search/SearchResults/SearchResultItem.tsx
@@ -10,6 +10,7 @@ import { useChannelListContext, useChatContext } from "../../../context";
 import { DEFAULT_JUMP_TO_PAGE_SIZE } from "../../../constants/limits";
 import {
   channelStateLoadMessageIntoState,
+  channelWatch,
   clientChannel,
 } from "../../../chatSDKShim";
 
@@ -102,16 +103,25 @@ export const UserSearchResultItem = ({ item }: UserSearchResultItemProps) => {
   const { setChannels } = useChannelListContext();
   const { directMessagingChannelType } = useSearchContext();
 
-  const onClick = useCallback(() => {
+  const onClick = useCallback(async () => {
+    if (!client.userID) return;
     const newChannel = clientChannel(
       client,
       directMessagingChannelType,
-      item.id,
-    ) as Channel;
-    /* TODO backend-wire-up: channel.watch */
+      undefined,
+      { members: [client.userID, item.id] },
+    ) as Channel | undefined;
+    if (!newChannel) return;
+    await channelWatch(newChannel);
     setActiveChannel(newChannel);
     setChannels?.((channels) => uniqBy([newChannel, ...channels], "cid"));
-  }, [item, setActiveChannel, setChannels, directMessagingChannelType]);
+  }, [
+    client,
+    directMessagingChannelType,
+    item.id,
+    setActiveChannel,
+    setChannels,
+  ]);
 
   return (
     <button

--- a/libs/stream-chat-shim/src/utils/getChannel.ts
+++ b/libs/stream-chat-shim/src/utils/getChannel.ts
@@ -4,7 +4,11 @@ import type {
   QueryChannelAPIResponse,
   StreamChat,
 } from 'chat-shim';
-import { clientChannel } from '../chatSDKShim';
+import {
+  channelWatch,
+  clientChannel,
+  type ChannelWatchOptions,
+} from '../chatSDKShim';
 
 /**
  * prevent from duplicate invocation of channel.watch()
@@ -46,9 +50,9 @@ export const getChannel = async ({
 
   // unfortunately typescript is not able to infer that if (!channel && !type) === false, then channel or type has to be truthy
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const extra = members && members.length ? { members } : undefined;
   const theChannel =
-    channel ||
-    (clientChannel(client, type!, id) as Channel);
+    channel || (clientChannel(client, type!, id, extra) as Channel);
 
   // need to keep as with call to channel.watch the id can be changed from undefined to an actual ID generated server-side
   const originalCid = theChannel?.id
@@ -69,8 +73,11 @@ export const getChannel = async ({
     await queryPromise;
   } else {
     try {
-      WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] =
-        /* TODO backend-wire-up: channel.watch */ Promise.resolve(undefined);
+      const watchOptions = options as ChannelWatchOptions | undefined;
+      WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = channelWatch(
+        theChannel,
+        watchOptions,
+      );
       await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
     } finally {
       delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];


### PR DESCRIPTION
## Summary
- add a typed `channelWatch` helper that delegates to the SDK when available and hydrates local state otherwise
- ensure `getChannel` and search flows invoke the helper and pass member metadata when creating direct channels

## Testing
- pnpm --filter frontend lint *(fails: next binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6be11e4388326bd2d13502ddd27fe