### PR TITLE
Wire up shim markUnread action

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -169,6 +169,15 @@ export type ThreadPreview = {
   replies: ThreadPreviewMessage[];
 };
 
+type ChannelMarkUnreadLike = {
+  markUnread?: (messageId: string) => Promise<unknown>;
+};
+
+export type MarkUnreadInput = {
+  channel?: ChannelMarkUnreadLike | null;
+  messageId: string | number;
+};
+
 export type ClientThreadsStateParams = {
   cid: string;
   limit?: number;
@@ -556,6 +565,23 @@ const getMessageLikeId = (
   }
 
   return normalizeMessageId(message.id);
+};
+
+const markUnread = async ({
+  channel,
+  messageId,
+}: MarkUnreadInput): Promise<unknown> => {
+  const normalizedId = normalizeMessageId(messageId);
+
+  if (!normalizedId) {
+    throw new Error("Invalid message id provided to markUnread");
+  }
+
+  if (!channel) {
+    return undefined;
+  }
+
+  return chatSDKShim.markUnread(channel, normalizedId);
 };
 
 const getMessageLikeUserId = (
@@ -1534,6 +1560,7 @@ export const chatAPI = {
   clientThreadsActivate,
   clientThreadsState,
   clientThreadsReload,
+  markUnread,
   createReminder,
   flagMessage,
   deleteReaction,

--- a/libs/stream-chat-shim/src/components/Message/hooks/useMarkUnreadHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useMarkUnreadHandler.ts
@@ -1,6 +1,6 @@
 import { validateAndGetMessage } from '../utils';
 import { useChannelStateContext, useTranslationContext } from '../../../context';
-import { markUnread } from '../../../chatSDKShim';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { LocalMessage } from 'chat-shim';
 import type { ReactEventHandler } from '../types';
@@ -28,7 +28,7 @@ export const useMarkUnreadHandler = (
     }
 
     try {
-      await markUnread(channel, message.id);
+      await chatAPI.markUnread({ channel, messageId: message.id });
       if (!notify) return;
       const successMessage =
         getSuccessNotification &&

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -482,7 +482,7 @@
     "operationId": "shim::markUnread",
     "stubName": "markUnread",
     "ticketType": "shim",
-    "todoCount": 1,
+    "todoCount": 0,
     "status": "ok"
   },
   {


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.markUnread` helper that normalizes ids before delegating to the SDK shim
- route the mark-unread UI handler through the new helper
- note the completed markUnread wire-up in the wireup manifest

## Testing
- pnpm test -- --runTestsByPath libs/stream-chat-shim/__tests__/markUnread.test.ts *(fails: sh: 1: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d750d250bc83269b0f73faf4f09804