### PR TITLE
feat(client.threads.activate): wire up (shim only)

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.activate.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.activate.test.ts
@@ -1,9 +1,16 @@
 import { clientThreadsActivate } from "../src/chatSDKShim";
+import { chatAPI } from "../src/api/chatAPI";
 
 describe("clientThreadsActivate", () => {
   it("calls client.threads.activate when available", () => {
     const fn = jest.fn();
     clientThreadsActivate({ threads: { activate: fn } } as any);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("invokes via chatAPI helper", () => {
+    const fn = jest.fn();
+    chatAPI.clientThreadsActivate({ client: { threads: { activate: fn } } });
     expect(fn).toHaveBeenCalled();
   });
 

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1,4 +1,7 @@
-import { chatSDKShim } from '../chatSDKShim';
+import {
+  chatSDKShim,
+  clientThreadsActivate as clientThreadsActivateShim,
+} from '../chatSDKShim';
 
 export type {
   ClientEventHandler,
@@ -115,9 +118,19 @@ export type ChannelCountUnreadParams = {
   lastRead?: Date;
 };
 
+export type ClientThreadsActivateInput = {
+  client: { threads?: { activate?: () => void } };
+};
+
 // shim-only: no network; delegate to SDK shim
 export async function addAnswer(input: AddAnswerInput): Promise<AddAnswer> {
   return chatSDKShim.addAnswer(input);
+}
+
+export function clientThreadsActivate({
+  client,
+}: ClientThreadsActivateInput): void {
+  clientThreadsActivateShim(client);
 }
 
 function channelCountUnread({
@@ -845,6 +858,7 @@ export const chatAPI = {
     on: chatSDKShim.client.on,
   },
   addAnswer,
+  clientThreadsActivate,
   createReminder,
   deleteMessage,
   updateMessage,

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -9,6 +9,7 @@ import { ThreadListEmptyPlaceholder as DefaultThreadListEmptyPlaceholder } from 
 import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner } from "./ThreadListUnseenThreadsBanner";
 import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from "./ThreadListLoadingIndicator";
 import { useChatContext, useComponentContext } from "../../../context";
+import { chatAPI } from "../../../api/chatAPI";
 import { useStateStore } from "../../../store";
 import { clientThreadsState } from "../../../chatSDKShim";
 import {
@@ -32,7 +33,7 @@ export const useThreadList = () => {
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
-        client.threads.activate();
+        chatAPI.clientThreadsActivate({ client });
       }
       if (document.visibilityState === "hidden") {
         clientThreadsDeactivate(client);


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.clientThreadsActivate` shim helper that delegates to the SDK shim
- update the thread list visibility handler to route activation through the new helper
- extend the existing unit test to cover the chatAPI helper

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/client.threads.activate.test.ts *(fails: pre-existing ts-jest type errors in chatSDKShim.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d6edd7f7f08326a77b5bbfcd7eb806