### PR TITLE
feat(query): wire up channel query helper

### DIFF
--- a/libs/stream-chat-shim/__tests__/query.test.ts
+++ b/libs/stream-chat-shim/__tests__/query.test.ts
@@ -1,3 +1,4 @@
+import { chatAPI } from '../src/api/chatAPI';
 import { query } from '../src/chatSDKShim';
 
 describe('query', () => {
@@ -9,16 +10,19 @@ describe('query', () => {
   });
 
   it('fetches members when not implemented', async () => {
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValue({ json: () => Promise.resolve(['m1']) });
-    // @ts-ignore
-    global.fetch = fetchMock;
+    const spy = jest
+      .spyOn(chatAPI, 'query')
+      .mockResolvedValue({ members: ['m1'] as any });
+
     const res = await query({ cid: 'room2' } as any, { offset: 1 });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/rooms/room2/members/?offset=1',
-      { credentials: 'same-origin' },
-    );
+
+    expect(spy).toHaveBeenCalledWith({
+      cid: 'room2',
+      limit: undefined,
+      offset: 1,
+    });
     expect(res).toEqual({ members: ['m1'] });
+
+    spy.mockRestore();
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1434,6 +1434,12 @@ function lastRead({ channel }: ChannelLastReadParams): Date | undefined {
 const isFiniteNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value);
 
+export type ChannelWatcher = {
+  user_id?: string | number | null;
+  user?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
 const parseChannelMessages = (value: unknown): Message[] => {
   if (!Array.isArray(value)) return [];
 
@@ -1447,6 +1453,81 @@ const parseChannelMessages = (value: unknown): Message[] => {
       typeof candidate.created_at === "string"
     );
   });
+};
+
+const parseChannelWatchers = (value: unknown): ChannelWatcher[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter((candidate): candidate is ChannelWatcher => {
+    if (!isRecord(candidate)) return false;
+
+    const { user_id, user } = candidate as ChannelWatcher;
+
+    const isValidUserId =
+      user_id === undefined ||
+      user_id === null ||
+      typeof user_id === "string" ||
+      (typeof user_id === "number" && Number.isFinite(user_id));
+
+    const isValidUserRecord =
+      user === undefined || user === null || isRecord(user);
+
+    return isValidUserId && isValidUserRecord;
+  });
+};
+
+export type QueryChannelWatchersRequest = {
+  cid: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type QueryChannelWatchersResponse = {
+  members: ChannelWatcher[];
+};
+
+export const queryChannelWatchers = async ({
+  cid,
+  limit,
+  offset,
+}: QueryChannelWatchersRequest): Promise<QueryChannelWatchersResponse> => {
+  const params = new URLSearchParams();
+
+  if (isFiniteNumber(limit)) {
+    params.set("limit", String(limit));
+  }
+
+  if (isFiniteNumber(offset)) {
+    params.set("offset", String(offset));
+  }
+
+  const query = params.toString();
+
+  const response = await fetch(
+    `/api/rooms/${encodeURIComponent(cid)}/members/${query ? `?${query}` : ""}`,
+    {
+      method: "GET",
+      credentials: "same-origin",
+    },
+  );
+
+  if (!response.ok) {
+    const error = new Error(
+      `Failed to query channel members (status ${response.status})`,
+    );
+    const errorWithStatus = error as ErrorWithStatus;
+    errorWithStatus.status = response.status;
+    throw errorWithStatus;
+  }
+
+  const data = (await response.json()) as unknown;
+  const membersSource = Array.isArray(data)
+    ? data
+    : isRecord(data) && Array.isArray(data.members)
+      ? data.members
+      : [];
+
+  return { members: parseChannelWatchers(membersSource) };
 };
 
 export const channelQuery = async ({
@@ -3147,6 +3228,7 @@ export const chatAPI = {
     query: channelQuery,
     unpin: channelUnpin,
   },
+  query: queryChannelWatchers,
   on,
   onPollVoteCasted,
   onPollVoteRemoved,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -1414,17 +1414,15 @@ export async function query(
   if (typeof channel.query === "function") {
     return channel.query({ watch: true, watchers });
   }
-  const params = new URLSearchParams();
-  if (watchers.limit !== undefined) params.set('limit', String(watchers.limit));
-  if (watchers.offset !== undefined)
-    params.set('offset', String(watchers.offset));
-  const q = params.toString();
-  const resp = await fetch(
-    `/api/rooms/${encodeURIComponent(channel.cid)}/members/${q ? `?${q}` : ''}`,
-    { credentials: 'same-origin' },
-  );
-  const data = await resp.json();
-  return { members: data };
+
+  const { limit, offset } = watchers;
+  const result = await chatAPI.query({
+    cid: channel.cid,
+    limit,
+    offset,
+  });
+
+  return result;
 }
 
 export async function channelSendMessage(

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -564,7 +564,7 @@
     "stubName": "query",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.query helper for channel member requests
- route the shim query implementation and unit test through the helper
- mark the query wire-up as complete in the manifest

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/query.test.ts *(fails: TypeScript compilation errors in existing shim sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f7063ac08326a63e1911559dbb05