### PR TITLE
wireup: reminders.initTimers shim helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -7,6 +7,7 @@ import {
   loadMessageIntoChannelState,
   pollsFromState as pollsFromStateShim,
   pollsUnregisterSubscriptions as pollsUnregisterSubscriptionsShim,
+  remindersInitTimers as remindersInitTimersShim,
   remindersClearTimers as remindersClearTimersShim,
   queryReactions as queryReactionsShim,
 } from '../chatSDKShim';
@@ -1135,10 +1136,14 @@ const pollsUnregisterSubscriptions = async ({
 };
 
 type RemindersTimerClient = {
-  reminders?: { clearTimers?: () => void };
+  reminders?: { clearTimers?: () => void; initTimers?: () => void };
 };
 
 export type RemindersClearTimersParams = {
+  client?: RemindersTimerClient | StreamChat | null;
+};
+
+export type RemindersInitTimersParams = {
   client?: RemindersTimerClient | StreamChat | null;
 };
 
@@ -1158,6 +1163,15 @@ const getDefaultRemindersTimerClient = (): RemindersTimerClient | undefined => {
   } catch {
     return undefined;
   }
+};
+
+const remindersInitTimers = async (
+  params: RemindersInitTimersParams = {},
+): Promise<void> => {
+  const client =
+    toRemindersTimerClient(params.client) ?? getDefaultRemindersTimerClient();
+
+  remindersInitTimersShim(client);
 };
 
 const remindersClearTimers = async (
@@ -3992,6 +4006,7 @@ export const chatAPI = {
   markUnread,
   createReminder,
   reminders: {
+    initTimers: remindersInitTimers,
     clearTimers: remindersClearTimers,
     deleteReminder,
   },

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -70,7 +70,7 @@ export const useChat = ({
     client.threads.registerSubscriptions();
     client.polls.registerSubscriptions();
     client.reminders.registerSubscriptions();
-    client.reminders.initTimers();
+    void chatAPI.reminders.initTimers({ client });
 
     return () => {
         client.threads.unregisterSubscriptions();

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -618,7 +618,7 @@
     "stubName": "reminders.initTimers",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.reminders.initTimers helper that uses the SDK shim
- switch useChat to invoke chatAPI.reminders.initTimers instead of the direct client call
- mark the reminders.initTimers entry in the wireup manifest as complete

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/useChat.test.tsx *(fails: missing @testing-library/react in workspace)*
- pnpm --filter frontend lint *(fails: existing lint violations in frontend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d81df333ec8326b7d7e5a3be6397db