### PR TITLE
feat(client.threads.deactivate): wire up shim-only (no HTTP)

### DIFF
--- a/frontend/__tests__/adapter/threads.test.js
+++ b/frontend/__tests__/adapter/threads.test.js
@@ -68,3 +68,24 @@ var originalFetch = global.fetch;
         }
     });
 }); });
+(0, vitest_1.test)('client.threads.deactivate clears active thread state', function () {
+    var client = new ChatClient_1.ChatClient('u1', 'jwt-test');
+    var channel = client.channel('messaging', 'room1');
+    client.stateStore._set({ channels: [channel] });
+    client.activeChannels[channel.cid] = channel;
+    channel.messageComposer.setThreadId('thread-1');
+    client.threads.state._set({
+        activeThread: { id: 'thread-1' },
+        activeThreadCid: channel.cid,
+        activeThreadId: 'thread-1',
+    });
+    var cleanup = vitest_1.vi.fn();
+    client.threadCleanupHandlers.add(cleanup);
+    client.threads.deactivate();
+    var snapshot = client.threads.state.getSnapshot();
+    (0, vitest_1.expect)(snapshot.activeThread).toBeNull();
+    (0, vitest_1.expect)(snapshot.activeThreadId).toBeNull();
+    (0, vitest_1.expect)(snapshot.activeThreadCid).toBeNull();
+    (0, vitest_1.expect)(channel.messageComposer.threadId).toBeUndefined();
+    (0, vitest_1.expect)(cleanup).toHaveBeenCalled();
+});

--- a/frontend/__tests__/adapter/threads.test.ts
+++ b/frontend/__tests__/adapter/threads.test.ts
@@ -24,3 +24,30 @@ test('getThreads fetches list and updates store', async () => {
   expect(res).toEqual([{ id: 't1' }]);
   expect(client.threads.state.getSnapshot().threads).toEqual([{ id: 't1' }]);
 });
+
+test('client.threads.deactivate clears active thread state', () => {
+  const client = new ChatClient('u1', 'jwt-test');
+  const channel = client.channel('messaging', 'room1');
+
+  client.stateStore._set({ channels: [channel] });
+  client.activeChannels[channel.cid] = channel;
+
+  channel.messageComposer.setThreadId('thread-1');
+  client.threads.state._set({
+    activeThread: { id: 'thread-1' } as any,
+    activeThreadCid: channel.cid,
+    activeThreadId: 'thread-1',
+  });
+
+  const cleanup = vi.fn();
+  (client as any).threadCleanupHandlers.add(cleanup);
+
+  client.threads.deactivate();
+
+  const snapshot = client.threads.state.getSnapshot();
+  expect(snapshot.activeThread).toBeNull();
+  expect(snapshot.activeThreadId).toBeNull();
+  expect(snapshot.activeThreadCid).toBeNull();
+  expect(channel.messageComposer.threadId).toBeUndefined();
+  expect(cleanup).toHaveBeenCalled();
+});

--- a/frontend/src/lib/stream-adapter/ChatClient.js
+++ b/frontend/src/lib/stream-adapter/ChatClient.js
@@ -92,6 +92,7 @@ var ChatClient = /** @class */ (function () {
         this.mutedChannels = [];
         this.mutedUsers = [];
         this.listeners = {};
+        this.threadCleanupHandlers = new Set();
         /** Minimal client.state stub holding fetched users */
         this.state = { users: {} };
         /** global stores Stream-UI subscribes to */
@@ -197,17 +198,23 @@ var ChatClient = /** @class */ (function () {
         this.clientID = randomId();
         this.tokenManager = new tokenManager_1.TokenManager(jwt || undefined);
         /* Basic threads manager */
+        var threadState = new MiniStore_1.MiniStore({
+            threads: [],
+            unseenThreadIds: [],
+            unreadThreadCount: 0,
+            pagination: { isLoadingNext: false },
+            activeThread: null,
+            activeThreadId: null,
+            activeThreadCid: null,
+        });
         this.threads = {
-            state: new MiniStore_1.MiniStore({
-                threads: [],
-                unseenThreadIds: [],
-                unreadThreadCount: 0,
-                pagination: { isLoadingNext: false },
-            }),
+            state: threadState,
             registerSubscriptions: function () { },
-            unregisterSubscriptions: function () { },
+            unregisterSubscriptions: function () {
+                _this.cleanupThreadSubscriptions();
+            },
             reload: function () {
-                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0: return [4 /*yield*/, this.getThreads()];
                         case 1:
@@ -217,7 +224,7 @@ var ChatClient = /** @class */ (function () {
                 }); });
             },
             loadNextPage: function () {
-                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0: return [4 /*yield*/, this.getThreads()];
                         case 1:
@@ -227,7 +234,40 @@ var ChatClient = /** @class */ (function () {
                 }); });
             },
             activate: function () { },
-            deactivate: function () { },
+            deactivate: function () {
+                var composerSources = new Set();
+                _this.cleanupThreadSubscriptions();
+                var snapshotChannels = _this.stateStore.getSnapshot().channels || [];
+                Object.values(_this.activeChannels || {}).forEach(function (chan) {
+                    if (chan)
+                        composerSources.add(chan);
+                });
+                snapshotChannels.forEach(function (chan) {
+                    if (chan)
+                        composerSources.add(chan);
+                });
+                composerSources.forEach(function (chan) {
+                    var composer = chan && chan.messageComposer;
+                    if (composer && typeof composer.setThreadId === 'function') {
+                        try {
+                            composer.setThreadId(void 0);
+                        }
+                        catch (_a) {
+                            /* ignore composer cleanup errors */
+                        }
+                    }
+                });
+                var snapshot = threadState.getSnapshot();
+                if (snapshot.activeThread !== null ||
+                    snapshot.activeThreadId !== null ||
+                    snapshot.activeThreadCid !== null) {
+                    threadState._set({
+                        activeThread: null,
+                        activeThreadId: null,
+                        activeThreadCid: null,
+                    });
+                }
+            },
         };
         this.polls = {
             store: new MiniStore_1.MiniStore({ polls: [] }),
@@ -249,6 +289,17 @@ var ChatClient = /** @class */ (function () {
             }),
         };
     }
