### PR TITLE
feat(queryReactions): wire up SDK shim (no HTTP)

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -7,6 +7,7 @@ import {
   loadMessageIntoChannelState,
   pollsFromState as pollsFromStateShim,
   pollsUnregisterSubscriptions as pollsUnregisterSubscriptionsShim,
+  queryReactions as queryReactionsShim,
 } from '../chatSDKShim';
 import { getLocalClient } from '../../chat-shim';
 import type {
@@ -15,12 +16,15 @@ import type {
   ChannelOptions,
   ChannelSort,
   Event,
+  LocalMessage,
   Notification,
   NotificationManagerState,
   Poll,
   PollAnswer,
   PollOption,
   PollVote,
+  ReactionResponse,
+  ReactionSort,
   StateStore,
   StreamChat,
   VotingVisibility,
@@ -2178,6 +2182,42 @@ type ReactionResponseLike = {
   [key: string]: unknown;
 };
 
+type QueryReactionsShimParams = {
+  limit?: number;
+  next?: string;
+  reaction_type?: string;
+  sort?: Record<string, number>;
+};
+
+type QueryReactionsShimMessage = {
+  id?: string | number | null;
+  queryReactions?: (params?: QueryReactionsShimParams) => Promise<unknown>;
+} & Record<string, unknown>;
+
+type ClientWithQueryReactions = {
+  queryReactions?: (
+    messageId: string,
+    filter?: Record<string, unknown>,
+    sort?: ReactionSort,
+    options?: { limit?: number; next?: string },
+  ) => Promise<unknown>;
+};
+
+export type QueryReactionsParams = {
+  client?: (StreamChat & ClientWithQueryReactions) | ClientWithQueryReactions | null;
+  message?: (LocalMessage & QueryReactionsShimMessage) | QueryReactionsShimMessage | null;
+  messageId?: string | number | null;
+  limit?: number;
+  next?: string;
+  reactionType?: string;
+  sort?: ReactionSort;
+};
+
+export type QueryReactionsResult = {
+  reactions: ReactionResponse[];
+  next?: string;
+};
+
 type ReactionCountsRecord = Record<string, number>;
 
 type ReactionScoresRecord = Record<string, number>;
@@ -2335,6 +2375,55 @@ const toReactionList = (value: unknown): ReactionResponseLike[] => {
   return value
     .filter((item): item is ReactionResponseLike => Boolean(item) && typeof item === "object")
     .map((item) => ({ ...(item as ReactionResponseLike) }));
+};
+
+const hasQueryReactions = (
+  client?: ClientWithQueryReactions | null,
+): client is ClientWithQueryReactions & { queryReactions: Required<ClientWithQueryReactions>['queryReactions'] } =>
+  Boolean(client && typeof client.queryReactions === "function");
+
+const toReactionSortRecord = (
+  sort?: ReactionSort,
+): Record<string, number> | undefined => {
+  if (!sort || typeof sort !== "object") {
+    return undefined;
+  }
+
+  const result: Record<string, number> = {};
+
+  for (const [field, direction] of Object.entries(sort as Record<string, unknown>)) {
+    if (typeof direction === "number" && Number.isFinite(direction)) {
+      if (direction > 0) {
+        result[field] = 1;
+      } else if (direction < 0) {
+        result[field] = -1;
+      }
+      continue;
+    }
+
+    if (typeof direction === "string") {
+      const normalized = direction.trim().toLowerCase();
+      if (normalized === "asc" || normalized === "ascending") {
+        result[field] = 1;
+      } else if (normalized === "desc" || normalized === "descending") {
+        result[field] = -1;
+      }
+    }
+  }
+
+  return Object.keys(result).length ? result : undefined;
+};
+
+const toQueryReactionsResult = (value: unknown): QueryReactionsResult | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as { reactions?: unknown; next?: unknown };
+  const reactions = toReactionList(record.reactions) as ReactionResponse[];
+  const nextValue = typeof record.next === "string" && record.next ? record.next : undefined;
+
+  return { reactions, next: nextValue };
 };
 
 const cloneReactionUser = (
@@ -2517,6 +2606,75 @@ const findMessageById = (
 
   return undefined;
 };
+
+export async function queryReactions({
+  client,
+  limit,
+  message,
+  messageId,
+  next,
+  reactionType,
+  sort,
+}: QueryReactionsParams): Promise<QueryReactionsResult> {
+  const normalizedId =
+    normalizeMessageId(messageId) ??
+    normalizeMessageId((message as { id?: unknown } | null | undefined)?.id);
+
+  if (!normalizedId) {
+    return { reactions: [] };
+  }
+
+  const filter = reactionType ? { type: reactionType } : {};
+  const queryOptions: { limit?: number; next?: string } = {};
+  if (limit !== undefined) {
+    queryOptions.limit = limit;
+  }
+  if (next !== undefined) {
+    queryOptions.next = next;
+  }
+
+  if (hasQueryReactions(client)) {
+    const response = await client.queryReactions(
+      normalizedId,
+      filter,
+      sort,
+      queryOptions,
+    );
+    const normalizedResponse = toQueryReactionsResult(response);
+    if (normalizedResponse) {
+      return normalizedResponse;
+    }
+  }
+
+  const fallbackMessage: QueryReactionsShimMessage = {
+    ...(message && typeof message === "object"
+      ? (message as Record<string, unknown>)
+      : {}),
+    id: normalizedId,
+  };
+
+  const fallbackParams: QueryReactionsShimParams = {};
+  if (limit !== undefined) {
+    fallbackParams.limit = limit;
+  }
+  if (next !== undefined) {
+    fallbackParams.next = next;
+  }
+  if (reactionType !== undefined) {
+    fallbackParams.reaction_type = reactionType;
+  }
+  const normalizedSort = toReactionSortRecord(sort);
+  if (normalizedSort) {
+    fallbackParams.sort = normalizedSort;
+  }
+
+  const fallbackResponse = await queryReactionsShim(
+    fallbackMessage,
+    fallbackParams,
+  );
+
+  return toQueryReactionsResult(fallbackResponse) ?? { reactions: [] };
+}
 
 export const deleteReaction = async ({
   channel,
@@ -3580,6 +3738,7 @@ export const chatAPI = {
   pinMessage,
   flagMessage,
   deleteReaction,
+  queryReactions,
   deleteMessage,
   updateMessage,
   muteUser,

--- a/libs/stream-chat-shim/src/components/Message/hooks/useReactionsFetcher.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useReactionsFetcher.ts
@@ -5,7 +5,7 @@ import type {
   ReactionSort,
   StreamChat,
 } from 'chat-shim';
-import { queryReactions } from '../../../chatSDKShim';
+import { chatAPI } from '../../../api/chatAPI';
 import type { ReactionType } from '../../Reactions/types';
 
 export const MAX_MESSAGE_REACTIONS_TO_FETCH = 1000;
@@ -25,7 +25,7 @@ export function useReactionsFetcher(
 
   return async (reactionType?: ReactionType, sort?: ReactionSort) => {
     try {
-      return await fetchMessageReactions(client, message.id, reactionType, sort);
+      return await fetchMessageReactions(client, message, message.id, reactionType, sort);
     } catch (e) {
       const errorMessage = getErrorNotification?.(message);
       notify?.(errorMessage || t('Error fetching reactions'), 'error');
@@ -36,6 +36,7 @@ export function useReactionsFetcher(
 
 async function fetchMessageReactions(
   client: StreamChat,
+  message: LocalMessage,
   messageId: string,
   reactionType?: ReactionType,
   sort?: ReactionSort,
@@ -46,15 +47,15 @@ async function fetchMessageReactions(
   let hasNext = true;
 
   while (hasNext && reactions.length < MAX_MESSAGE_REACTIONS_TO_FETCH) {
-    const response = await queryReactions(
-      { id: messageId } as any,
-      {
-        limit,
-        next,
-        reaction_type: reactionType,
-        sort,
-      },
-    );
+    const response = await chatAPI.queryReactions({
+      client,
+      limit,
+      message,
+      messageId,
+      next,
+      reactionType,
+      sort,
+    });
 
     reactions.push(...response.reactions);
     next = response.next;

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -591,7 +591,7 @@
     "stubName": "queryReactions",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.queryReactions` helper that calls the client when available and falls back to the shim implementation
- update the message reactions fetcher hook to use the new helper and pass through the current message context
- mark the `shim::queryReactions` wire-up entry as complete in the manifest

## Testing
- `pnpm exec jest libs/stream-chat-shim/__tests__/queryReactions.test.ts libs/stream-chat-shim/__tests__/useReactionsFetcher.test.js libs/stream-chat-shim/__tests__/useReactionsFetcher.test.tsx` *(fails: missing @testing-library/react dependency and legacy test path errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d80909c86c8326ba71d69cd088c19b