### PR TITLE
feat: add shim handler for polls.unregisterSubscriptions

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -6,6 +6,7 @@ import {
   clientThreadsReload as clientThreadsReloadShim,
   loadMessageIntoChannelState,
   pollsFromState as pollsFromStateShim,
+  pollsUnregisterSubscriptions as pollsUnregisterSubscriptionsShim,
 } from '../chatSDKShim';
 import { getLocalClient } from '../../chat-shim';
 import type {
@@ -789,6 +790,30 @@ export const polls_fromState = ({
   targetPoll.state = store;
 
   return targetPoll as PollsFromStateResult;
+};
+
+type PollsSubscriptionsClient = {
+  polls?: { unregisterSubscriptions?: () => void };
+};
+
+export type PollsUnregisterSubscriptionsParams = {
+  client?: PollsSubscriptionsClient | StreamChat | null;
+};
+
+const toPollsSubscriptionsClient = (
+  client: PollsUnregisterSubscriptionsParams['client'],
+): PollsSubscriptionsClient | undefined => {
+  if (!client) return undefined;
+  if (typeof client === 'object') {
+    return client as PollsSubscriptionsClient;
+  }
+  return undefined;
+};
+
+const pollsUnregisterSubscriptions = async ({
+  client,
+}: PollsUnregisterSubscriptionsParams = {}): Promise<void> => {
+  pollsUnregisterSubscriptionsShim(toPollsSubscriptionsClient(client));
 };
 
 const toPollVoteLike = (value: unknown): PollVoteLike | null => {
@@ -3149,6 +3174,9 @@ export const chatAPI = {
       state: ({ cid, limit, before }: ClientThreadsStateParams) =>
         clientThreadsState({ cid, limit, before }),
     },
+  },
+  polls: {
+    unregisterSubscriptions: pollsUnregisterSubscriptions,
   },
   addAnswer,
   polls_fromState,

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -74,7 +74,7 @@ export const useChat = ({
 
     return () => {
         client.threads.unregisterSubscriptions();
-        client.polls.unregisterSubscriptions();
+        void chatAPI.polls.unregisterSubscriptions({ client });
         client.reminders.unregisterSubscriptions();
         client.reminders.clearTimers();
     };

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -554,7 +554,7 @@
     "operationId": "shim::polls.unregisterSubscriptions",
     "stubName": "polls.unregisterSubscriptions",
     "ticketType": "shim",
-    "todoCount": 1,
+    "todoCount": 0,
     "status": "ok"
   },
   {


### PR DESCRIPTION
## Summary
- add a typed chatAPI.polls.unregisterSubscriptions helper that invokes the shim-only unsubscribe logic
- use the new helper from the chat useChat hook cleanup and reset the wireup manifest todo count for the opId

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/useChat.test.tsx *(fails: repository is missing @testing-library/react for these tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d7eb7d8c10832687960bf78f0cb231