### PR TITLE
feat(client.off): wire up shim helper and remove TODOs

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.off.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.off.test.ts
@@ -1,14 +1,121 @@
-import { clientOff } from '../src/chatSDKShim';
+import { clientOff, clientOn, __TESTING__ } from '../src/client';
 
-describe('clientOff', () => {
-  it('calls client.off when available', () => {
-    const fn = jest.fn();
-    const handler = jest.fn();
-    clientOff({ off: fn }, 'user.updated', handler);
-    expect(fn).toHaveBeenCalledWith('user.updated', handler);
+type Handler = (...args: any[]) => void;
+
+type TestClient = {
+  listeners: Map<string, Set<Handler>>;
+  on: (eventType: string, handler: Handler) => { unsubscribe: () => void };
+  off: (eventType?: string, handler?: Handler) => void;
+  emit: (eventType: string, payload?: unknown) => void;
+};
+
+const createTestClient = (): TestClient => {
+  const listeners = new Map<string, Set<Handler>>();
+
+  const client: TestClient = {
+    listeners,
+    on: (eventType, handler) => {
+      if (!listeners.has(eventType)) listeners.set(eventType, new Set());
+      listeners.get(eventType)!.add(handler);
+      return {
+        unsubscribe: () => {
+          client.off(eventType, handler);
+        },
+      };
+    },
+    off: (eventType, handler) => {
+      if (!eventType || !handler) return;
+      const handlerSet = listeners.get(eventType);
+      if (!handlerSet) return;
+      handlerSet.delete(handler);
+      if (handlerSet.size === 0) {
+        listeners.delete(eventType);
+      }
+    },
+    emit: (eventType, payload) => {
+      listeners.get(eventType)?.forEach((fn) => fn(payload));
+    },
+  };
+
+  return client;
+};
+
+describe('client.off helper', () => {
+  it('removes a specific handler while keeping others', () => {
+    const client = createTestClient();
+    const handlerOne = jest.fn();
+    const handlerTwo = jest.fn();
+
+    clientOn(client, 'message.new', handlerOne);
+    clientOn(client, 'message.new', handlerTwo);
+
+    client.emit('message.new', {});
+    expect(handlerOne).toHaveBeenCalledTimes(1);
+    expect(handlerTwo).toHaveBeenCalledTimes(1);
+
+    clientOff(client, 'message.new', handlerOne);
+    client.emit('message.new', {});
+
+    expect(handlerOne).toHaveBeenCalledTimes(1);
+    expect(handlerTwo).toHaveBeenCalledTimes(2);
   });
 
-  it('does nothing when not implemented', () => {
-    expect(() => clientOff({} as any, 'event', () => {})).not.toThrow();
+  it('removes all handlers for an event when only the event is provided', () => {
+    const client = createTestClient();
+    const first = jest.fn();
+    const second = jest.fn();
+
+    clientOn(client, 'message.new', first);
+    clientOn(client, 'message.new', second);
+
+    clientOff(client, 'message.new');
+
+    client.emit('message.new', {});
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+    expect(client.listeners.has('message.new')).toBe(false);
+  });
+
+  it('removes all handlers across events when called without arguments', () => {
+    const client = createTestClient();
+    const handler = jest.fn();
+    const otherHandler = jest.fn();
+
+    clientOn(client, 'message.new', handler);
+    clientOn(client, 'typing.start', otherHandler);
+
+    clientOff(client);
+
+    client.emit('message.new', {});
+    client.emit('typing.start', {});
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(otherHandler).not.toHaveBeenCalled();
+    expect(client.listeners.size).toBe(0);
+  });
+
+  it('is a no-op when removing an unregistered handler', () => {
+    const client = createTestClient();
+    const registered = jest.fn();
+    const unregistered = jest.fn();
+
+    clientOn(client, 'message.new', registered);
+
+    expect(() => clientOff(client, 'message.new', unregistered)).not.toThrow();
+
+    client.emit('message.new', {});
+    expect(registered).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retain handlers after they are removed', () => {
+    const client = createTestClient();
+    const handler = jest.fn();
+
+    clientOn(client, 'message.new', handler);
+    expect(__TESTING__.getTrackedHandlers(client).length).toBe(1);
+
+    clientOff(client, 'message.new');
+
+    expect(__TESTING__.getTrackedHandlers(client).length).toBe(0);
   });
 });

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1,6 +1,15 @@
 import { StateStore } from '../../chat-shim';
 import type { Channel, PollOption as ChatShimPollOption, PollVote } from '../../chat-shim';
 import { stopTyping as stopTypingImpl } from '../../chat-shim/typing';
+import {
+  clientOff,
+  clientOn,
+  createSubscription,
+  type ChannelEventSubscription,
+  type EventTargetLike,
+} from './client';
+
+export type { ChannelEventSubscription };
 
 import {
   chatAPI,
@@ -393,48 +402,6 @@ export type ChannelUnknownEvent = ChannelEventBase<string>;
 export type ChannelEventHandler<T extends ChannelKnownEvent> = (
   event: KnownChannelEventMap[T],
 ) => void;
-export type ChannelEventSubscription = { unsubscribe: () => void };
-
-type EventTargetLike = {
-  on?: (
-    eventType: string,
-    handler: (...args: any[]) => void,
-  ) => { unsubscribe?: () => void } | void;
-  off?: (eventType?: string, handler?: (...args: any[]) => void) => void;
-};
-
-const noopSubscription: ChannelEventSubscription = { unsubscribe: () => {} };
-
-const createSubscription = (
-  target: EventTargetLike | undefined,
-  eventType: string,
-  handler: (...args: any[]) => void,
-): ChannelEventSubscription => {
-  if (!target || typeof target.on !== 'function') {
-    return noopSubscription;
-  }
-
-  const maybeSubscription = target.on(eventType, handler);
-  let unsubscribed = false;
-
-  return {
-    unsubscribe: () => {
-      if (unsubscribed) return;
-      unsubscribed = true;
-
-      if (
-        maybeSubscription &&
-        typeof maybeSubscription === 'object' &&
-        typeof (maybeSubscription as { unsubscribe?: () => void }).unsubscribe === 'function'
-      ) {
-        (maybeSubscription as { unsubscribe: () => void }).unsubscribe();
-      } else if (typeof target.off === 'function') {
-        target.off(eventType, handler);
-      }
-    },
-  };
-};
-
 export type CastVoteParams = {
   poll: PollLike;
   optionId: string;
@@ -1257,23 +1224,7 @@ export function clientChannel(
   return undefined;
 }
 
-export function clientOff(
-  client: EventTargetLike | undefined,
-  eventType?: string,
-  handler?: (...args: any[]) => void,
-): void {
-  if (client && typeof client.off === "function") {
-    client.off(eventType, handler);
-  }
-}
-
-export function clientOn(
-  client: EventTargetLike | undefined,
-  eventType: string,
-  handler: (...args: any[]) => void,
-): ChannelEventSubscription {
-  return createSubscription(client, eventType, handler);
-}
+export { clientOff, clientOn };
 
 export function on<TEvent extends ChannelKnownEvent>(
   channel: Channel,

--- a/libs/stream-chat-shim/src/client/events.ts
+++ b/libs/stream-chat-shim/src/client/events.ts
@@ -1,0 +1,243 @@
+export type EventTargetLike = {
+  on?: (
+    eventType: string,
+    handler: (...args: any[]) => void,
+  ) => { unsubscribe?: () => void } | void;
+  off?: (eventType?: string, handler?: (...args: any[]) => void) => void;
+  listeners?: unknown;
+};
+
+type Handler = (...args: any[]) => void;
+
+type SubscriptionRecord = {
+  handler: Handler;
+  unsubscribe: () => void;
+};
+
+export type ChannelEventSubscription = { unsubscribe: () => void };
+
+const noopSubscription: ChannelEventSubscription = { unsubscribe: () => {} };
+
+const registry = new WeakMap<EventTargetLike, Map<string, Set<SubscriptionRecord>>>();
+
+const getOrCreateSet = (target: EventTargetLike, eventType: string): Set<SubscriptionRecord> => {
+  let map = registry.get(target);
+  if (!map) {
+    map = new Map();
+    registry.set(target, map);
+  }
+  let set = map.get(eventType);
+  if (!set) {
+    set = new Set();
+    map.set(eventType, set);
+  }
+  return set;
+};
+
+const removeRecord = (target: EventTargetLike, eventType: string, record: SubscriptionRecord) => {
+  const map = registry.get(target);
+  if (!map) return;
+  const set = map.get(eventType);
+  if (!set) return;
+  set.delete(record);
+  if (set.size === 0) {
+    map.delete(eventType);
+  }
+  if (map.size === 0) {
+    registry.delete(target);
+  }
+};
+
+const callNativeOff = (
+  target: EventTargetLike,
+  eventType?: string,
+  handler?: Handler,
+): void => {
+  if (typeof target.off !== 'function') return;
+  if (eventType === undefined) {
+    target.off();
+    return;
+  }
+  if (handler === undefined) {
+    target.off(eventType);
+    return;
+  }
+  target.off(eventType, handler);
+};
+
+const extractHandlers = (
+  target: EventTargetLike,
+  eventType?: string,
+): Array<[string, Handler[]]> => {
+  const container = (target as { listeners?: unknown }).listeners;
+  if (!container) return [];
+
+  const result: Array<[string, Handler[]]> = [];
+
+  if (container instanceof Map) {
+    const events = eventType !== undefined ? [eventType] : Array.from(container.keys());
+    for (const evt of events) {
+      const value = container.get(evt);
+      if (!value) continue;
+      if (Array.isArray(value)) {
+        const handlers = value.filter((fn): fn is Handler => typeof fn === 'function');
+        if (handlers.length) result.push([evt, [...handlers]]);
+      } else if (value instanceof Set) {
+        const handlers = Array.from(value).filter((fn): fn is Handler => typeof fn === 'function');
+        if (handlers.length) result.push([evt, handlers]);
+      }
+    }
+    return result;
+  }
+
+  if (typeof container === 'object' && container !== null) {
+    const record = container as Record<string, unknown>;
+    const events = eventType !== undefined ? [eventType] : Object.keys(record);
+    for (const evt of events) {
+      const value = record[evt];
+      if (!value) continue;
+      if (Array.isArray(value)) {
+        const handlers = value.filter((fn): fn is Handler => typeof fn === 'function');
+        if (handlers.length) result.push([evt, [...handlers]]);
+      } else if (value instanceof Set) {
+        const handlers = Array.from(value).filter((fn): fn is Handler => typeof fn === 'function');
+        if (handlers.length) result.push([evt, handlers]);
+      }
+    }
+  }
+
+  return result;
+};
+
+const removeTrackedHandlers = (
+  target: EventTargetLike,
+  eventType?: string,
+  predicate?: (record: SubscriptionRecord) => boolean,
+): boolean => {
+  const map = registry.get(target);
+  if (!map) return false;
+
+  const events = eventType !== undefined ? [eventType] : Array.from(map.keys());
+  let removed = false;
+
+  for (const evt of events) {
+    const set = map.get(evt);
+    if (!set || set.size === 0) continue;
+    for (const record of Array.from(set)) {
+      if (predicate && !predicate(record)) continue;
+      record.unsubscribe();
+      removed = true;
+    }
+  }
+
+  return removed;
+};
+
+export const createSubscription = (
+  target: EventTargetLike | undefined,
+  eventType: string,
+  handler: Handler,
+): ChannelEventSubscription => {
+  if (!target || typeof target.on !== 'function') {
+    return noopSubscription;
+  }
+
+  const maybeSubscription = target.on(eventType, handler);
+  let unsubscribed = false;
+
+  const record: SubscriptionRecord = {
+    handler,
+    unsubscribe: () => {
+      if (unsubscribed) return;
+      unsubscribed = true;
+
+      if (
+        maybeSubscription &&
+        typeof maybeSubscription === 'object' &&
+        typeof (maybeSubscription as { unsubscribe?: () => void }).unsubscribe === 'function'
+      ) {
+        (maybeSubscription as { unsubscribe: () => void }).unsubscribe();
+      } else if (typeof target.off === 'function') {
+        target.off(eventType, handler);
+      }
+
+      removeRecord(target, eventType, record);
+    },
+  };
+
+  getOrCreateSet(target, eventType).add(record);
+
+  return {
+    unsubscribe: record.unsubscribe,
+  };
+};
+
+export const clientOn = (
+  client: EventTargetLike | undefined,
+  eventType: string,
+  handler: Handler,
+): ChannelEventSubscription => createSubscription(client, eventType, handler);
+
+export const clientOff = (
+  client: EventTargetLike | undefined,
+  eventType?: string,
+  handler?: Handler,
+): void => {
+  if (!client) return;
+
+  const predicate = handler ? (record: SubscriptionRecord) => record.handler === handler : undefined;
+  const removedTracked = removeTrackedHandlers(client, eventType, predicate);
+
+  if (handler) {
+    callNativeOff(client, eventType, handler);
+    return;
+  }
+
+  if (eventType) {
+    const fallbackHandlers = extractHandlers(client, eventType);
+    if (fallbackHandlers.length === 0 && !removedTracked) {
+      callNativeOff(client, eventType);
+      return;
+    }
+
+    for (const [, handlers] of fallbackHandlers) {
+      for (const fn of handlers) {
+        callNativeOff(client, eventType, fn);
+      }
+    }
+
+    return;
+  }
+
+  const fallbackHandlers = extractHandlers(client);
+  if (fallbackHandlers.length === 0 && !removedTracked) {
+    callNativeOff(client);
+    return;
+  }
+
+  for (const [evt, handlers] of fallbackHandlers) {
+    for (const fn of handlers) {
+      callNativeOff(client, evt, fn);
+    }
+  }
+};
+
+export const __TESTING__ = {
+  getTrackedHandlers(target: EventTargetLike, eventType?: string): Handler[] {
+    const map = registry.get(target);
+    if (!map) return [];
+    if (eventType !== undefined) {
+      const set = map.get(eventType);
+      if (!set) return [];
+      return Array.from(set).map((record) => record.handler);
+    }
+
+    const handlers: Handler[] = [];
+    for (const set of map.values()) {
+      for (const record of set) {
+        handlers.push(record.handler);
+      }
+    }
+    return handlers;
+  },
+};

--- a/libs/stream-chat-shim/src/client/index.ts
+++ b/libs/stream-chat-shim/src/client/index.ts
@@ -1,0 +1,2 @@
+export type { ChannelEventSubscription, EventTargetLike } from './events';
+export { clientOff, clientOn, createSubscription, __TESTING__ } from './events';

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -100,6 +100,7 @@ import {
   loadMessageIntoChannelState,
 } from "../../chatSDKShim";
 import { chatAPI } from "../../api/chatAPI";
+import { clientOff, clientOn } from "../../client";
 
 type ChannelPropsForwardedToComponentContext = Pick<
   ComponentContextValue,
@@ -594,6 +595,12 @@ const ChannelInner = (
          */
         if (chatAPI.channel.countUnread({ channel }) > 0 && markReadOnMount)
           markRead({ updateChannelUiUnreadState: false });
+
+        clientOn(client, 'connection.changed', handleEvent);
+        clientOn(client, 'connection.recovered', handleEvent);
+        clientOn(client, 'user.updated', handleEvent);
+        clientOn(client, 'user.deleted', handleEvent);
+        channel.on?.('all', handleEvent as (event: Event) => void);
         // The more complex sync logic is done in Chat
       }
     })();
@@ -601,9 +608,11 @@ const ChannelInner = (
 
     return () => {
       if (errored || !done) return;
-      /* TODO backend-wire-up: client.off */
-      /* TODO backend-wire-up: client.off */
-      /* TODO backend-wire-up: client.off */
+      channel.off?.('all', handleEvent as (event: Event) => void);
+      clientOff(client, 'connection.changed', handleEvent);
+      clientOff(client, 'connection.recovered', handleEvent);
+      clientOff(client, 'user.updated', handleEvent);
+      clientOff(client, 'user.deleted', handleEvent);
       notificationTimeoutsRef.forEach(clearTimeout);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
@@ -30,6 +30,7 @@ import {
   useChatContext,
   useComponentContext,
 } from "../../context";
+import { clientOff, clientOn } from "../../client";
 import { NullComponent } from "../UtilityComponents";
 import { clientQueryChannels } from "../../chatSDKShim";
 import { MAX_QUERY_CHANNELS_LIMIT, moveChannelUpwards } from "./utils";
@@ -342,9 +343,12 @@ const UnMemoizedChannelList = (props: ChannelListProps) => {
       }
     };
 
+    clientOn(client, 'channel.deleted', handleEvent);
+    clientOn(client, 'channel.hidden', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'channel.deleted', handleEvent);
+      clientOff(client, 'channel.hidden', handleEvent);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel?.cid]);

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelDeletedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelDeletedListener.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type { Channel, Event } from 'chat-shim';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 export const useChannelDeletedListener = (
   setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
@@ -30,8 +31,10 @@ export const useChannelDeletedListener = (
       }
     };
 
+    clientOn(client, 'channel.deleted', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'channel.deleted', handleEvent);
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelHiddenListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelHiddenListener.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type { Channel, Event } from 'chat-shim';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 export const useChannelHiddenListener = (
   setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
@@ -29,8 +30,10 @@ export const useChannelHiddenListener = (
       }
     };
 
+    clientOn(client, 'channel.hidden', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'channel.hidden', handleEvent);
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelTruncatedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelTruncatedListener.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -26,8 +27,10 @@ export const useChannelTruncatedListener = (
       }
     };
 
+    clientOn(client, 'channel.truncated', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'channel.truncated', handleEvent);
     };
   }, [client, customHandler, forceUpdate, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -44,8 +45,10 @@ export const useChannelUpdatedListener = (
       }
     };
 
+    clientOn(client, 'channel.updated', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'channel.updated', handleEvent);
     };
   }, [client, customHandler, forceUpdate, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelVisibleListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelVisibleListener.ts
@@ -4,6 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { getChannel } from '../../../utils/getChannel';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -30,8 +31,10 @@ export const useChannelVisibleListener = (
       }
     };
 
+    clientOn(client, 'channel.visible', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'channel.visible', handleEvent);
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useConnectionRecoveredListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useConnectionRecoveredListener.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 export const useConnectionRecoveredListener = (forceUpdate?: () => void) => {
   const { client } = useChatContext('useConnectionRecoveredListener');
@@ -12,8 +13,10 @@ export const useConnectionRecoveredListener = (forceUpdate?: () => void) => {
       }
     };
 
+    clientOn(client, 'connection.recovered', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'connection.recovered', handleEvent);
     };
   }, [client, forceUpdate]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
