### PR TITLE
feat(client.threads.state): wire up GET /api/rooms/{cid}/messages/

### DIFF
--- a/backend/chat/api_views.py
+++ b/backend/chat/api_views.py
@@ -12,6 +12,7 @@ from django.http import QueryDict
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import generics, permissions, status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -127,6 +128,8 @@ class RoomMessageListCreateView(RoomFromCIDMixin, generics.ListCreateAPIView):
 
     def get_queryset(self):
         room = self.get_room()
+        if not _user_can_access_room(self.request.user, room):
+            raise PermissionDenied()
         qs = room.messages.order_by("-id")
         before = self.request.query_params.get("before")
         if before:

--- a/libs/stream-chat-shim/__tests__/client.threads.state.test.ts
+++ b/libs/stream-chat-shim/__tests__/client.threads.state.test.ts
@@ -1,6 +1,5 @@
 import { clientThreadsState } from '../src/chatSDKShim';
 import { StateStore } from 'chat-shim';
-import { noopStore } from 'chat-shim/noopStore';
 
 describe('clientThreadsState', () => {
   it('returns client.threads.state when available', () => {
@@ -9,8 +8,14 @@ describe('clientThreadsState', () => {
     expect(clientThreadsState(client)).toBe(store);
   });
 
-  it('falls back to noopStore when not implemented', () => {
+  it('returns a StateStore when threads.state is missing', () => {
     const client = {} as any;
-    expect(clientThreadsState(client)).toBe(noopStore);
+    const store = clientThreadsState(client);
+    expect(store).toBeInstanceOf(StateStore);
+    expect(store.getLatestValue()).toMatchObject({
+      threads: [],
+      unseenThreadIds: [],
+      unreadThreadCount: 0,
+    });
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -102,6 +102,9 @@ export type Message = {
   body: string;
   created_at: string;
   sent_by: string;
+  text?: string;
+  updated_at?: string;
+  deleted_at?: string | null;
 };
 
 export type ChannelQueryRequest = {
@@ -116,6 +119,33 @@ export type ChannelQueryResponse = {
 };
 
 export type ThreadMessage = Message;
+
+export type ThreadPreviewMessage = {
+  id: string;
+  text: string;
+  created_at: string;
+  deleted_at: string | null;
+  sent_by: string;
+};
+
+export type ThreadPreview = {
+  id: string;
+  parent: ThreadPreviewMessage;
+  replies: ThreadPreviewMessage[];
+};
+
+export type ClientThreadsStateParams = {
+  cid: string;
+  limit?: number;
+  before?: number;
+};
+
+export type ClientThreadsStateResponse = {
+  threads: ThreadPreview[];
+  unreadThreadCount: number;
+  unseenThreadIds: string[];
+  next: number | null;
+};
 
 export type LoadNextPageArgs = {
   cid?: string;
@@ -226,6 +256,53 @@ export const channelQuery = async ({
   const next = typeof rawNext === "number" ? rawNext : null;
 
   return { messages, next };
+};
+
+const toThreadPreviewMessage = (message: Message): ThreadPreviewMessage => {
+  const text =
+    typeof message.text === "string" && message.text.trim()
+      ? message.text
+      : message.body;
+
+  const deletedAt = message.deleted_at;
+  let normalizedDeleted: string | null = null;
+  if (typeof deletedAt === "string") {
+    normalizedDeleted = deletedAt;
+  } else if (deletedAt instanceof Date) {
+    normalizedDeleted = deletedAt.toISOString();
+  }
+
+  return {
+    id: String(message.id),
+    text,
+    created_at: message.created_at,
+    deleted_at: normalizedDeleted,
+    sent_by: message.sent_by,
+  };
+};
+
+export const clientThreadsState = async ({
+  cid,
+  limit,
+  before,
+}: ClientThreadsStateParams): Promise<ClientThreadsStateResponse> => {
+  const { messages, next } = await channelQuery({ cid, limit, before });
+
+  const threads = messages.map((message) => {
+    const preview = toThreadPreviewMessage(message);
+    return {
+      id: preview.id,
+      parent: preview,
+      replies: [preview],
+    } satisfies ThreadPreview;
+  });
+
+  return {
+    threads,
+    unreadThreadCount: 0,
+    unseenThreadIds: [],
+    next,
+  };
 };
 
 type ChannelMembershipRecord = Record<string, unknown>;
@@ -899,10 +976,13 @@ export const chatAPI = {
       reload: ({
         client,
       }: ClientThreadsReloadInput) => clientThreadsReloadShim(client),
+      state: ({ cid, limit, before }: ClientThreadsStateParams) =>
+        clientThreadsState({ cid, limit, before }),
     },
   },
   addAnswer,
   clientThreadsActivate,
+  clientThreadsState,
   clientThreadsReload,
   createReminder,
   deleteMessage,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -2079,8 +2079,6 @@ export async function clientThreadsReload(client: {
   await client.threads.reload();
 }
 
-const fallbackThreadStateStore = new StateStore<any>({} as any);
-
 export async function deleteReaction(
   messageId: string,
   reactionId: string,
@@ -2217,10 +2215,59 @@ const fallbackNotificationsStore = new StateStore<{ notifications: any[] }>({
   notifications: [],
 });
 
+type ThreadManagerStateShape = {
+  threads: any[];
+  unseenThreadIds: string[];
+  unreadThreadCount: number;
+  pagination: {
+    isLoadingNext: boolean;
+    isLoadingPrev: boolean;
+    nextCursor?: string | null;
+  };
+};
+
+const createInitialThreadManagerState = (): ThreadManagerStateShape => ({
+  threads: [],
+  unseenThreadIds: [],
+  unreadThreadCount: 0,
+  pagination: { isLoadingNext: false, isLoadingPrev: false, nextCursor: null },
+});
+
+const fallbackThreadStateStore = new StateStore<ThreadManagerStateShape>(
+  createInitialThreadManagerState(),
+);
+
+const threadStateByClient = new WeakMap<
+  object,
+  StateStore<ThreadManagerStateShape>
+>();
+
 export function clientThreadsState(client: {
   threads?: { state?: StateStore<any> };
-}): StateStore<any> {
-  return client.threads?.state ?? fallbackThreadStateStore;
+}): StateStore<ThreadManagerStateShape> {
+  if (!client) {
+    return fallbackThreadStateStore;
+  }
+
+  const existing = client.threads?.state;
+  if (existing?.getLatestValue) {
+    return existing as StateStore<ThreadManagerStateShape>;
+  }
+
+  let store = threadStateByClient.get(client as object);
+  if (!store) {
+    store = new StateStore<ThreadManagerStateShape>(
+      createInitialThreadManagerState(),
+    );
+    threadStateByClient.set(client as object, store);
+  }
+
+  if (client.threads) {
+    (client.threads as { state?: StateStore<ThreadManagerStateShape> }).state =
+      store;
+  }
+
+  return store;
 }
 
 export function notificationsStore(client: {

--- a/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
+++ b/libs/stream-chat-shim/src/components/Threads/ThreadList/ThreadList.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import type { ComputeItemKey, VirtuosoProps } from "react-virtuoso";
 import { Virtuoso } from "react-virtuoso";
 
+import { StateStore } from "chat-shim";
 import type { Thread, ThreadManagerState } from "chat-shim";
 
 import { ThreadListItem as DefaultThreadListItem } from "./ThreadListItem";
@@ -10,6 +11,7 @@ import { ThreadListUnseenThreadsBanner as DefaultThreadListUnseenThreadsBanner }
 import { ThreadListLoadingIndicator as DefaultThreadListLoadingIndicator } from "./ThreadListLoadingIndicator";
 import { useChatContext, useComponentContext } from "../../../context";
 import { chatAPI } from "../../../api/chatAPI";
+import type { ThreadPreview, ThreadPreviewMessage } from "../../../api/chatAPI";
 import { useStateStore } from "../../../store";
 import { clientThreadsState } from "../../../chatSDKShim";
 import {
@@ -22,6 +24,100 @@ const selector = (nextValue: ThreadManagerState) => ({
 });
 
 const computeItemKey: ComputeItemKey<Thread, unknown> = (_, item) => item.id;
+
+const toSafeDate = (value: string): Date => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return new Date();
+  }
+  return date;
+};
+
+const toLocalMessage = (message: ThreadPreviewMessage, cid?: string) => {
+  const createdAt = toSafeDate(message.created_at);
+  const local: Record<string, unknown> = {
+    id: message.id,
+    cid: cid ?? "",
+    type: "regular",
+    status: "received",
+    text: message.text,
+    html: message.text,
+    body: message.text,
+    created_at: createdAt,
+    updated_at: createdAt,
+    attachments: [],
+    latest_reactions: [],
+    own_reactions: [],
+    reaction_groups: {},
+    user: { id: message.sent_by, name: message.sent_by },
+    user_id: message.sent_by,
+  };
+
+  if (message.deleted_at) {
+    const deletedAt = new Date(message.deleted_at);
+    local.deleted_at = Number.isNaN(deletedAt.getTime())
+      ? message.deleted_at
+      : deletedAt;
+  }
+
+  return local;
+};
+
+const createThreadFromPreview = ({
+  preview,
+  channel,
+  currentUserId,
+}: {
+  preview: ThreadPreview;
+  channel?: Thread["channel"];
+  currentUserId?: string;
+}): Thread => {
+  const cid = channel?.cid;
+  const parentMessage = toLocalMessage(preview.parent, cid);
+  const replies = preview.replies.length
+    ? preview.replies.map((reply) => toLocalMessage(reply, cid))
+    : [parentMessage];
+
+  const readState =
+    currentUserId !== undefined
+      ? {
+          [currentUserId]: {
+            unreadMessageCount: 0,
+          },
+        }
+      : {};
+
+  const state = new StateStore({
+    channel,
+    deletedAt: preview.parent.deleted_at ?? null,
+    parentMessage,
+    replies,
+    read: readState,
+    pagination: { isLoadingNext: false, isLoadingPrev: false },
+  });
+
+  return {
+    id: preview.id,
+    channel,
+    state,
+    activate: () => {},
+    deactivate: () => {},
+    loadNextPage: async () => {},
+    loadPrevPage: async () => {},
+  } as Thread;
+};
+
+const setThreadManagerLoading = (
+  store: StateStore<ThreadManagerState>,
+  isLoading: boolean,
+) => {
+  const snapshot = store.getLatestValue?.();
+  const pagination = {
+    ...(snapshot?.pagination ?? {}),
+    isLoadingNext: isLoading,
+  };
+  store.dispatch({ pagination });
+};
 
 type ThreadListProps = {
   virtuosoProps?: VirtuosoProps<Thread, unknown>;
@@ -51,16 +147,79 @@ export const useThreadList = () => {
 };
 
 export const ThreadList = ({ virtuosoProps }: ThreadListProps) => {
-  const { client } = useChatContext();
+  const { client, channel } = useChatContext();
   const {
     ThreadListEmptyPlaceholder = DefaultThreadListEmptyPlaceholder,
     ThreadListItem = DefaultThreadListItem,
     ThreadListLoadingIndicator = DefaultThreadListLoadingIndicator,
     ThreadListUnseenThreadsBanner = DefaultThreadListUnseenThreadsBanner,
   } = useComponentContext();
-  const { threads } = useStateStore(clientThreadsState(client), selector);
+  const threadManagerStore = clientThreadsState(client);
+  const { threads } = useStateStore(threadManagerStore, selector);
 
   useThreadList();
+
+  useEffect(() => {
+    let cancelled = false;
+    const cid = channel?.cid;
+
+    if (!cid) {
+      threadManagerStore.dispatch({
+        threads: [],
+        unseenThreadIds: [],
+        unreadThreadCount: 0,
+        pagination: { isLoadingNext: false, isLoadingPrev: false, nextCursor: null },
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const load = async () => {
+      setThreadManagerLoading(threadManagerStore, true);
+      try {
+        const response = await chatAPI.client.threads.state({ cid });
+        if (cancelled) return;
+
+        const rawUserId = client.user?.id;
+        const currentUserId =
+          typeof rawUserId === "string"
+            ? rawUserId
+            : rawUserId != null
+              ? String(rawUserId)
+              : undefined;
+
+        const nextThreads = response.threads.map((preview) =>
+          createThreadFromPreview({
+            preview,
+            channel,
+            currentUserId,
+          }),
+        );
+
+        threadManagerStore.dispatch({
+          threads: nextThreads,
+          unseenThreadIds: response.unseenThreadIds,
+          unreadThreadCount: response.unreadThreadCount,
+          pagination: {
+            isLoadingNext: false,
+            isLoadingPrev: false,
+            nextCursor: response.next ? String(response.next) : null,
+          },
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setThreadManagerLoading(threadManagerStore, false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [channel?.cid, channel, client, threadManagerStore]);
 
   return (
     <div className="str-chat__thread-list-container">

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -419,7 +419,7 @@
     "operationId": "shim::client.threads.state",
     "stubName": "client.threads.state",
     "ticketType": "shim",
-    "todoCount": 1,
+    "todoCount": 0,
     "status": "ok"
   },
   {


### PR DESCRIPTION
## Summary
- guard room message listing with the existing permission helper and reuse the GET /api/rooms/{cid}/messages/ response for thread data
- add typed thread preview mapping in the chat API, keep a per-client thread manager store, and hydrate the thread list from the fetched previews
- flip the wireup manifest entry for shim::client.threads.state and update its unit test expectations

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/client.threads.state.test.ts *(fails: Command "jest" not found)*
- pnpm --filter frontend exec jest libs/stream-chat-shim/__tests__/client.threads.state.test.ts *(fails: Command "jest" not found)*
- pipenv run pytest chat/tests/test_api_views.py::RoomMessageListCreateViewTests --maxfail=1 *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d711bffd3083268554c6c0382359a9