### PR TITLE
feat: wire up stream chat client.on shim

### DIFF
--- a/libs/chat-shim/index.ts
+++ b/libs/chat-shim/index.ts
@@ -509,8 +509,12 @@ export class LocalChatClient {
       if (this.listeners[evt].length === 0) delete this.listeners[evt];
     }
   };
-  private emit = (evt: string, data: any) =>
+  private emit = (evt: string, data: any) => {
     this.bus.get(evt)?.forEach((cb) => cb(data));
+    if (evt !== "all") {
+      this.bus.get("all")?.forEach((cb) => cb(data));
+    }
+  };
 
   /* ------------------------------------------------------------------- */
   /*  ░░ 3.   ultra-thin “state” & “user” objects the hook assumes exist */
@@ -617,6 +621,7 @@ export class LocalChatClient {
       sock.onmessage = (ev) => {
         const data = JSON.parse(ev.data);
         this.channels.get(data.cid)?.emit(data.type, data);
+        this.emit(data.type, data);
       };
       this.sockets.set(cid, sock);
       const chan = new LocalChannel(cid, sock, () => this.userId, this);

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1,5 +1,11 @@
 import { chatSDKShim } from '../chatSDKShim';
 
+export type {
+  ClientEventHandler,
+  ClientKnownEvent,
+  ClientKnownEventMap,
+} from '../chatSDKShim';
+
 export type DeleteMessageParams = {
   cid: string;
   message_id: number;
@@ -834,6 +840,9 @@ export const chatAPI = {
     countUnread: channelCountUnread,
     query: channelQuery,
     unpin: channelUnpin,
+  },
+  client: {
+    on: chatSDKShim.client.on,
   },
   addAnswer,
   createReminder,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -402,6 +402,59 @@ export type ChannelUnknownEvent = ChannelEventBase<string>;
 export type ChannelEventHandler<T extends ChannelKnownEvent> = (
   event: KnownChannelEventMap[T],
 ) => void;
+
+type ClientSpecificEventMap = {
+  all: ChannelUnknownEvent;
+  'connection.recovered': ChannelEventBase<'connection.recovered'> & { online?: boolean };
+  'notification.added_to_channel': ChannelEventBase<'notification.added_to_channel'> &
+    NotificationEventFields;
+  'notification.message_new': ChannelEventBase<'notification.message_new'> &
+    NotificationEventFields;
+  'notification.removed_from_channel': ChannelEventBase<'notification.removed_from_channel'> &
+    NotificationEventFields;
+  'notification.mutes_updated': { type: 'notification.mutes_updated'; me?: Record<string, unknown> } &
+    Record<string, unknown>;
+  'notification.channel_mutes_updated': {
+    type: 'notification.channel_mutes_updated';
+    [key: string]: unknown;
+  };
+  'user.updated': ChannelEventBase<'user.updated'> & { user?: ChannelUserLike | null };
+  'user.presence.changed': ChannelEventBase<'user.presence.changed'> & {
+    user?: ChannelUserLike | null;
+  };
+  'poll.vote_casted': {
+    type: 'poll.vote_casted';
+    poll_vote?: Record<string, unknown> | null;
+    [key: string]: unknown;
+  };
+  'poll.vote_removed': {
+    type: 'poll.vote_removed';
+    poll_vote?: Record<string, unknown> | null;
+    [key: string]: unknown;
+  };
+  'poll.vote_changed': {
+    type: 'poll.vote_changed';
+    poll_vote?: Record<string, unknown> | null;
+    [key: string]: unknown;
+  };
+};
+
+export type ClientKnownEventMap = KnownChannelEventMap & ClientSpecificEventMap;
+export type ClientKnownEvent = keyof ClientKnownEventMap;
+export type ClientEventHandler<T extends ClientKnownEvent> = (
+  event: ClientKnownEventMap[T],
+) => void;
+
+const clientOnTyped = <TEvent extends ClientKnownEvent>(
+  client: EventTargetLike | undefined,
+  eventType: TEvent,
+  handler: ClientEventHandler<TEvent>,
+): ChannelEventSubscription =>
+  clientOn(client, eventType, handler as (...args: any[]) => void);
+
+export const client = {
+  on: clientOnTyped,
+};
 export type CastVoteParams = {
   poll: PollLike;
   optionId: string;
@@ -685,6 +738,7 @@ export const chatSDKShim = {
     return castVoteInternal(params);
   },
   channelCountUnread,
+  client,
 };
 
 export const chatSDK = {
@@ -991,7 +1045,11 @@ export function channelOn(
   eventType: string,
   handler: (event: ChannelUnknownEvent) => void,
 ): ChannelEventSubscription {
-  return createSubscription(channel, eventType, handler as (...args: any[]) => void);
+  return createSubscription(
+    channel as unknown as EventTargetLike | undefined,
+    eventType,
+    handler as (...args: any[]) => void,
+  );
 }
 
 type ChannelPinTarget = string | ChannelMessageLike;
@@ -1242,11 +1300,15 @@ export function on(
   handler: (...args: any[]) => void,
 ): ChannelEventSubscription;
 export function on(
-  target: EventTargetLike | undefined,
+  target: Channel | EventTargetLike | undefined,
   eventType: string,
   handler: (...args: any[]) => void,
 ): ChannelEventSubscription {
-  return createSubscription(target, eventType, handler);
+  return createSubscription(
+    target as unknown as EventTargetLike | undefined,
+    eventType,
+    handler,
+  );
 }
 
 export function onPollVoteCasted(

--- a/libs/stream-chat-shim/src/components/Channel/Channel.tsx
+++ b/libs/stream-chat-shim/src/components/Channel/Channel.tsx
@@ -100,7 +100,7 @@ import {
   loadMessageIntoChannelState,
 } from "../../chatSDKShim";
 import { chatAPI } from "../../api/chatAPI";
-import { clientOff, clientOn } from "../../client";
+import type { ChannelEventSubscription } from "../../client";
 
 type ChannelPropsForwardedToComponentContext = Pick<
   ComponentContextValue,
@@ -534,6 +534,7 @@ const ChannelInner = (
   // useLayoutEffect here to prevent spinner. Use Suspense when it is available in stable release
   useLayoutEffect(() => {
     let errored = false;
+    const subscriptions: ChannelEventSubscription[] = [];
     let done = false;
 
     (async () => {
@@ -596,10 +597,12 @@ const ChannelInner = (
         if (chatAPI.channel.countUnread({ channel }) > 0 && markReadOnMount)
           markRead({ updateChannelUiUnreadState: false });
 
-        clientOn(client, 'connection.changed', handleEvent);
-        clientOn(client, 'connection.recovered', handleEvent);
-        clientOn(client, 'user.updated', handleEvent);
-        clientOn(client, 'user.deleted', handleEvent);
+        subscriptions.push(
+          chatAPI.client.on(client, 'connection.changed', handleEvent),
+          chatAPI.client.on(client, 'connection.recovered', handleEvent),
+          chatAPI.client.on(client, 'user.updated', handleEvent),
+          chatAPI.client.on(client, 'user.deleted', handleEvent),
+        );
         channel.on?.('all', handleEvent as (event: Event) => void);
         // The more complex sync logic is done in Chat
       }
@@ -609,10 +612,7 @@ const ChannelInner = (
     return () => {
       if (errored || !done) return;
       channel.off?.('all', handleEvent as (event: Event) => void);
-      clientOff(client, 'connection.changed', handleEvent);
-      clientOff(client, 'connection.recovered', handleEvent);
-      clientOff(client, 'user.updated', handleEvent);
-      clientOff(client, 'user.deleted', handleEvent);
+      subscriptions.forEach((subscription) => subscription.unsubscribe());
       notificationTimeoutsRef.forEach(clearTimeout);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
@@ -30,7 +30,7 @@ import {
   useChatContext,
   useComponentContext,
 } from "../../context";
-import { clientOff, clientOn } from "../../client";
+import { chatAPI } from "../../api/chatAPI";
 import { NullComponent } from "../UtilityComponents";
 import { clientQueryChannels } from "../../chatSDKShim";
 import { MAX_QUERY_CHANNELS_LIMIT, moveChannelUpwards } from "./utils";
@@ -343,12 +343,13 @@ const UnMemoizedChannelList = (props: ChannelListProps) => {
       }
     };
 
-    clientOn(client, 'channel.deleted', handleEvent);
-    clientOn(client, 'channel.hidden', handleEvent);
+    const subscriptions = [
+      chatAPI.client.on(client, 'channel.deleted', handleEvent),
+      chatAPI.client.on(client, 'channel.hidden', handleEvent),
+    ];
 
     return () => {
-      clientOff(client, 'channel.deleted', handleEvent);
-      clientOff(client, 'channel.hidden', handleEvent);
+      subscriptions.forEach((subscription) => subscription.unsubscribe());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel?.cid]);

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelDeletedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelDeletedListener.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import type { Channel, Event } from 'chat-shim';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 export const useChannelDeletedListener = (
   setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
@@ -31,10 +31,14 @@ export const useChannelDeletedListener = (
       }
     };
 
-    clientOn(client, 'channel.deleted', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'channel.deleted',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'channel.deleted', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelHiddenListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelHiddenListener.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import type { Channel, Event } from 'chat-shim';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 export const useChannelHiddenListener = (
   setChannels: React.Dispatch<React.SetStateAction<Array<Channel>>>,
@@ -30,10 +30,14 @@ export const useChannelHiddenListener = (
       }
     };
 
-    clientOn(client, 'channel.hidden', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'channel.hidden',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'channel.hidden', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelTruncatedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelTruncatedListener.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -27,10 +27,14 @@ export const useChannelTruncatedListener = (
       }
     };
 
-    clientOn(client, 'channel.truncated', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'channel.truncated',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'channel.truncated', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, customHandler, forceUpdate, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -45,10 +45,14 @@ export const useChannelUpdatedListener = (
       }
     };
 
-    clientOn(client, 'channel.updated', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'channel.updated',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'channel.updated', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, customHandler, forceUpdate, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelVisibleListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useChannelVisibleListener.ts
@@ -4,7 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { getChannel } from '../../../utils/getChannel';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -31,10 +31,14 @@ export const useChannelVisibleListener = (
       }
     };
 
-    clientOn(client, 'channel.visible', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'channel.visible',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'channel.visible', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useConnectionRecoveredListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useConnectionRecoveredListener.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 export const useConnectionRecoveredListener = (forceUpdate?: () => void) => {
   const { client } = useChatContext('useConnectionRecoveredListener');
@@ -13,10 +13,14 @@ export const useConnectionRecoveredListener = (forceUpdate?: () => void) => {
       }
     };
 
-    clientOn(client, 'connection.recovered', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'connection.recovered',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'connection.recovered', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, forceUpdate]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useMessageNewListener.ts
@@ -4,7 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { moveChannelUp } from '../utils';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -47,10 +47,10 @@ export const useMessageNewListener = (
       }
     };
 
-    clientOn(client, 'message.new', handleEvent);
+    const subscription = chatAPI.client.on(client, 'message.new', handleEvent);
 
     return () => {
-      clientOff(client, 'message.new', handleEvent);
+      subscription.unsubscribe();
     };
   }, [
     allowNewMessagesFromUnfilteredChannels,

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationAddedToChannelListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationAddedToChannelListener.ts
@@ -4,7 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { getChannel } from '../../../utils/getChannel';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -39,10 +39,14 @@ export const useNotificationAddedToChannelListener = (
       }
     };
 
-    clientOn(client, 'notification.added_to_channel', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'notification.added_to_channel',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'notification.added_to_channel', handleEvent);
+      subscription.unsubscribe();
     };
   }, [allowNewMessagesFromUnfilteredChannels, client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationMessageNewListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationMessageNewListener.ts
@@ -4,7 +4,7 @@ import uniqBy from 'lodash.uniqby';
 import { getChannel } from '../../../utils/getChannel';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -32,10 +32,14 @@ export const useNotificationMessageNewListener = (
       }
     };
 
-    clientOn(client, 'notification.message_new', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'notification.message_new',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'notification.message_new', handleEvent);
+      subscription.unsubscribe();
     };
   }, [allowNewMessagesFromUnfilteredChannels, client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -25,10 +25,14 @@ export const useNotificationRemovedFromChannelListener = (
       }
     };
 
-    clientOn(client, 'notification.removed_from_channel', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'notification.removed_from_channel',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'notification.removed_from_channel', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, customHandler, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/useUserPresenceChangedListener.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/useUserPresenceChangedListener.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useChatContext } from '../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { Channel, Event } from 'chat-shim';
 
@@ -28,10 +28,14 @@ export const useUserPresenceChangedListener = (
       });
     };
 
-    clientOn(client, 'user.presence.changed', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'user.presence.changed',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'user.presence.changed', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, setChannels]);
 };

--- a/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/ChannelPreview.tsx
@@ -8,7 +8,6 @@ import { useIsChannelMuted } from './hooks/useIsChannelMuted';
 import { useChannelPreviewInfo } from './hooks/useChannelPreviewInfo';
 import { getLatestMessagePreview as defaultGetLatestMessagePreview } from './utils';
 import { chatAPI } from '../../api/chatAPI';
-import { clientOff, clientOn } from '../../client';
 import { useChatContext } from '../../context/ChatContext';
 import { useTranslationContext } from '../../context/TranslationContext';
 import { useMessageDeliveryStatus } from './hooks/useMessageDeliveryStatus';
@@ -106,10 +105,14 @@ export const ChannelPreview = (props: ChannelPreviewProps) => {
       if (channel.cid === event.cid) setUnread(0);
     };
 
-    clientOn(client, 'notification.mark_read', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'notification.mark_read',
+      handleEvent,
+    );
 
     return () => {
-      clientOff(client, 'notification.mark_read', handleEvent);
+      subscription.unsubscribe();
     };
   }, [channel, client]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useChannelPreviewInfo.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useChannelPreviewInfo.ts
