### PR TITLE
feat: wire up poll vote casted shim subscription

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -11,11 +11,18 @@ import type {
   ChannelFilters,
   ChannelOptions,
   ChannelSort,
+  Event,
   Notification,
   NotificationManagerState,
   StateStore,
   StreamChat,
+  PollAnswer,
+  PollVote,
 } from '../../chat-shim';
+import type {
+  ChannelEventSubscription,
+  ClientKnownEventMap,
+} from '../chatSDKShim';
 
 export type {
   ClientEventHandler,
@@ -170,6 +177,84 @@ export type ThreadPreview = {
   id: string;
   parent: ThreadPreviewMessage;
   replies: ThreadPreviewMessage[];
+};
+
+type PollVoteLike = PollVote | PollAnswer;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const toPollVoteLike = (value: unknown): PollVoteLike | null => {
+  if (!isRecord(value)) return null;
+  const identifier = (value as { id?: unknown }).id;
+  if (typeof identifier !== 'string' && typeof identifier !== 'number') {
+    return null;
+  }
+  return value as PollVoteLike;
+};
+
+export type PollVoteCastedEvent = Event & {
+  type: 'poll.vote_casted';
+  poll_vote: PollVoteLike | null;
+};
+
+const emptySubscription: ChannelEventSubscription = {
+  unsubscribe: () => undefined,
+};
+
+const withChannelMetadata = (
+  event: ClientKnownEventMap['poll.vote_casted'],
+  channel?: Channel | null,
+): Pick<PollVoteCastedEvent, 'cid' | 'channel_id' | 'channel_type'> => {
+  const cid = typeof event.cid === 'string' && event.cid ? event.cid : channel?.cid;
+  const channelId =
+    typeof event.channel_id === 'string' && event.channel_id
+      ? event.channel_id
+      : typeof event.channel_id === 'number'
+        ? String(event.channel_id)
+        : channel?.id;
+  const channelType =
+    typeof event.channel_type === 'string' && event.channel_type
+      ? event.channel_type
+      : channel?.type;
+
+  return {
+    cid,
+    channel_id: channelId,
+    channel_type: channelType,
+  };
+};
+
+export type OnPollVoteCastedParams = {
+  channel?: Channel | null;
+  handler: (event: PollVoteCastedEvent) => void;
+};
+
+export const onPollVoteCasted = ({
+  channel,
+  handler,
+}: OnPollVoteCastedParams): ChannelEventSubscription => {
+  if (!channel || typeof (channel as { on?: unknown }).on !== 'function') {
+    return emptySubscription;
+  }
+
+  const subscription = chatSDKShim.on(
+    channel,
+    'poll.vote_casted',
+    (event) => {
+      const pollVote = toPollVoteLike(event.poll_vote);
+      const metadata = withChannelMetadata(event, channel);
+      const normalizedEvent: PollVoteCastedEvent = {
+        ...(event as Event),
+        ...metadata,
+        type: 'poll.vote_casted',
+        poll_vote: pollVote,
+      };
+      handler(normalizedEvent);
+    },
+  );
+
+  return subscription ?? emptySubscription;
 };
 
 type ChannelMarkUnreadLike = {
@@ -1687,6 +1772,7 @@ export const chatAPI = {
     query: channelQuery,
     unpin: channelUnpin,
   },
+  onPollVoteCasted,
   lastRead,
   clientQueryChannels,
   client: {

--- a/libs/stream-chat-shim/src/components/Poll/hooks/useManagePollVotesRealtime.ts
+++ b/libs/stream-chat-shim/src/components/Poll/hooks/useManagePollVotesRealtime.ts
@@ -3,6 +3,7 @@ import { isVoteAnswer } from 'chat-shim';
 import { useChatContext } from '../../../context';
 import type { Event, PollAnswer, PollVote } from 'chat-shim';
 import { on } from '../../../chatSDKShim';
+import { chatAPI } from '../../../api/chatAPI';
 
 import type { CursorPaginatorStateStore } from '../../InfiniteScrollPaginator/hooks/useCursorPaginator';
 
@@ -11,7 +12,7 @@ export function useManagePollVotesRealtime<T extends PollVote | PollAnswer = Pol
   cursorPaginatorState?: CursorPaginatorStateStore<T>,
   optionId?: string,
 ) {
-  const { client } = useChatContext();
+  const { client, channel } = useChatContext();
   const [votesInRealtime, setVotesInRealtime] = useState<T[]>(
     cursorPaginatorState?.getLatestValue().items ?? [],
   );
@@ -58,9 +59,10 @@ export function useManagePollVotesRealtime<T extends PollVote | PollAnswer = Pol
       }
     };
 
-    const voteCastedSubscription =
-      on(client, 'poll.vote_casted', handleVoteEvent) ??
-      ({ unsubscribe: () => undefined } as any);
+    const voteCastedSubscription = chatAPI.onPollVoteCasted({
+      channel,
+      handler: handleVoteEvent,
+    });
     const voteRemovedSubscription =
       on(client, 'poll.vote_removed', handleVoteEvent) ??
       ({ unsubscribe: () => undefined } as any);
@@ -73,7 +75,7 @@ export function useManagePollVotesRealtime<T extends PollVote | PollAnswer = Pol
       voteRemovedSubscription.unsubscribe();
       voteChangedSubscription.unsubscribe();
     };
-  }, [client, optionId, managedVoteType]);
+  }, [channel?.cid, client, optionId, managedVoteType]);
 
   return votesInRealtime;
 }

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -510,7 +510,7 @@
     "stubName": "on(poll.vote_casted)",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.onPollVoteCasted helper to normalize poll vote events and return an unsubscribe handle
- use the new helper in useManagePollVotesRealtime so poll updates listen on the active channel bus
- flip the shim::on(poll.vote_casted) entry in wireup_manifest.json to ok

## Testing
- pnpm lint *(fails: Command "lint" not found)*
- pnpm test *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d75f739ea8832689a06feb5a72f070