+    ChatClient.prototype.cleanupThreadSubscriptions = function () {
+        this.threadCleanupHandlers.forEach(function (cleanup) {
+            try {
+                cleanup();
+            }
+            catch (_a) {
+                /* ignore cleanup errors */
+            }
+        });
+        this.threadCleanupHandlers.clear();
+    };
     /**
      * Manually dispatch an event to this client and its channels.
      * Only a tiny subset of Stream events is supported.

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -40,6 +40,7 @@ export class ChatClient {
     mutedChannels: unknown[] = [];
     mutedUsers: unknown[] = [];
     listeners: Record<string, any[]> = {};
+    private threadCleanupHandlers = new Set<() => void>();
 
     /** Minimal client.state stub holding fetched users */
     state = { users: {} as Record<string, User> };
@@ -108,19 +109,68 @@ export class ChatClient {
         this.tokenManager = new TokenManager(jwt || undefined);
 
         /* Basic threads manager */
+        const threadState = new MiniStore({
+            threads: [] as Message[],
+            unseenThreadIds: [] as string[],
+            unreadThreadCount: 0,
+            pagination: { isLoadingNext: false },
+            activeThread: null as Message | null,
+            activeThreadId: null as string | null,
+            activeThreadCid: null as string | null,
+        });
+
         this.threads = {
-            state: new MiniStore({
-                threads: [] as Message[],
-                unseenThreadIds: [] as string[],
-                unreadThreadCount: 0,
-                pagination: { isLoadingNext: false },
-            }),
-            registerSubscriptions() {/* noop */ },
-            unregisterSubscriptions() {/* noop */ },
-            async reload() { await (this as any).getThreads(); },
-            async loadNextPage() { await (this as any).getThreads(); },
-            activate() {/* noop */ },
-            deactivate() {/* noop */ },
+            state: threadState,
+            registerSubscriptions: () => {
+                /* noop */
+            },
+            unregisterSubscriptions: () => {
+                this.cleanupThreadSubscriptions();
+            },
+            reload: async () => {
+                await this.getThreads();
+            },
+            loadNextPage: async () => {
+                await this.getThreads();
+            },
+            activate: () => {
+                /* noop */
+            },
+            deactivate: () => {
+                this.cleanupThreadSubscriptions();
+
+                const composerSources = [
+                    ...Object.values(this.activeChannels ?? {}),
+                    ...this.stateStore.getSnapshot().channels,
+                ];
+
+                for (const channel of composerSources) {
+                    const composer = channel?.messageComposer as
+                        | { setThreadId?: (id: string | undefined) => void }
+                        | undefined;
+
+                    if (composer && typeof composer.setThreadId === 'function') {
+                        try {
+                            composer.setThreadId(undefined);
+                        } catch {
+                            /* ignore composer cleanup errors */
+                        }
+                    }
+                }
+
+                const snapshot = threadState.getSnapshot();
+                if (
+                    snapshot.activeThread !== null ||
+                    snapshot.activeThreadId !== null ||
+                    snapshot.activeThreadCid !== null
+                ) {
+                    threadState._set({
+                        activeThread: null,
+                        activeThreadId: null,
+                        activeThreadCid: null,
+                    });
+                }
+            },
         } as any;
         this.polls = {
             store: new MiniStore({ polls: [] as any[] }),
@@ -160,6 +210,17 @@ export class ChatClient {
         }
     };
     emit = this.bus.emit.bind(this);
+
+    private cleanupThreadSubscriptions() {
+        this.threadCleanupHandlers.forEach((cleanup) => {
+            try {
+                cleanup();
+            } catch {
+                /* ignore cleanup errors */
+            }
+        });
+        this.threadCleanupHandlers.clear();
+    }
 
     /**
      * Manually dispatch an event to this client and its channels.

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -392,7 +392,7 @@
     "operationId": "shim::client.threads.deactivate",
     "stubName": "client.threads.deactivate",
     "ticketType": "shim",
-    "todoCount": 2,
+    "todoCount": 0,
     "status": "ok"
   },
   {


### PR DESCRIPTION
## Summary
- add thread cleanup tracking to the shim ChatClient so `client.threads.deactivate` clears active thread metadata and composer thread IDs
- cover the new behaviour with a focused Vitest spec
- mark the wireup manifest entry as complete for this stub

## Testing
- pnpm --filter frontend test -- frontend/__tests__/adapter/threads.test.ts *(fails: Cannot find module '../api')*


------
https://chatgpt.com/codex/tasks/task_e_68d6fc6f15288326b3da13c6187c4bf1