@@ -4,6 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { moveChannelUp } from '../utils';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -46,8 +47,10 @@ export const useMessageNewListener = (
       }
     };
 
+    clientOn(client, 'message.new', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'message.new', handleEvent);
     };
   }, [
     allowNewMessagesFromUnfilteredChannels,

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationAddedToChannelListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationAddedToChannelListener.ts
@@ -4,6 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { getChannel } from '../../../utils/getChannel';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -38,8 +39,10 @@ export const useNotificationAddedToChannelListener = (
       }
     };
 
+    clientOn(client, 'notification.added_to_channel', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'notification.added_to_channel', handleEvent);
     };
   }, [allowNewMessagesFromUnfilteredChannels, client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationMessageNewListener.ts
@@ -4,6 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { getChannel } from '../../../utils/getChannel';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -31,8 +32,10 @@ export const useNotificationMessageNewListener = (
       }
     };
 
+    clientOn(client, 'notification.message_new', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'notification.message_new', handleEvent);
     };
   }, [allowNewMessagesFromUnfilteredChannels, client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -24,8 +25,10 @@ export const useNotificationRemovedFromChannelListener = (
       }
     };
 
+    clientOn(client, 'notification.removed_from_channel', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'notification.removed_from_channel', handleEvent);
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useUserPresenceChangedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useUserPresenceChangedListener.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../client';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -27,8 +28,10 @@ export const useUserPresenceChangedListener = (
       });
     };
 
