### PR TITLE
feat(reminders.scheduledOffsetsMs): wire up shim helper (no HTTP)

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.scheduledOffsetsMs.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.scheduledOffsetsMs.test.ts
@@ -1,3 +1,4 @@
+import { chatAPI } from '../src/api/chatAPI';
 import { remindersScheduledOffsetsMs } from '../src/chatSDKShim';
 
 describe('remindersScheduledOffsetsMs', () => {
@@ -10,5 +11,26 @@ describe('remindersScheduledOffsetsMs', () => {
     const res = remindersScheduledOffsetsMs();
     expect(Array.isArray(res)).toBe(true);
     expect(res.length).toBeGreaterThan(0);
+  });
+});
+
+describe('chatAPI.reminders.scheduledOffsetsMs', () => {
+  it('normalizes offset values from the provided client', () => {
+    const client = {
+      reminders: {
+        scheduledOffsetsMs: [1000, Number.NaN, '5000', 2000],
+      },
+    } as any;
+
+    expect(chatAPI.reminders.scheduledOffsetsMs({ client })).toEqual([1000, 2000]);
+  });
+
+  it('returns default offsets when client data is missing', () => {
+    expect(chatAPI.reminders.scheduledOffsetsMs({})).toEqual([
+      5 * 60 * 1000,
+      30 * 60 * 1000,
+      60 * 60 * 1000,
+      24 * 60 * 60 * 1000,
+    ]);
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -1184,6 +1184,47 @@ const remindersClearTimers = async (
   clearAllReminderTimers();
 };
 
+const DEFAULT_REMINDER_SCHEDULED_OFFSETS_MS: readonly number[] = Object.freeze([
+  5 * 60 * 1000,
+  30 * 60 * 1000,
+  60 * 60 * 1000,
+  24 * 60 * 60 * 1000,
+]);
+
+export type RemindersScheduledOffsetsMsParams = {
+  client?: ReminderAwareClient | StreamChat;
+};
+
+const normalizeScheduledOffsets = (value: unknown): number[] | null => {
+  if (!Array.isArray(value)) return null;
+
+  const normalized: number[] = [];
+
+  for (const entry of value) {
+    if (typeof entry === 'number' && Number.isFinite(entry)) {
+      normalized.push(entry);
+    }
+  }
+
+  return normalized.length ? normalized : null;
+};
+
+const remindersScheduledOffsetsMs = (
+  params: RemindersScheduledOffsetsMsParams = {},
+): number[] => {
+  const manager =
+    toReminderManager(params.client) ??
+    toReminderManager(getDefaultRemindersClient());
+
+  const normalized = normalizeScheduledOffsets(manager?.scheduledOffsetsMs);
+
+  if (normalized) {
+    return normalized.slice();
+  }
+
+  return [...DEFAULT_REMINDER_SCHEDULED_OFFSETS_MS];
+};
+
 const toPollVoteLike = (value: unknown): PollVoteLike | null => {
   if (!isRecord(value)) return null;
   const identifier = (value as { id?: unknown }).id;
@@ -3588,9 +3629,13 @@ type ReminderManagerLike = {
   deleteReminder?: (id: string) => Promise<unknown>;
   store?: StateStore<{ reminders?: ReminderEntryLike[] }>;
   state?: StateStore<{ reminders?: unknown }>;
+  scheduledOffsetsMs?: number[];
 };
 
-type ReminderAwareClient = { reminders?: ReminderManagerLike } | null | undefined;
+export type ReminderAwareClient =
+  | { reminders?: ReminderManagerLike }
+  | null
+  | undefined;
 
 const getDefaultRemindersClient = (): ReminderAwareClient => {
   try {
@@ -4008,6 +4053,7 @@ export const chatAPI = {
   reminders: {
     initTimers: remindersInitTimers,
     clearTimers: remindersClearTimers,
+    scheduledOffsetsMs: remindersScheduledOffsetsMs,
     deleteReminder,
   },
   notifications: {

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -42,6 +42,7 @@ import {
   type QueryAnswersResult as QueryAnswersAPIResult,
   type SyncUserRequest,
   type SyncUserResponse,
+  type RemindersScheduledOffsetsMsParams,
 } from './api/chatAPI';
 import {
   createMessage,
@@ -2726,17 +2727,10 @@ export function remindersClearTimers(client?: {
   client?.reminders?.clearTimers?.();
 }
 
-export function remindersScheduledOffsetsMs(client?: {
-  reminders?: { scheduledOffsetsMs?: number[] };
-}): number[] {
-  return (
-    client?.reminders?.scheduledOffsetsMs ?? [
-      5 * 60 * 1000,
-      30 * 60 * 1000,
-      60 * 60 * 1000,
-      24 * 60 * 60 * 1000,
-    ]
-  );
+export function remindersScheduledOffsetsMs(
+  client?: RemindersScheduledOffsetsMsParams['client'],
+): number[] {
+  return chatAPI.reminders.scheduledOffsetsMs({ client });
 }
 
 export async function remindersUpsertReminder(

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { useChatContext, useMessageContext, useTranslationContext } from '../../context';
-import type { CreateReminderInput } from '../../api/chatAPI';
-import {
-  remindersScheduledOffsetsMs,
-  remindersUpsertReminder,
-} from '../../chatSDKShim';
+import { chatAPI, type CreateReminderInput } from '../../api/chatAPI';
+import { remindersUpsertReminder } from '../../chatSDKShim';
 import { ButtonWithSubmenu } from '../Dialog';
 import type { ComponentProps } from 'react';
 
@@ -30,7 +27,7 @@ export const RemindMeSubmenu = () => {
   const { t } = useTranslationContext();
   const { client, channel } = useChatContext();
   const { message } = useMessageContext();
-  const scheduledOffsetsMs = remindersScheduledOffsetsMs(client);
+  const scheduledOffsetsMs = chatAPI.reminders.scheduledOffsetsMs({ client });
   const cid = channel?.cid ?? (message.cid as string | undefined);
   return (
     <div

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -627,7 +627,7 @@
     "stubName": "reminders.scheduledOffsetsMs",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed `chatAPI.reminders.scheduledOffsetsMs` helper with normalization and fallback defaults and expose the reminder-aware client type
- route the shim function and Remind Me submenu through the new helper so the UI uses the centralized offsets lookup
- extend reminders unit coverage and mark the wire-up manifest entry as complete

## Testing
- pnpm test -- --runTestsByPath libs/stream-chat-shim/__tests__/reminders.scheduledOffsetsMs.test.ts *(fails: turbo not found in workspace without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d83f8aeb288326b0744841a7ac4d67