### PR TITLE
feat(onPollVoteChanged): wire up WS poll.vote_changed

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -198,12 +198,21 @@ export type PollVoteCastedEvent = Event & {
   poll_vote: PollVoteLike | null;
 };
 
+export type PollVoteChangedEvent = Event & {
+  type: 'poll.vote_changed';
+  poll_vote: PollVoteLike | null;
+};
+
 const emptySubscription: ChannelEventSubscription = {
   unsubscribe: () => undefined,
 };
 
+type VoteEventWithChannelMetadata =
+  | ClientKnownEventMap['poll.vote_casted']
+  | ClientKnownEventMap['poll.vote_changed'];
+
 const withChannelMetadata = (
-  event: ClientKnownEventMap['poll.vote_casted'],
+  event: VoteEventWithChannelMetadata,
   channel?: Channel | null,
 ): Pick<PollVoteCastedEvent, 'cid' | 'channel_id' | 'channel_type'> => {
   const cid = typeof event.cid === 'string' && event.cid ? event.cid : channel?.cid;
@@ -250,6 +259,59 @@ export const onPollVoteCasted = ({
         type: 'poll.vote_casted',
         poll_vote: pollVote,
       };
+      handler(normalizedEvent);
+    },
+  );
+
+  return subscription ?? emptySubscription;
+};
+
+export type OnPollVoteChangedParams = {
+  channel?: Channel | null;
+  cid?: string | null;
+  client?: StreamChat | null;
+  handler: (event: PollVoteChangedEvent) => void;
+};
+
+export const onPollVoteChanged = ({
+  channel,
+  cid,
+  client,
+  handler,
+}: OnPollVoteChangedParams): ChannelEventSubscription => {
+  if (!client || typeof (client as { on?: unknown }).on !== 'function') {
+    return emptySubscription;
+  }
+
+  const targetCid = cid ?? channel?.cid ?? null;
+
+  const subscription = chatSDKShim.client.on(
+    client,
+    'poll.vote_changed',
+    (event) => {
+      const eventCid =
+        typeof event.cid === 'string' && event.cid ? event.cid : null;
+      if (targetCid && eventCid && eventCid !== targetCid) {
+        return;
+      }
+
+      const metadata = withChannelMetadata(event, channel);
+      const normalizedCid =
+        metadata.cid ?? eventCid ?? (targetCid ?? undefined);
+
+      if (targetCid && normalizedCid && normalizedCid !== targetCid) {
+        return;
+      }
+
+      const pollVote = toPollVoteLike(event.poll_vote);
+      const normalizedEvent: PollVoteChangedEvent = {
+        ...(event as Event),
+        ...metadata,
+        cid: normalizedCid ?? undefined,
+        type: 'poll.vote_changed',
+        poll_vote: pollVote,
+      };
+
       handler(normalizedEvent);
     },
   );
@@ -1773,6 +1835,7 @@ export const chatAPI = {
     unpin: channelUnpin,
   },
   onPollVoteCasted,
+  onPollVoteChanged,
   lastRead,
   clientQueryChannels,
   client: {

--- a/libs/stream-chat-shim/src/components/Poll/hooks/useManagePollVotesRealtime.ts
+++ b/libs/stream-chat-shim/src/components/Poll/hooks/useManagePollVotesRealtime.ts
@@ -66,9 +66,11 @@ export function useManagePollVotesRealtime<T extends PollVote | PollAnswer = Pol
     const voteRemovedSubscription =
       on(client, 'poll.vote_removed', handleVoteEvent) ??
       ({ unsubscribe: () => undefined } as any);
-    const voteChangedSubscription =
-      on(client, 'poll.vote_changed', handleVoteEvent) ??
-      ({ unsubscribe: () => undefined } as any);
+    const voteChangedSubscription = chatAPI.onPollVoteChanged({
+      channel,
+      client,
+      handler: handleVoteEvent,
+    });
 
     return () => {
       voteCastedSubscription.unsubscribe();

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -519,7 +519,7 @@
     "stubName": "on(poll.vote_changed)",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.onPollVoteChanged helper that normalizes poll vote change events and filters by cid
- update the poll vote realtime hook to subscribe via the new helper and keep the manifest in sync

## Testing
- pnpm --filter stream-chat-shim test -- --runTestsByPath libs/stream-chat-shim/__tests__/onPollVoteChanged.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7ca0978d08326a0dba098d3925691