+    clientOn(client, 'user.presence.changed', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'user.presence.changed', handleEvent);
     };
   }, [client, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
@@ -8,6 +8,7 @@ import { useIsChannelMuted } from './hooks/useIsChannelMuted';
 import { useChannelPreviewInfo } from './hooks/useChannelPreviewInfo';
 import { getLatestMessagePreview as defaultGetLatestMessagePreview } from './utils';
 import { chatAPI } from '../../api/chatAPI';
+import { clientOff, clientOn } from '../../client';
 import { useChatContext } from '../../context/ChatContext';
 import { useTranslationContext } from '../../context/TranslationContext';
 import { useMessageDeliveryStatus } from './hooks/useMessageDeliveryStatus';
@@ -105,8 +106,10 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
       if (channel.cid === event.cid) setUnread(0);
     };
 
+    clientOn(client, 'notification.mark_read', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'notification.mark_read', handleEvent);
     };
   }, [channel, client]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useChannelPreviewInfo.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useChannelPreviewInfo.ts
@@ -3,6 +3,7 @@ import type { Channel } from 'chat-shim';
 
 import { getDisplayImage, getDisplayTitle, getGroupChannelDisplayInfo } from '../utils';
 import { useChatContext } from '../../../context';
+import { clientOff, clientOn } from '../../../client';
 
 export type ChannelPreviewInfoParams = {
   channel: Channel;
@@ -40,8 +41,10 @@ export const useChannelPreviewInfo = (props: ChannelPreviewInfoParams) => {
 
     updateInfo();
 
+    clientOn(client, 'user.updated', updateInfo);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'user.updated', updateInfo);
     };
   }, [channel, channel.data, client, overrideImage, overrideTitle]);
 

