### PR TITLE
feat: wire up reminders.clearTimers shim action

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -7,9 +7,11 @@ import {
   loadMessageIntoChannelState,
   pollsFromState as pollsFromStateShim,
   pollsUnregisterSubscriptions as pollsUnregisterSubscriptionsShim,
+  remindersClearTimers as remindersClearTimersShim,
   queryReactions as queryReactionsShim,
 } from '../chatSDKShim';
 import { getLocalClient } from '../../chat-shim';
+import { clearAllReminderTimers } from '../reminders/timerRegistry';
 import type {
   Channel,
   ChannelFilters,
@@ -1123,6 +1125,42 @@ const pollsUnregisterSubscriptions = async ({
   client,
 }: PollsUnregisterSubscriptionsParams = {}): Promise<void> => {
   pollsUnregisterSubscriptionsShim(toPollsSubscriptionsClient(client));
+};
+
+type RemindersTimerClient = {
+  reminders?: { clearTimers?: () => void };
+};
+
+export type RemindersClearTimersParams = {
+  client?: RemindersTimerClient | StreamChat | null;
+};
+
+const toRemindersTimerClient = (
+  client: RemindersClearTimersParams['client'],
+): RemindersTimerClient | undefined => {
+  if (!client) return undefined;
+  if (typeof client === 'object') {
+    return client as RemindersTimerClient;
+  }
+  return undefined;
+};
+
+const getDefaultRemindersTimerClient = (): RemindersTimerClient | undefined => {
+  try {
+    return getLocalClient() as RemindersTimerClient;
+  } catch {
+    return undefined;
+  }
+};
+
+const remindersClearTimers = async (
+  params: RemindersClearTimersParams = {},
+): Promise<void> => {
+  const client =
+    toRemindersTimerClient(params.client) ?? getDefaultRemindersTimerClient();
+
+  remindersClearTimersShim(client);
+  clearAllReminderTimers();
 };
 
 const toPollVoteLike = (value: unknown): PollVoteLike | null => {
@@ -3732,6 +3770,9 @@ export const chatAPI = {
   clientThreadsReload,
   markUnread,
   createReminder,
+  reminders: {
+    clearTimers: remindersClearTimers,
+  },
   notifications: {
     store: resolveNotificationsStore,
   },

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -76,7 +76,7 @@ export const useChat = ({
         client.threads.unregisterSubscriptions();
         void chatAPI.polls.unregisterSubscriptions({ client });
         client.reminders.unregisterSubscriptions();
-        client.reminders.clearTimers();
+        void chatAPI.reminders.clearTimers({ client });
     };
   }, [client]);
 

--- a/libs/stream-chat-shim/src/reminders/timerRegistry.ts
+++ b/libs/stream-chat-shim/src/reminders/timerRegistry.ts
@@ -1,0 +1,65 @@
+export type ReminderTimerHandle =
+  | ReturnType<typeof setTimeout>
+  | ReturnType<typeof setInterval>;
+
+type ReminderTimerEntry = {
+  clear: () => void;
+};
+
+const activeReminderTimers = new Map<ReminderTimerHandle, ReminderTimerEntry>();
+
+const registerTimer = <T extends ReminderTimerHandle>(
+  handle: T,
+  clear: ReminderTimerEntry['clear'],
+): T => {
+  activeReminderTimers.set(handle, { clear });
+  return handle;
+};
+
+export const scheduleReminderTimeout = (
+  callback: () => void,
+  delay: number,
+): ReturnType<typeof setTimeout> => {
+  const timeout = setTimeout(() => {
+    activeReminderTimers.delete(timeout);
+    callback();
+  }, delay);
+
+  return registerTimer(timeout, () => clearTimeout(timeout));
+};
+
+export const scheduleReminderInterval = (
+  callback: () => void,
+  delay: number,
+): ReturnType<typeof setInterval> => {
+  const interval = setInterval(callback, delay);
+  return registerTimer(interval, () => clearInterval(interval));
+};
+
+export const trackReminderTimer = <T extends ReminderTimerHandle>(
+  handle: T,
+  clear: ReminderTimerEntry['clear'],
+): T => registerTimer(handle, clear);
+
+export const cancelReminderTimer = (
+  handle: ReminderTimerHandle,
+): void => {
+  const entry = activeReminderTimers.get(handle);
+  if (!entry) return;
+  entry.clear();
+  activeReminderTimers.delete(handle);
+};
+
+export const forgetReminderTimer = (handle: ReminderTimerHandle): void => {
+  activeReminderTimers.delete(handle);
+};
+
+export const clearAllReminderTimers = (): void => {
+  activeReminderTimers.forEach((entry) => {
+    entry.clear();
+  });
+  activeReminderTimers.clear();
+};
+
+export const getTrackedReminderTimerCount = (): number =>
+  activeReminderTimers.size;


### PR DESCRIPTION
## Summary
- add a reminder timer registry to track shim-managed timeouts/intervals and expose helpers for clearing them
- expose `chatAPI.reminders.clearTimers` to call the shim registry alongside the SDK helper
- update the chat cleanup hook to route reminder timer teardown through the new API helper

## Testing
- pnpm --filter stream-chat-shim exec tsc --noEmit *(fails: existing storybook TODO stubs break type-checking)*

------
https://chatgpt.com/codex/tasks/task_e_68d80f96c60c8326ad9d88658509d76f