### PR TITLE
feat: add typed shim helper for client.threads.loadNextPage

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.loadNextPage.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.loadNextPage.test.ts
@@ -1,24 +1,52 @@
+import type { LoadNextPageArgs } from '../src/api/chatAPI';
 import { clientThreadsLoadNextPage } from '../src/chatSDKShim';
 
+const persistedMessage = {
+  id: 42,
+  body: 'hello',
+  sent_by: 'user-1',
+  created_at: '2024-01-01T00:00:00Z',
+};
+
 describe('clientThreadsLoadNextPage', () => {
-  it('calls client.threads.loadNextPage when available', async () => {
-    const fn = jest.fn().mockResolvedValue('ok');
-    const client = { threads: { loadNextPage: fn } } as any;
-    const res = await clientThreadsLoadNextPage(client);
-    expect(fn).toHaveBeenCalled();
-    expect(res).toBe('ok');
+  it('normalizes results and forwards arguments to the client', async () => {
+    const args: LoadNextPageArgs = {
+      cid: 'channel_123',
+      parentId: 'parent-message',
+      limit: 25,
+      cursor: 'cursor-1',
+    };
+
+    const loadNextPage = jest.fn().mockResolvedValue({
+      messages: [
+        { ...persistedMessage },
+        { id: 'invalid', body: 1, sent_by: 'user-2', created_at: 'oops' },
+      ],
+      next_cursor: 'next-cursor',
+      has_more: true,
+    });
+
+    const client = { threads: { loadNextPage } } as any;
+
+    const result = await clientThreadsLoadNextPage(client, args);
+
+    expect(loadNextPage).toHaveBeenCalledWith({
+      cid: 'channel_123',
+      parentId: 'parent-message',
+      parent_id: 'parent-message',
+      limit: 25,
+      cursor: 'cursor-1',
+    });
+
+    expect(result).toEqual({
+      messages: [persistedMessage],
+      nextCursor: 'next-cursor',
+      hasMore: true,
+    });
   });
 
-  it('falls back to HTTP request when not implemented', async () => {
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValue({ json: () => Promise.resolve('ok') });
-    // @ts-ignore
-    global.fetch = fetchMock;
-    const res = await clientThreadsLoadNextPage({} as any);
-    expect(fetchMock).toHaveBeenCalledWith('/api/threads/', {
-      credentials: 'same-origin',
-    });
-    expect(res).toBe('ok');
+  it('returns an empty page when loadNextPage is unavailable', async () => {
+    const result = await clientThreadsLoadNextPage({} as any);
+    expect(result).toEqual({ messages: [], hasMore: false });
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1,6 +1,7 @@
 import {
   chatSDKShim,
   clientThreadsActivate as clientThreadsActivateShim,
+  clientThreadsLoadNextPage as clientThreadsLoadNextPageShim,
 } from '../chatSDKShim';
 
 export type {
@@ -111,6 +112,21 @@ export type ChannelQueryRequest = {
 export type ChannelQueryResponse = {
   messages: Message[];
   next: number | null;
+};
+
+export type ThreadMessage = Message;
+
+export type LoadNextPageArgs = {
+  cid?: string;
+  parentId?: string;
+  limit?: number;
+  cursor?: string;
+};
+
+export type ThreadPage = {
+  messages: ThreadMessage[];
+  nextCursor?: string;
+  hasMore: boolean;
 };
 
 export type ChannelCountUnreadParams = {
@@ -856,6 +872,20 @@ export const chatAPI = {
   },
   client: {
     on: chatSDKShim.client.on,
+    threads: {
+      loadNextPage: ({
+        client,
+        ...args
+      }: {
+        client: {
+          threads?: { loadNextPage?: (options?: unknown) => Promise<unknown> };
+        };
+      } & Partial<LoadNextPageArgs>) =>
+        clientThreadsLoadNextPageShim(
+          client,
+          Object.keys(args).length ? (args as LoadNextPageArgs) : undefined,
+        ),
+    },
   },
   addAnswer,
   clientThreadsActivate,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -22,12 +22,14 @@ import {
   type AddAnswerInput,
   type AppSettings,
   type CreateReminderInput,
+  type LoadNextPageArgs,
   type Message as APIMessage,
   type MuteUserInput,
   type UnmuteUserResponse,
   type RegisterSubscriptionsInput,
   type WebPushSubscription,
   type RoomDraft,
+  type ThreadPage,
   type User,
   type UserAgentInfo,
   type ChannelUnpinResult,
@@ -1940,14 +1942,131 @@ export function clientThreadsDeactivate(client: {
   client.threads?.deactivate?.();
 }
 
-export async function clientThreadsLoadNextPage(client: {
-  threads?: { loadNextPage?: () => Promise<any> };
-}): Promise<any> {
-  if (client.threads?.loadNextPage) {
-    return client.threads.loadNextPage();
+type ThreadPaginationClient = {
+  threads?: {
+    loadNextPage?: (options?: unknown) => Promise<unknown>;
+  };
+};
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const parseThreadMessages = (value: unknown): APIMessage[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter((item): item is APIMessage => {
+    if (!item || typeof item !== 'object') return false;
+    const candidate = item as Partial<APIMessage>;
+    return (
+      typeof candidate.id === 'number' &&
+      typeof candidate.body === 'string' &&
+      typeof candidate.sent_by === 'string' &&
+      typeof candidate.created_at === 'string'
+    );
+  });
+};
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const toBooleanLike = (value: unknown, fallback: boolean): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value > 0 : fallback;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return fallback;
+    if (normalized === 'true' || normalized === '1' || normalized === 'yes') return true;
+    if (normalized === 'false' || normalized === '0' || normalized === 'no') return false;
   }
-  const resp = await fetch('/api/threads/', { credentials: 'same-origin' });
-  return resp.json();
+  return fallback;
+};
+
+const parseThreadPage = (value: unknown): ThreadPage => {
+  if (Array.isArray(value)) {
+    return { messages: parseThreadMessages(value), hasMore: false };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return { messages: [], hasMore: false };
+  }
+
+  const record = value as Record<string, unknown>;
+  const messagesSource =
+    record.messages ??
+    record.data ??
+    record.results ??
+    record.threads ??
+    record.items ??
+    record.replies;
+  const messages = parseThreadMessages(messagesSource);
+
+  const nextCursor =
+    toOptionalString(record.nextCursor) ??
+    toOptionalString(record.next_cursor) ??
+    toOptionalString(record.next) ??
+    toOptionalString(record.cursor);
+
+  const hasMoreRaw =
+    record.hasMore ??
+    record.has_more ??
+    record.more ??
+    record.hasNext ??
+    record.has_next;
+
+  const page: ThreadPage = {
+    messages,
+    hasMore: toBooleanLike(hasMoreRaw, Boolean(nextCursor)),
+  };
+
+  if (nextCursor) {
+    page.nextCursor = nextCursor;
+  }
+
+  return page;
+};
+
+const mapLoadNextPageArgs = (
+  args?: LoadNextPageArgs,
+): Record<string, unknown> | undefined => {
+  if (!args) return undefined;
+
+  const payload: Record<string, unknown> = {};
+
+  if (typeof args.cid === 'string' && args.cid) {
+    payload.cid = args.cid;
+  }
+
+  if (typeof args.parentId === 'string' && args.parentId) {
+    payload.parentId = args.parentId;
+    payload.parent_id = args.parentId;
+  }
+
+  if (isFiniteNumber(args.limit)) {
+    payload.limit = args.limit;
+  }
+
+  if (typeof args.cursor === 'string' && args.cursor) {
+    payload.cursor = args.cursor;
+  }
+
+  return Object.keys(payload).length ? payload : undefined;
+};
+
+export async function clientThreadsLoadNextPage(
+  client: ThreadPaginationClient,
+  args?: LoadNextPageArgs,
+): Promise<ThreadPage> {
+  const loadNextPage = client.threads?.loadNextPage;
+  if (typeof loadNextPage !== 'function') {
+    return { messages: [], hasMore: false };
+  }
+
+  const payload = mapLoadNextPageArgs(args);
+  const result = await loadNextPage(payload);
+  return parseThreadPage(result);
 }
 
 export async function clientThreadsReload(client: {

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -402,7 +402,7 @@
     "stubName": "client.threads.loadNextPage",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- expose a typed `chatAPI.client.threads.loadNextPage` helper for thread pagination
- normalize shim-side `clientThreadsLoadNextPage` logic and remove the HTTP fallback
- refresh the unit test to validate the typed result and mark the manifest entry as wired

## Testing
- TS_JEST_IGNORE_DIAGNOSTICS=2339,2345,151001 pnpm exec jest libs/stream-chat-shim/__tests__/client.threads.loadNextPage.test.ts *(fails: existing ts-jest TypeScript diagnostics unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d703acbf7c83268e5d51b0bec7c225