--- a/libs/stream-chat-shim/src/components/MessageList/ConnectionStatus.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/ConnectionStatus.tsx
@@ -4,6 +4,7 @@ import type { Event } from 'chat-shim';
 
 import { CustomNotification } from './CustomNotification';
 import { useChatContext, useTranslationContext } from '../../context';
+import { clientOff, clientOn } from '../../client';
 
 const UnMemoizedConnectionStatus = () => {
   const { client } = useChatContext('ConnectionStatus');
@@ -18,8 +19,10 @@ const UnMemoizedConnectionStatus = () => {
       }
     };
 
+    clientOn(client, 'connection.changed', connectionChanged);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'connection.changed', connectionChanged);
     };
   }, [client, online]);
 

--- a/libs/stream-chat-shim/src/components/MessageList/ScrollToBottomButton.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/ScrollToBottomButton.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { ArrowDown } from './icons';
 
 import { useChannelStateContext, useChatContext } from '../../context';
+import { clientOff, clientOn } from '../../client';
 import { chatAPI } from '../../api/chatAPI';
 
 import type { Event } from 'chat-shim';
@@ -62,8 +63,10 @@ const UnMemoizedScrollToBottomButton = (
       }
     };
 
+    clientOn(client, observedEvent, handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, observedEvent, handleEvent);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeChannel, isMessageListScrolledToBottom, observedEvent, replyCount, thread]);

--- a/libs/stream-chat-shim/src/components/MessageList/hooks/VirtualizedMessageList/useGiphyPreview.ts
+++ b/libs/stream-chat-shim/src/components/MessageList/hooks/VirtualizedMessageList/useGiphyPreview.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useChatContext } from '../../../../context/ChatContext';
+import { clientOff, clientOn } from '../../../../client';
 
 import type { EventHandler, LocalMessage } from 'chat-shim';
 
@@ -19,8 +20,10 @@ export const useGiphyPreview = (separateGiphyPreview: boolean) => {
       }
     };
 
+    clientOn(client, 'message.new', handleEvent);
+
     return () => {
-      /* TODO backend-wire-up: client.off */
+      clientOff(client, 'message.new', handleEvent);
     };
   }, [client, separateGiphyPreview]);
 


### PR DESCRIPTION
## Summary
- add a client events helper that records subscriptions so client.off can remove specific, per-event, or all listeners
- replace client.off TODO placeholders with real clientOn/clientOff usage across Channel and ChannelList listeners
- exercise the new helper with targeted Jest tests covering all supported client.off variants

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/client.off.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6cbca80f8832692551b5304baf81d