@@ -3,7 +3,7 @@ import type { Channel } from 'chat-shim';
 
 import { getDisplayImage, getDisplayTitle, getGroupChannelDisplayInfo } from '../utils';
 import { useChatContext } from '../../../context';
-import { clientOff, clientOn } from '../../../client';
+import { chatAPI } from '../../../api/chatAPI';
 
 export type ChannelPreviewInfoParams = {
   channel: Channel;
@@ -41,10 +41,10 @@ export const useChannelPreviewInfo = (props: ChannelPreviewInfoParams) => {
 
     updateInfo();
 
-    clientOn(client, 'user.updated', updateInfo);
+    const subscription = chatAPI.client.on(client, 'user.updated', updateInfo);
 
     return () => {
-      clientOff(client, 'user.updated', updateInfo);
+      subscription.unsubscribe();
     };
   }, [channel, channel.data, client, overrideImage, overrideTitle]);
 

--- a/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
+++ b/libs/stream-chat-shim/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
@@ -98,15 +98,15 @@ export const useIsChannelMuted = (channel: Channel): MuteStatus => {
       void fetchStatus();
     };
 
-    const subscription = client.on?.('notification.mutes_updated', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'notification.mutes_updated',
+      handleEvent,
+    );
 
     return () => {
       isMounted = false;
-      if (subscription?.unsubscribe) {
-        subscription.unsubscribe();
-      } else if (typeof client?.off === 'function') {
-        client.off('notification.mutes_updated', handleEvent);
-      }
+      subscription.unsubscribe();
     };
   }, [channel, client]);
 

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -87,14 +87,14 @@ export const useChat = ({
       setMutes(event.me?.mutes || []);
     };
 
-    const subscription = client.on?.('notification.mutes_updated', handleEvent);
+    const subscription = chatAPI.client.on(
+      client,
+      'notification.mutes_updated',
+      handleEvent,
+    );
 
     return () => {
-      if (subscription?.unsubscribe) {
-        subscription.unsubscribe();
-      } else if (typeof client?.off === 'function') {
-        client.off('notification.mutes_updated', handleEvent);
-      }
+      subscription.unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clientMutes?.length]);

