### PR TITLE
feat(client.queryChannels): wire up shim helper and replace TODOs

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1,9 +1,17 @@
 import {
   chatSDKShim,
+  clientQueryChannels as clientQueryChannelsShim,
   clientThreadsActivate as clientThreadsActivateShim,
   clientThreadsLoadNextPage as clientThreadsLoadNextPageShim,
   clientThreadsReload as clientThreadsReloadShim,
 } from '../chatSDKShim';
+import type {
+  Channel,
+  ChannelFilters,
+  ChannelOptions,
+  ChannelSort,
+  StreamChat,
+} from '../../chat-shim';
 
 export type {
   ClientEventHandler,
@@ -118,6 +126,13 @@ export type ChannelQueryResponse = {
   next: number | null;
 };
 
+export type ClientQueryChannelsParams = {
+  client: StreamChat;
+  filters?: ChannelFilters;
+  sort?: ChannelSort;
+  options?: ChannelOptions;
+};
+
 export type ThreadMessage = Message;
 
 export type ThreadPreviewMessage = {
@@ -189,6 +204,14 @@ export async function clientThreadsReload({
 }: ClientThreadsReloadInput): Promise<void> {
   await clientThreadsReloadShim(client);
 }
+
+const clientQueryChannels = async ({
+  client,
+  filters = {},
+  sort = {},
+  options = {},
+}: ClientQueryChannelsParams): Promise<Channel[]> =>
+  clientQueryChannelsShim(client, filters, sort, options);
 
 function channelCountUnread({
   channel,
@@ -958,6 +981,7 @@ export const chatAPI = {
     query: channelQuery,
     unpin: channelUnpin,
   },
+  clientQueryChannels,
   client: {
     on: chatSDKShim.client.on,
     threads: {

--- a/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
+++ b/libs/stream-chat-shim/src/components/ChannelList/ChannelList.tsx
@@ -32,7 +32,6 @@ import {
 } from "../../context";
 import { chatAPI } from "../../api/chatAPI";
 import { NullComponent } from "../UtilityComponents";
-import { clientQueryChannels } from "../../chatSDKShim";
 import { MAX_QUERY_CHANNELS_LIMIT, moveChannelUpwards } from "./utils";
 import type { CustomQueryChannelsFn } from "./hooks/usePaginatedChannels";
 import type { ChannelListMessengerProps } from "./ChannelListMessenger";
@@ -249,12 +248,12 @@ const UnMemoizedChannelList = (props: ChannelListProps) => {
       );
 
       if (!customActiveChannelObject) {
-        [customActiveChannelObject] = await clientQueryChannels(
+        [customActiveChannelObject] = await chatAPI.clientQueryChannels({
           client,
-          filters || DEFAULT_FILTERS,
-          sort || DEFAULT_SORT,
-          options || DEFAULT_OPTIONS,
-        );
+          filters: filters || DEFAULT_FILTERS,
+          sort: sort || DEFAULT_SORT,
+          options: options || DEFAULT_OPTIONS,
+        });
       }
 
       if (customActiveChannelObject) {

--- a/libs/stream-chat-shim/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/libs/stream-chat-shim/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -14,7 +14,7 @@ import type {
 } from "chat-shim";
 
 import { useChatContext } from "../../../context/ChatContext";
-import { clientQueryChannels } from "../../../chatSDKShim";
+import { chatAPI } from "../../../api/chatAPI";
 
 import type { ChannelsQueryState } from "../../Chat/hooks/useChannelsQueryState";
 import { DEFAULT_INITIAL_CHANNEL_PAGE_SIZE } from "../../../constants/limits";
@@ -95,12 +95,12 @@ export const usePaginatedChannels = (
           ...options,
         };
 
-        const channelQueryResponse = await clientQueryChannels(
+        const channelQueryResponse = await chatAPI.clientQueryChannels({
           client,
           filters,
           sort,
-          newOptions,
-        );
+          options: newOptions,
+        });
 
         const newChannels =
           queryType === "reload"

--- a/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/libs/stream-chat-shim/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -7,11 +7,8 @@ import type { ChannelOrUserResponse } from "../utils";
 import { isChannel } from "../utils";
 
 import { useChatContext } from "../../../context/ChatContext";
-import {
-  channelWatch,
-  clientQueryChannels,
-  clientQueryUsers,
-} from "../../../chatSDKShim";
+import { channelWatch, clientQueryUsers } from "../../../chatSDKShim";
+import { chatAPI } from "../../../api/chatAPI";
 
 import type {
   Channel,
@@ -229,12 +226,12 @@ export const useChannelSearch = ({
           } = searchQueryParams?.channelFilters ?? {};
 
           promises.push(
-            clientQueryChannels(
+            chatAPI.clientQueryChannels({
               client,
-              channelFiltersConfig ?? {},
-              channelSortConfig ?? {},
-              channelOptionsConfig ?? {},
-            ),
+              filters: channelFiltersConfig ?? {},
+              sort: channelSortConfig ?? {},
+              options: channelOptionsConfig ?? {},
+            }),
           );
         }
 


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.clientQueryChannels` helper that delegates to the shimmed client logic
- update channel list/search utilities to consume the new helper instead of the TODO stubs

## Testing
- pnpm test --filter stream-chat-shim *(fails: turbo not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d727aff8ec8326bbc0023d0f6916be