### PR TITLE
feat: wire up client.channel helper

### DIFF
--- a/libs/chat-shim/index.d.ts
+++ b/libs/chat-shim/index.d.ts
@@ -1,4 +1,21 @@
 declare module 'stream-chat' {
+  export type ChannelMemberLike =
+    | string
+    | number
+    | {
+        id?: string | number;
+        user_id?: string | number;
+        user?: { id?: string | number } & Record<string, unknown>;
+        [key: string]: unknown;
+      };
+
+  export type ChannelCreateConfig = {
+    cid?: string;
+    id?: string;
+    members?: ChannelMemberLike[];
+    data?: { members?: ChannelMemberLike[] } & Record<string, unknown>;
+  } & Record<string, unknown>;
+
   /** Local replacement for Stream’s client */
   export class LocalChatClient {
     user: ({ id: string } & Record<string, unknown>) | undefined;
@@ -6,7 +23,11 @@ declare module 'stream-chat' {
     wsConnection: { online: boolean };
     connectUser(user: { id: string } & Record<string, unknown>, jwt: string): Promise<void>;
     queryUsers(): Promise<{ users: { id: string }[] }>;
-    channel(type: string, id?: string): any;
+    channel(
+      type: string,
+      idOrConfig?: string | ChannelCreateConfig,
+      config?: ChannelCreateConfig,
+    ): LocalChannel;
     disconnectUser(): void;
     deleteMessage(id: string): Promise<any>;
     updateMessage(id: string, text: string): Promise<any>;
@@ -61,6 +82,7 @@ declare module 'stream-chat' {
     readonly cid: string;
     readonly state: ChannelState;
     readonly stateStore: StateStore<ChannelState>;
+    data: Record<string, any>;
     readonly messageComposer: MessageComposer;
     watch(): Promise<LocalChannel>;
     sendMessage(msg: { text: string }): Promise<void>;

--- a/libs/chat-shim/index.js
+++ b/libs/chat-shim/index.js
@@ -182,6 +182,7 @@ var LocalChannel = /** @class */ (function () {
         this.getUserId = getUid;
         this.state = new ChannelState(function (patch) { return _this.stateStore.dispatch(patch); });
         this.stateStore = new StateStore(this.state);
+        this.data = {};
         this.messageComposer = new MessageComposer();
         this.messageComposer.submit = function () {
             var text = _this.messageComposer.state.text.trim();
@@ -247,6 +248,70 @@ var LocalChannel = /** @class */ (function () {
     return LocalChannel;
 }());
 exports.LocalChannel = LocalChannel;
+var toMemberId = function (value) {
+    if (typeof value === 'string' && value)
+        return value;
+    if (typeof value === 'number' && Number.isFinite(value))
+        return String(value);
+    return undefined;
+};
+var normalizeMember = function (input) {
+    if (input === null || input === void 0)
+        return undefined;
+    if (typeof input === 'string' || typeof input === 'number') {
+        var id = String(input);
+        return { id: id, record: { user_id: id, user: { id: id } } };
+    }
+    if (typeof input !== 'object')
+        return undefined;
+    var candidate = toMemberId(input.user_id) || toMemberId(input.id) || toMemberId(input.user && input.user.id);
+    if (!candidate)
+        return undefined;
+    var record = __assign(__assign({}, input), { user_id: candidate });
+    var rawUser = input.user;
+    var baseUser = rawUser && typeof rawUser === 'object' ? __assign({}, rawUser) : {};
+    record.user = __assign(__assign({}, baseUser), { id: baseUser.id !== undefined ? String(baseUser.id) : candidate });
+    return { id: candidate, record: record };
+};
+var collectMembers = function (config) {
+    var rawMembers = [];
+    if (config && Array.isArray(config.members)) {
+        rawMembers = rawMembers.concat(config.members);
+    }
+    var dataMembers = config && config.data && Array.isArray(config.data.members) ? config.data.members : [];
+    rawMembers = rawMembers.concat(dataMembers);
+    var memberMap = new Map();
+    rawMembers.forEach(function (raw) {
+        var normalized = normalizeMember(raw);
+        if (!normalized)
+            return;
+        var existing = memberMap.get(normalized.id);
+        memberMap.set(normalized.id, existing ? __assign(__assign({}, existing), normalized.record) : normalized.record);
+    });
+    var ids = Array.from(memberMap.keys()).sort();
+    var records = ids.map(function (id) { return memberMap.get(id); });
+    var map = {};
+    records.forEach(function (record) {
+        map[record.user_id] = record;
+    });
+    return { ids: ids, records: records, map: map };
+};
+var buildChannelData = function (config, members) {
+    if (!config && members.length === 0)
+        return undefined;
+    var base = {};
+    if (config) {
+        var data = config.data, membersProp = config.members, cid = config.cid, rest = __rest(config, ["data", "members", "cid"]);
+        if (data && typeof data === 'object') {
+            base = __assign(__assign({}, base), data);
+        }
+        base = __assign(__assign({}, base), rest);
+    }
+    if (members.length) {
+        base.members = members.map(function (member) { return __assign({}, member); });
+    }
+    return Object.keys(base).length ? base : undefined;
+};
 var LocalChatClient = /** @class */ (function () {
     function LocalChatClient() {
         /* ------------------------------------------------------------------- */
@@ -347,9 +412,32 @@ var LocalChatClient = /** @class */ (function () {
             });
         });
     };
-    LocalChatClient.prototype.channel = function (type, id) {
+    LocalChatClient.prototype.channel = function (type, idOrConfig, maybeConfig) {
         var _this = this;
-        var cid = "".concat(type, ":").concat(id !== null && id !== void 0 ? id : 'local');
+        var channelId;
+        var config;
+        if (typeof idOrConfig === 'string' || typeof idOrConfig === 'undefined') {
+            channelId = typeof idOrConfig === 'string' ? idOrConfig : undefined;
+            config = maybeConfig && typeof maybeConfig === 'object' ? __assign({}, maybeConfig) : maybeConfig;
+        }
+        else {
+            config = __assign({}, idOrConfig);
+            if (maybeConfig && typeof maybeConfig === 'object') {
+                config = __assign(__assign({}, config), maybeConfig);
+            }
+            if ((config === null || config === void 0 ? void 0 : config.id) && typeof config.id === 'string') {
+                channelId = config.id;
+            }
+        }
+        var members = collectMembers(config);
+        if (!channelId && (config === null || config === void 0 ? void 0 : config.cid)) {
+            var parts = String(config.cid).split(':');
+            channelId = parts[1] || String(config.cid);
+        }
+        if (!channelId) {
+            channelId = members.ids.length ? "!members-".concat(members.ids.join(',')) : 'local';
+        }
+        var cid = (config === null || config === void 0 ? void 0 : config.cid) || "".concat(type, ":").concat(channelId);
         if (!this.channels.has(cid)) {
             var url = "ws://".concat(location.host, "/ws/").concat(cid, "/?token=").concat(this.jwt);
             var sock = new WebSocket(url);
@@ -359,12 +447,28 @@ var LocalChatClient = /** @class */ (function () {
                 (_a = _this.channels.get(data.cid)) === null || _a === void 0 ? void 0 : _a.emit(data.type, data);
             };
             this.sockets.set(cid, sock);
-            var chan = new LocalChannel(cid, sock, function () { return _this.userId; }, _this);
+            var chan = new LocalChannel(cid, sock, function () { return _this.userId; }, this);
             this.channels.set(cid, chan);
             this.activeChannels[cid] = chan;
             this.state.channels.set(cid, chan);
         }
-        return this.channels.get(cid);
+        var channel = this.channels.get(cid);
+        var dataPatch = buildChannelData(config, members.records);
+        if (dataPatch) {
+            channel.data = __assign(__assign({}, channel.data), dataPatch);
+        }
+        if (members.records.length) {
+            var nextMembers_1 = __assign(__assign({}, channel.state.members), members.map);
+            channel.state.members = nextMembers_1;
+            channel.stateStore.dispatch({ members: nextMembers_1 });
+            var currentUserId = (this.user && this.user.id) || this.userId;
+            if (currentUserId && nextMembers_1[currentUserId]) {
+                var nextMembership = __assign(__assign({}, channel.state.membership || {}), { user_id: currentUserId, user: nextMembers_1[currentUserId].user || { id: currentUserId } });
+                channel.state.membership = nextMembership;
+                channel.stateStore.dispatch({ membership: nextMembership });
+            }
+        }
+        return channel;
     };
     LocalChatClient.prototype.disconnectUser = function () {
         this.sockets.forEach(function (s) { return s.close(); });

--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -105,6 +105,9 @@ export class LocalChannel {
   /** Minimal state object mimicking Stream's ChannelState */
   readonly state: ChannelState;
 
+  /** Data bag mimicking Stream's Channel.data */
+  data: Record<string, any> = {};
+
   /** Minimal message composer so <MessageInput> works */
   readonly messageComposer: MessageComposer;
 
@@ -299,6 +302,131 @@ export class LocalChannel {
   }
 }
 
+type ChannelMemberLike =
+  | string
+  | number
+  | {
+      id?: string | number | null;
+      user_id?: string | number | null;
+      user?: { id?: string | number | null } | null;
+      [key: string]: unknown;
+    };
+
+type ChannelCreateConfig = {
+  cid?: string;
+  id?: string;
+  members?: ChannelMemberLike[];
+  data?: { members?: ChannelMemberLike[] } & Record<string, unknown>;
+} & Record<string, unknown>;
+
+type NormalizedMember = {
+  user_id: string;
+  user: { id: string } & Record<string, unknown>;
+} & Record<string, unknown>;
+
+const toMemberId = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value) return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+};
+
+const normalizeMember = (
+  input: ChannelMemberLike | undefined,
+): { id: string; record: NormalizedMember } | undefined => {
+  if (input === null || input === undefined) return undefined;
+  if (typeof input === "string" || typeof input === "number") {
+    const id = String(input);
+    return { id, record: { user_id: id, user: { id } } };
+  }
+
+  if (typeof input !== "object") return undefined;
+
+  const candidate =
+    toMemberId((input as { user_id?: unknown }).user_id) ??
+    toMemberId((input as { id?: unknown }).id) ??
+    toMemberId((input as { user?: { id?: unknown } | null }).user?.id);
+
+  if (!candidate) return undefined;
+
+  const record: NormalizedMember = {
+    ...input,
+    user_id: candidate,
+    user: {},
+  } as NormalizedMember;
+
+  const rawUser = (input as { user?: unknown }).user;
+  const baseUser =
+    rawUser && typeof rawUser === "object" ? { ...(rawUser as Record<string, unknown>) } : {};
+  record.user = {
+    ...baseUser,
+    id: baseUser.id !== undefined ? String(baseUser.id) : candidate,
+  } as { id: string } & Record<string, unknown>;
+
+  return { id: candidate, record };
+};
+
+const collectMembers = (
+  config?: ChannelCreateConfig,
+): {
+  ids: string[];
+  records: NormalizedMember[];
+  map: Record<string, NormalizedMember>;
+} => {
+  const rawMembers: ChannelMemberLike[] = [];
+  if (config?.members && Array.isArray(config.members)) {
+    rawMembers.push(...config.members);
+  }
+  const dataMembers = config?.data?.members;
+  if (dataMembers && Array.isArray(dataMembers)) {
+    rawMembers.push(...dataMembers);
+  }
+
+  const memberMap = new Map<string, NormalizedMember>();
+
+  for (const raw of rawMembers) {
+    const normalized = normalizeMember(raw);
+    if (!normalized) continue;
+    const existing = memberMap.get(normalized.id);
+    memberMap.set(
+      normalized.id,
+      existing ? { ...existing, ...normalized.record } : normalized.record,
+    );
+  }
+
+  const ids = Array.from(memberMap.keys()).sort();
+  const records = ids.map((id) => memberMap.get(id)!) as NormalizedMember[];
+  const map: Record<string, NormalizedMember> = {};
+  for (const record of records) {
+    map[record.user_id] = record;
+  }
+
+  return { ids, records, map };
+};
+
+const buildChannelData = (
+  config: ChannelCreateConfig | undefined,
+  members: NormalizedMember[],
+): Record<string, unknown> | undefined => {
+  if (!config && members.length === 0) return undefined;
+
+  const { data, members: _members, cid: _cid, ...rest } = config ?? {};
+  const base: Record<string, unknown> = {};
+
+  if (data && typeof data === "object") {
+    Object.assign(base, data);
+  }
+
+  Object.assign(base, rest);
+
+  if (members.length) {
+    base.members = members.map((member) => ({ ...member }));
+  }
+
+  return Object.keys(base).length ? base : undefined;
+};
+
 /* ---------------------------- Chat-client shim --------------------------- */
 
 type Handler = (e: any) => void;
@@ -446,8 +574,43 @@ export class LocalChatClient {
     return { users: data };
   }
 
-  channel(type: string, id?: string) {
-    const cid = `${type}:${id ?? "local"}`;
+  channel(
+    type: string,
+    idOrConfig?: string | ChannelCreateConfig,
+    maybeConfig?: ChannelCreateConfig,
+  ) {
+    let channelId: string | undefined;
+    let config: ChannelCreateConfig | undefined;
+
+    if (typeof idOrConfig === "string" || idOrConfig === undefined) {
+      channelId = typeof idOrConfig === "string" ? idOrConfig : undefined;
+      config =
+        maybeConfig && typeof maybeConfig === "object"
+          ? { ...maybeConfig }
+          : maybeConfig;
+    } else {
+      config = { ...idOrConfig };
+      if (maybeConfig && typeof maybeConfig === "object") {
+        config = { ...config, ...maybeConfig };
+      }
+      if (typeof config?.id === "string" && config.id) {
+        channelId = config.id;
+      }
+    }
+
+    const members = collectMembers(config);
+
+    if (!channelId && config?.cid) {
+      const [, derivedId] = String(config.cid).split(":");
+      channelId = derivedId ?? String(config.cid);
+    }
+
+    if (!channelId) {
+      channelId = members.ids.length ? `!members-${members.ids.join(",")}` : "local";
+    }
+
+    const cid = config?.cid ?? `${type}:${channelId}`;
+
     if (!this.channels.has(cid)) {
       const url = `ws://${location.host}/ws/${cid}/?token=${this.jwt}`;
       const sock = new WebSocket(url);
@@ -461,7 +624,32 @@ export class LocalChatClient {
       this.activeChannels[cid] = chan;
       (this.state.channels as Map<string, any>).set(cid, chan);
     }
-    return this.channels.get(cid)!;
+
+    const channel = this.channels.get(cid)!;
+
+    const dataPatch = buildChannelData(config, members.records);
+    if (dataPatch) {
+      channel.data = { ...channel.data, ...dataPatch };
+    }
+
+    if (members.records.length) {
+      const nextMembers = { ...channel.state.members, ...members.map };
+      channel.state.members = nextMembers;
+      channel.stateStore.dispatch({ members: nextMembers });
+
+      const currentUserId = this.user?.id ?? this.userId;
+      if (currentUserId && nextMembers[currentUserId]) {
+        const nextMembership = {
+          ...(channel.state.membership ?? {}),
+          user_id: currentUserId,
+          user: nextMembers[currentUserId].user ?? { id: currentUserId },
+        };
+        channel.state.membership = nextMembership;
+        channel.stateStore.dispatch({ membership: nextMembership });
+      }
+    }
+
+    return channel;
   }
 
   disconnectUser() {

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelListShape.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelListShape.ts
@@ -13,7 +13,6 @@ import {
 } from '../utils';
 import { useChatContext } from '../../../context';
 import { getChannel } from '../../../utils';
-import { clientChannel } from '../../../chatSDKShim';
 import type { ChannelListProps } from '../ChannelList';
 
 type SetChannels = Dispatch<SetStateAction<Channel[]>>;
@@ -111,8 +110,7 @@ export const useChannelListShapeDefaults = () => {
       if (!channelType || !channelId) return;
 
       setChannels((currentChannels) => {
-        const targetChannel = clientChannel(
-          client,
+        const targetChannel = client.channel(
           channelType,
           channelId,
         ) as any;
@@ -285,8 +283,7 @@ export const useChannelListShapeDefaults = () => {
       const pinnedAtSort = extractSortValue({ atIndex: 0, sort, targetKey: 'pinned_at' });
 
       setChannels((currentChannels) => {
-        const targetChannel = clientChannel(
-          client,
+        const targetChannel = client.channel(
           event.channel_type!,
           event.channel_id!,
         ) as any;

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import uniqBy from 'lodash.uniqby';
 
 import { moveChannelUp } from '../utils';
-import { clientChannel } from '../../../chatSDKShim';
 
 import { useChatContext } from '../../../context/ChatContext';
 
@@ -33,8 +32,7 @@ export const useMessageNewListener = (
             allowNewMessagesFromUnfilteredChannels &&
             event.channel_type
           ) {
-            const channel = clientChannel(
-              client,
+            const channel = client.channel(
               event.channel_type,
               event.channel_id,
             ) as any;

--- a/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -9,7 +9,6 @@ import { isChannel } from "../utils";
 import { useChatContext } from "../../../context/ChatContext";
 import {
   channelWatch,
-  clientChannel,
   clientQueryChannels,
   clientQueryUsers,
 } from "../../../chatSDKShim";
@@ -185,11 +184,11 @@ export const useChannelSearch = ({
         setActiveChannel(result);
         selectedChannel = result;
       } else {
-        const newChannel = clientChannel(
-          client,
+        const newChannel = client.channel(
           result.type,
-          undefined,
-          { members: [client.userID, result.id] },
+          {
+            members: [client.userID, result.id],
+          },
         ) as Channel | undefined;
         if (!newChannel) return;
         await channelWatch(newChannel);

--- a/libs/stream-chat-shim/src/experimental/Search/SearchResults/SearchResultItem.tsx
+++ b/libs/stream-chat-shim/src/experimental/Search/SearchResults/SearchResultItem.tsx
@@ -11,7 +11,6 @@ import { DEFAULT_JUMP_TO_PAGE_SIZE } from "../../../constants/limits";
 import {
   channelStateLoadMessageIntoState,
   channelWatch,
-  clientChannel,
 } from "../../../chatSDKShim";
 
 export type ChannelSearchResultItemProps = {
@@ -57,8 +56,8 @@ export const MessageSearchResultItem = ({
     const { channel: channelData } = item;
     const type = channelData?.type ?? "unknown";
     const id = channelData?.id ?? "unknown";
-    return clientChannel(client, type, id) as Channel;
-  }, [item]);
+    return client.channel(type, id) as Channel;
+  }, [client, item]);
 
   const onSelect = useCallback(async () => {
     if (!channel) return;
@@ -105,11 +104,11 @@ export const UserSearchResultItem = ({ item }: UserSearchResultItemProps) => {
 
   const onClick = useCallback(async () => {
     if (!client.userID) return;
-    const newChannel = clientChannel(
-      client,
+    const newChannel = client.channel(
       directMessagingChannelType,
-      undefined,
-      { members: [client.userID, item.id] },
+      {
+        members: [client.userID, item.id],
+      },
     ) as Channel | undefined;
     if (!newChannel) return;
     await channelWatch(newChannel);

--- a/libs/stream-chat-shim/src/utils/getChannel.ts
+++ b/libs/stream-chat-shim/src/utils/getChannel.ts
@@ -4,11 +4,7 @@ import type {
   QueryChannelAPIResponse,
   StreamChat,
 } from 'chat-shim';
-import {
-  channelWatch,
-  clientChannel,
-  type ChannelWatchOptions,
-} from '../chatSDKShim';
+import { channelWatch, type ChannelWatchOptions } from '../chatSDKShim';
 
 /**
  * prevent from duplicate invocation of channel.watch()
@@ -52,7 +48,7 @@ export const getChannel = async ({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const extra = members && members.length ? { members } : undefined;
   const theChannel =
-    channel || (clientChannel(client, type!, id, extra) as Channel);
+    channel || (client.channel(type!, id, extra) as Channel);
 
   // need to keep as with call to channel.watch the id can be changed from undefined to an actual ID generated server-side
   const originalCid = theChannel?.id


### PR DESCRIPTION
## Summary
- extend the chat-shim client so `client.channel` can derive stable CIDs, seed member state, and expose channel data when called with config objects
- expose the new helper through updated type definitions and ensure channel data is recorded on local channel instances
- replace the temporary `clientChannel` shim usage across search and channel list utilities with direct calls to `client.channel`

## Testing
- `pnpm --filter stream-chat-shim test`


------
https://chatgpt.com/codex/tasks/task_e_68d6c453a9688326a734bd451cb51a95