--- a/libs/stream-chat-shim/src/components/MessageList/ConnectionStatus.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/ConnectionStatus.tsx
@@ -4,7 +4,7 @@ import type { Event } from 'chat-shim';
 
 import { CustomNotification } from './CustomNotification';
 import { useChatContext, useTranslationContext } from '../../context';
-import { clientOff, clientOn } from '../../client';
+import { chatAPI } from '../../api/chatAPI';
 
 const UnMemoizedConnectionStatus = () => {
   const { client } = useChatContext('ConnectionStatus');
@@ -19,10 +19,14 @@ const UnMemoizedConnectionStatus = () => {
       }
     };
 
-    clientOn(client, 'connection.changed', connectionChanged);
+    const subscription = chatAPI.client.on(
+      client,
+      'connection.changed',
+      connectionChanged,
+    );
 
     return () => {
-      clientOff(client, 'connection.changed', connectionChanged);
+      subscription.unsubscribe();
     };
   }, [client, online]);
 

--- a/libs/stream-chat-shim/src/components/MessageList/ScrollToBottomButton.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/ScrollToBottomButton.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { ArrowDown } from './icons';
 
 import { useChannelStateContext, useChatContext } from '../../context';
-import { clientOff, clientOn } from '../../client';
 import { chatAPI } from '../../api/chatAPI';
 
 import type { Event } from 'chat-shim';
