### PR TITLE
feat(lastRead): wire up shim-only helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -211,6 +211,12 @@ export type ChannelCountUnreadParams = {
   lastRead?: Date;
 };
 
+export type ChannelLastReadParams = {
+  channel: {
+    lastRead?: () => Date | undefined;
+  };
+};
+
 export type ClientThreadsActivateInput = {
   client: { threads?: { activate?: () => void } };
 };
@@ -249,6 +255,10 @@ function channelCountUnread({
   lastRead,
 }: ChannelCountUnreadParams): number {
   return chatSDKShim.channelCountUnread(channel, lastRead);
+}
+
+function lastRead({ channel }: ChannelLastReadParams): Date | undefined {
+  return chatSDKShim.lastRead(channel);
 }
 
 const isFiniteNumber = (value: unknown): value is number =>
@@ -1496,6 +1506,7 @@ export const chatAPI = {
     query: channelQuery,
     unpin: channelUnpin,
   },
+  lastRead,
   clientQueryChannels,
   client: {
     on: chatSDKShim.client.on,

--- a/libs/stream-chat-shim/src/components/Channel/hooks/useCreateChannelStateContext.ts
+++ b/libs/stream-chat-shim/src/components/Channel/hooks/useCreateChannelStateContext.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { isDate, isDayOrMoment } from '../../../i18n';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { ChannelStateContextValue } from '../../../context/ChannelStateContext';
 
@@ -43,7 +44,8 @@ export const useCreateChannelStateContext = (
   } = value;
 
   const channelId = channel.cid;
-  const lastRead = channel.initialized && channel.lastRead()?.getTime();
+  const lastReadDate = channel.initialized ? chatAPI.lastRead({ channel }) : undefined;
+  const lastRead = lastReadDate?.getTime();
   const membersLength = Object.keys(members || []).length;
   const notificationsLength = notifications.length;
   const readUsers = Object.values(read);

--- a/libs/stream-chat-shim/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/libs/stream-chat-shim/src/components/MessageList/VirtualizedMessageList.tsx
@@ -11,7 +11,7 @@ import { Virtuoso } from 'react-virtuoso';
 
 import { GiphyPreviewMessage as DefaultGiphyPreviewMessage } from './GiphyPreviewMessage';
 import { useLastReadData } from './hooks';
-import { lastRead as getLastRead } from '../../chatSDKShim';
+import { chatAPI } from '../../api/chatAPI';
 import {
   useGiphyPreview,
   useMessageSetKey,
@@ -248,7 +248,7 @@ const VirtualizedMessageListWithContext = (
 
   const virtuoso = useRef<VirtuosoHandle>(null);
 
-  const lastRead = useMemo(() => getLastRead(channel), [channel]);
+  const lastRead = useMemo(() => chatAPI.lastRead({ channel }), [channel]);
 
   const { show: showUnreadMessagesNotification, toggleShowUnreadMessagesNotification } =
     useUnreadMessagesNotificationVirtualized({

--- a/libs/stream-chat-shim/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
+++ b/libs/stream-chat-shim/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
@@ -5,7 +5,7 @@ import { getGroupStyles, insertIntro, processMessages } from '../../utils';
 
 import { useChatContext } from '../../../../context/ChatContext';
 import { useComponentContext } from '../../../../context/ComponentContext';
-import { lastRead as getLastRead } from '../../../../chatSDKShim';
+import { chatAPI } from '../../../../api/chatAPI';
 
 import type { Channel, LocalMessage } from 'chat-shim';
 
@@ -43,7 +43,7 @@ export const useEnrichedMessages = (args: {
   const { client } = useChatContext('useEnrichedMessages');
   const { HeaderComponent } = useComponentContext('useEnrichedMessages');
 
-  const lastRead = useMemo(() => getLastRead(channel), [channel]);
+  const lastRead = useMemo(() => chatAPI.lastRead({ channel }), [channel]);
 
   const enableDateSeparator = !disableDateSeparator;
 

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -474,7 +474,7 @@
     "stubName": "lastRead",
     "ticketType": "shim",
     "todoCount": 2,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- expose a typed chatAPI.lastRead helper that proxies to the SDK shim
- update message list and channel state hooks to resolve lastRead via the API helper
- mark the lastRead wireup manifest entry as complete

## Testing
- pnpm test --filter stream-chat-shim *(fails: turbo_json_parse_error)*

------
https://chatgpt.com/codex/tasks/task_e_68d74557c79083269f0ac04c2b512dd6