### PR TITLE
feat(client.threads.reload): wire up shim-only

### DIFF
--- a/libs/stream-chat-shim/__tests__/client.threads.reload.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.reload.test.ts
@@ -1,20 +1,30 @@
 import { clientThreadsReload } from '../src/chatSDKShim';
 
 describe('clientThreadsReload', () => {
-  it('calls client.threads.reload when available', async () => {
-    const fn = jest.fn().mockResolvedValue('ok');
-    const client = { threads: { reload: fn } } as any;
-    const res = await clientThreadsReload(client);
-    expect(fn).toHaveBeenCalled();
-    expect(res).toBe('ok');
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-ignore
+      delete global.fetch;
+    }
   });
 
-  it('falls back to HTTP request when not implemented', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve('ok') });
+  it('calls client.threads.reload when available', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    const client = { threads: { reload: fn } } as any;
+    await clientThreadsReload(client);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('no-ops when reload implementation is missing', async () => {
+    const fetchMock = jest.fn();
     // @ts-ignore
     global.fetch = fetchMock;
-    const res = await clientThreadsReload({} as any);
-    expect(fetchMock).toHaveBeenCalledWith('/api/threads/', { credentials: 'same-origin' });
-    expect(res).toBe('ok');
+
+    await expect(clientThreadsReload({} as any)).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -2,6 +2,7 @@ import {
   chatSDKShim,
   clientThreadsActivate as clientThreadsActivateShim,
   clientThreadsLoadNextPage as clientThreadsLoadNextPageShim,
+  clientThreadsReload as clientThreadsReloadShim,
 } from '../chatSDKShim';
 
 export type {
@@ -138,6 +139,10 @@ export type ClientThreadsActivateInput = {
   client: { threads?: { activate?: () => void } };
 };
 
+export type ClientThreadsReloadInput = {
+  client: { threads?: { reload?: () => Promise<unknown> } };
+};
+
 // shim-only: no network; delegate to SDK shim
 export async function addAnswer(input: AddAnswerInput): Promise<AddAnswer> {
   return chatSDKShim.addAnswer(input);
@@ -147,6 +152,12 @@ export function clientThreadsActivate({
   client,
 }: ClientThreadsActivateInput): void {
   clientThreadsActivateShim(client);
+}
+
+export async function clientThreadsReload({
+  client,
+}: ClientThreadsReloadInput): Promise<void> {
+  await clientThreadsReloadShim(client);
 }
 
 function channelCountUnread({
@@ -885,10 +896,14 @@ export const chatAPI = {
           client,
           Object.keys(args).length ? (args as LoadNextPageArgs) : undefined,
         ),
+      reload: ({
+        client,
+      }: ClientThreadsReloadInput) => clientThreadsReloadShim(client),
     },
   },
   addAnswer,
   clientThreadsActivate,
+  clientThreadsReload,
   createReminder,
   deleteMessage,
   updateMessage,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -2070,13 +2070,13 @@ export async function clientThreadsLoadNextPage(
 }
 
 export async function clientThreadsReload(client: {
-  threads?: { reload?: () => Promise<any> };
-}): Promise<any> {
-  if (client.threads?.reload) {
-    return client.threads.reload();
+  threads?: { reload?: () => Promise<unknown> };
+}): Promise<void> {
+  if (typeof client.threads?.reload !== 'function') {
+    return;
   }
-  const resp = await fetch('/api/threads/', { credentials: 'same-origin' });
-  return resp.json();
+
+  await client.threads.reload();
 }
 
 const fallbackThreadStateStore = new StateStore<any>({} as any);

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadListUnseenThreadsBanner.tsx
@@ -5,6 +5,7 @@ import type { ThreadManagerState } from 'chat-shim';
 import { Icon } from '../icons';
 import { useChatContext } from '../../../context';
 import { useStateStore } from '../../../store';
+import { chatAPI } from '../../../api/chatAPI';
 import { clientThreadsState } from '../../../chatSDKShim';
 
 const selector = (nextValue: ThreadManagerState) => ({
@@ -27,7 +28,7 @@ export const ThreadListUnseenThreadsBanner = () => {
       <button
         className='str-chat__unseen-threads-banner__button'
         onClick={() => {
-          client.threads.reload();
+          void chatAPI.clientThreadsReload({ client });
         }}
       >
         <Icon.Reload />


### PR DESCRIPTION
## Summary
- add a typed chatAPI.clientThreadsReload helper that drives the SDK shim reload path
- remove the HTTP fallback, delegate to the real client reload, and update the unseen threads banner wiring
- refresh the related unit test to cover the no-op guard

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/client.threads.reload.test.ts libs/stream-chat-shim/__tests__/ThreadListUnseenThreadsBanner.test.tsx *(fails: missing @testing-library/react and downstream TS errors in the broader suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d70e0d57508326bfd54e4400508223