@@ -63,10 +62,10 @@ const UnMemoizedScrollToBottomButton = (
       }
     };
 
-    clientOn(client, observedEvent, handleEvent);
+    const subscription = chatAPI.client.on(client, observedEvent, handleEvent);
 
     return () => {
-      clientOff(client, observedEvent, handleEvent);
+      subscription.unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeChannel, isMessageListScrolledToBottom, observedEvent, replyCount, thread]);

--- a/libs/stream-chat-shim/src/components/MessageList/hooks/VirtualizedMessageList/useGiphyPreview.ts
+++ b/libs/stream-chat-shim/src/components/MessageList/hooks/VirtualizedMessageList/useGiphyPreview.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useChatContext } from '../../../../context/ChatContext';
-import { clientOff, clientOn } from '../../../../client';
+import { chatAPI } from '../../../../api/chatAPI';
 
 import type { EventHandler, LocalMessage } from 'chat-shim';
 
@@ -20,10 +20,10 @@ export const useGiphyPreview = (separateGiphyPreview: boolean) => {
       }
     };
 
-    clientOn(client, 'message.new', handleEvent);
+    const subscription = chatAPI.client.on(client, 'message.new', handleEvent);
 
     return () => {
-      clientOff(client, 'message.new', handleEvent);
+      subscription.unsubscribe();
     };
   }, [client, separateGiphyPreview]);
 

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -357,7 +357,7 @@
     "stubName": "client.on",
     "ticketType": "shim",
     "todoCount": 25,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- define typed client event handling in the shim and expose chatAPI.client.on
- re-emit websocket events on the local client bus and wire UI listeners through the new helper
- mark the client.on wire-up manifest entry as complete

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/client.on.test.ts *(fails: Cannot find module 'react' from 'libs/chat-shim/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d6e4230a948326a185377ba564287e