### PR TITLE
feat: wire up shim notifications store helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -11,6 +11,9 @@ import type {
   ChannelFilters,
   ChannelOptions,
   ChannelSort,
+  Notification,
+  NotificationManagerState,
+  StateStore,
   StreamChat,
 } from '../../chat-shim';
 
@@ -1526,6 +1529,158 @@ async function endSession(): Promise<void> {
   }
 }
 
+type NotificationStoreLike = {
+  getLatestValue?: () => NotificationManagerState | undefined;
+  getSnapshot?: () => NotificationManagerState | undefined;
+  subscribe?: (listener: () => void) => () => void;
+  subscribeWithSelector?: (
+    selector: (value: NotificationManagerState) => unknown,
+    listener: () => void,
+  ) => () => void;
+  dispatch?: (patch: Partial<NotificationManagerState>) => void;
+  next?: (patch: Partial<NotificationManagerState>) => void;
+  _set?: (patch: Partial<NotificationManagerState>) => void;
+};
+
+type NotificationsStoreClient = {
+  notifications?: {
+    store?: NotificationStoreLike | null;
+  } | null;
+};
+
+type NotificationsUpdater =
+  | Notification[]
+  | ((current: Notification[]) => Notification[]);
+
+const emptyNotificationsState: NotificationManagerState = { notifications: [] };
+
+const readNotificationState = (
+  store: NotificationStoreLike,
+): NotificationManagerState => {
+  if (typeof store.getLatestValue === "function") {
+    const latest = store.getLatestValue();
+    if (latest && typeof latest === "object") {
+      return latest;
+    }
+  }
+
+  if (typeof store.getSnapshot === "function") {
+    const snapshot = store.getSnapshot();
+    if (snapshot && typeof snapshot === "object") {
+      return snapshot;
+    }
+  }
+
+  return emptyNotificationsState;
+};
+
+const notificationArrayFromState = (
+  notifications: NotificationManagerState["notifications"],
+): Notification[] => {
+  if (Array.isArray(notifications)) {
+    return notifications as Notification[];
+  }
+  return emptyNotificationsState.notifications;
+};
+
+const areNotificationArraysEqual = (
+  previous: Notification[],
+  next: Notification[],
+): boolean => {
+  if (previous === next) return true;
+  if (previous.length !== next.length) return false;
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) return false;
+  }
+  return true;
+};
+
+const applyNotificationPatch = (
+  store: NotificationStoreLike,
+  patch: Partial<NotificationManagerState>,
+) => {
+  if (typeof store.dispatch === "function") {
+    store.dispatch(patch);
+    return;
+  }
+
+  if (typeof store.next === "function") {
+    store.next(patch);
+    return;
+  }
+
+  if (typeof store._set === "function") {
+    store._set(patch);
+  }
+};
+
+const ensureNotificationsStore = (
+  client?: NotificationsStoreClient | null,
+): NotificationStoreLike => {
+  const normalizedClient =
+    (client ?? ({} as NotificationsStoreClient)) as Parameters<
+      typeof chatSDKShim.notificationsStore
+    >[0];
+  return chatSDKShim.notificationsStore(normalizedClient) as NotificationStoreLike;
+};
+
+export type NotificationsStoreParams = {
+  client?: NotificationsStoreClient | null;
+  notifications?: NotificationsUpdater;
+};
+
+export type NotificationsStoreResult = {
+  store: StateStore<NotificationManagerState>;
+  state: NotificationManagerState;
+  notifications: Notification[];
+};
+
+const resolveNotificationsStore = ({
+  client,
+  notifications: updater,
+}: NotificationsStoreParams = {}): NotificationsStoreResult => {
+  const storeLike = ensureNotificationsStore(client);
+  const store = storeLike as StateStore<NotificationManagerState>;
+
+  if (updater !== undefined) {
+    const currentState = readNotificationState(storeLike);
+    const currentNotifications = notificationArrayFromState(
+      currentState.notifications,
+    );
+    const nextNotifications =
+      typeof updater === "function" ? updater(currentNotifications) : updater;
+    const normalizedNext = notificationArrayFromState(nextNotifications);
+
+    if (!areNotificationArraysEqual(currentNotifications, normalizedNext)) {
+      applyNotificationPatch(storeLike, { notifications: normalizedNext });
+    }
+  }
+
+  const finalState = readNotificationState(storeLike);
+  const finalNotifications = notificationArrayFromState(
+    finalState.notifications,
+  );
+
+  const originalNotifications = Array.isArray(finalState.notifications)
+    ? (finalState.notifications as Notification[])
+    : emptyNotificationsState.notifications;
+
+  if (!areNotificationArraysEqual(originalNotifications, finalNotifications)) {
+    applyNotificationPatch(storeLike, { notifications: finalNotifications });
+  }
+
+  const normalizedState: NotificationManagerState = {
+    ...finalState,
+    notifications: finalNotifications,
+  };
+
+  return {
+    store,
+    state: normalizedState,
+    notifications: normalizedState.notifications,
+  };
+};
+
 export const chatAPI = {
   channel: {
     countUnread: channelCountUnread,
@@ -1562,6 +1717,9 @@ export const chatAPI = {
   clientThreadsReload,
   markUnread,
   createReminder,
+  notifications: {
+    store: resolveNotificationsStore,
+  },
   flagMessage,
   deleteReaction,
   deleteMessage,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -3,6 +3,7 @@ import type {
   Channel,
   PollOption as ChatShimPollOption,
   PollVote,
+  NotificationManagerState,
   StreamChat,
 } from '../../chat-shim';
 import { stopTyping as stopTypingImpl } from '../../chat-shim/typing';
@@ -2427,7 +2428,7 @@ export async function getDraft(roomUuid: string): Promise<RoomDraft> {
 }
 
 
-const fallbackNotificationsStore = new StateStore<{ notifications: any[] }>({
+const fallbackNotificationsStore = new StateStore<NotificationManagerState>({
   notifications: [],
 });
 
@@ -2487,8 +2488,8 @@ export function clientThreadsState(client: {
 }
 
 export function notificationsStore(client: {
-  notifications?: { store?: StateStore<{ notifications: any[] }> };
-}): StateStore<{ notifications: any[] }> {
+  notifications?: { store?: StateStore<NotificationManagerState> };
+}): StateStore<NotificationManagerState> {
   return client.notifications?.store ?? fallbackNotificationsStore;
 }
 

--- a/libs/stream-chat-shim/src/components/Notifications/hooks/useNotifications.ts
+++ b/libs/stream-chat-shim/src/components/Notifications/hooks/useNotifications.ts
@@ -1,7 +1,21 @@
 
-import type { Notification } from 'chat-shim';
+import type { Notification, NotificationManagerState } from 'chat-shim';
+
+import { chatAPI } from '../../../api/chatAPI';
+import { useChatContext } from '../../../context';
+import { useStateStore } from '../../../store';
+
+const notificationsSelector = (
+  state: NotificationManagerState,
+): { notifications: Notification[] } => ({
+  notifications: Array.isArray(state.notifications)
+    ? (state.notifications as Notification[])
+    : [],
+});
 
 export const useNotifications = (): Notification[] => {
-  /* TODO backend-wire-up: notifications.store */
-  return [];
+  const { client } = useChatContext('useNotifications');
+  const { store } = chatAPI.notifications.store({ client });
+  const snapshot = useStateStore(store, notificationsSelector);
+  return snapshot?.notifications ?? [];
 };


### PR DESCRIPTION
## Summary
- add a typed chatAPI.notifications.store helper that normalizes and updates the shim notifications state store
- align the shim SDK fallback notifications store typing and hook the Notifications UI through the new helper

## Testing
- pnpm --filter frontend test frontend/__tests__/adapter/notifications.test.ts *(fails: vitest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d758e124cc8326a949da6a37276dae