### PR TITLE
feat: wire up reminders.unregisterSubscriptions shim

### DIFF
--- a/libs/stream-chat-shim/__tests__/chatAPI.reminders.unregisterSubscriptions.test.ts
+++ b/libs/stream-chat-shim/__tests__/chatAPI.reminders.unregisterSubscriptions.test.ts
@@ -1,0 +1,70 @@
+import { StateStore } from 'chat-shim';
+
+import { chatAPI } from '../src/api/chatAPI';
+
+describe('chatAPI.reminders.unregisterSubscriptions', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('delegates to the client and clears reminder stores', async () => {
+    const timerHandle = {} as unknown as ReturnType<typeof setTimeout>;
+
+    const remindersStore = new StateStore({
+      reminders: [
+        {
+          reminder: { id: '42', message_id: '99' },
+          timer: timerHandle,
+        },
+      ],
+    });
+
+    const remindersState = new StateStore({
+      reminders: new Map([[
+        '99',
+        { reminder: { id: '42', message_id: '99' } },
+      ]]),
+    });
+
+    const unregisterSubscriptions = jest.fn();
+    const clearTimers = jest.fn();
+
+    const client = {
+      reminders: {
+        unregisterSubscriptions,
+        clearTimers,
+        store: remindersStore,
+        state: remindersState,
+      },
+    } as const;
+
+    const clearTimeoutSpy = jest
+      .spyOn(global, 'clearTimeout')
+      .mockImplementation(() => undefined as any);
+
+    await chatAPI.reminders.unregisterSubscriptions({ client });
+
+    expect(unregisterSubscriptions).toHaveBeenCalled();
+    expect(clearTimers).toHaveBeenCalled();
+    expect(remindersStore.getLatestValue().reminders).toHaveLength(0);
+
+    const stateSnapshot = remindersState.getLatestValue().reminders;
+    if (stateSnapshot instanceof Map) {
+      expect(stateSnapshot.size).toBe(0);
+    } else if (Array.isArray(stateSnapshot)) {
+      expect(stateSnapshot.length).toBe(0);
+    } else if (stateSnapshot && typeof stateSnapshot === 'object') {
+      expect(Object.keys(stateSnapshot).length).toBe(0);
+    } else {
+      expect(stateSnapshot).toBeUndefined();
+    }
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timerHandle);
+  });
+
+  it('resolves when the reminders helper is missing', async () => {
+    await expect(
+      chatAPI.reminders.unregisterSubscriptions({ client: {} as any }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -9,6 +9,7 @@ import {
   pollsUnregisterSubscriptions as pollsUnregisterSubscriptionsShim,
   remindersInitTimers as remindersInitTimersShim,
   remindersClearTimers as remindersClearTimersShim,
+  remindersUnregisterSubscriptions as remindersUnregisterSubscriptionsShim,
   queryReactions as queryReactionsShim,
 } from '../chatSDKShim';
 import { getLocalClient } from '../../chat-shim';
@@ -3637,12 +3638,51 @@ export type ReminderAwareClient =
   | null
   | undefined;
 
+export type RemindersUnregisterSubscriptionsParams = {
+  client?: ReminderAwareClient | StreamChat | null;
+};
+
+type RemindersSubscriptionsClient = {
+  reminders?: {
+    unregisterSubscriptions?: () => void;
+    clearTimers?: () => void;
+    store?: StateStore<{ reminders?: unknown }>;
+    state?: StateStore<{ reminders?: unknown }>;
+  };
+};
+
 const getDefaultRemindersClient = (): ReminderAwareClient => {
   try {
     return getLocalClient() as ReminderAwareClient;
   } catch {
     return undefined;
   }
+};
+
+const getDefaultRemindersSubscriptionsClient =
+  (): RemindersSubscriptionsClient | undefined => {
+    const client = getDefaultRemindersClient();
+    if (!client) return undefined;
+    if (
+      typeof client === 'object' &&
+      'reminders' in (client as Record<string, unknown>)
+    ) {
+      return client as RemindersSubscriptionsClient;
+    }
+    return undefined;
+  };
+
+const toRemindersSubscriptionsClient = (
+  client: RemindersUnregisterSubscriptionsParams['client'],
+): RemindersSubscriptionsClient | undefined => {
+  if (!client || typeof client !== 'object') return undefined;
+  if (
+    'reminders' in (client as Record<string, unknown>) &&
+    typeof (client as Record<string, unknown>).reminders === 'object'
+  ) {
+    return client as RemindersSubscriptionsClient;
+  }
+  return undefined;
 };
 
 const toReminderManager = (
@@ -3684,6 +3724,76 @@ const dispatchStateStorePatch = (
   if (typeof maybeSet === "function") {
     maybeSet(patch);
   }
+};
+
+const clearReminderStoreEntries = (
+  manager: ReminderManagerLike | undefined,
+) => {
+  const store = manager?.store;
+  const getLatest = store?.getLatestValue ?? store?.getSnapshot;
+  if (!store || typeof getLatest !== 'function') return;
+
+  const snapshot = getLatest.call(store);
+  const reminders = Array.isArray(snapshot?.reminders)
+    ? (snapshot?.reminders as ReminderEntryLike[])
+    : [];
+
+  if (!reminders.length) return;
+
+  for (const entry of reminders) {
+    const handle = entry?.timer;
+    if (!handle) continue;
+    try {
+      clearTimeout(handle as ReturnType<typeof setTimeout>);
+    } catch {
+      try {
+        clearInterval(handle as ReturnType<typeof setInterval>);
+      } catch {
+        // ignore timers that cannot be cleared
+      }
+    }
+  }
+
+  dispatchStateStorePatch(store, { reminders: [] });
+};
+
+const clearReminderStateStore = (
+  manager: ReminderManagerLike | undefined,
+) => {
+  const stateStore = manager?.state;
+  const getLatest = stateStore?.getLatestValue ?? stateStore?.getSnapshot;
+  if (!stateStore || typeof getLatest !== 'function') return;
+
+  const snapshot = getLatest.call(stateStore);
+  if (!snapshot || typeof snapshot !== 'object') return;
+
+  const container = (snapshot as { reminders?: unknown }).reminders;
+  if (!container) return;
+
+  if (container instanceof Map) {
+    if (!container.size) return;
+    dispatchStateStorePatch(stateStore, { reminders: new Map() });
+    return;
+  }
+
+  if (Array.isArray(container)) {
+    if (!container.length) return;
+    dispatchStateStorePatch(stateStore, { reminders: [] });
+    return;
+  }
+
+  if (typeof container === 'object') {
+    if (!Object.keys(container as Record<string, unknown>).length) return;
+    dispatchStateStorePatch(stateStore, { reminders: {} });
+  }
+};
+
+const resetReminderManagerState = (
+  manager: ReminderManagerLike | undefined,
+) => {
+  if (!manager) return;
+  clearReminderStoreEntries(manager);
+  clearReminderStateStore(manager);
 };
 
 const removeReminderFromStore = (
@@ -3794,6 +3904,36 @@ const updateReminderState = (
       dispatchStateStorePatch(stateStore, { reminders: clone });
     }
   }
+};
+
+const remindersUnregisterSubscriptions = async (
+  params: RemindersUnregisterSubscriptionsParams = {},
+): Promise<void> => {
+  const defaultClient = getDefaultRemindersClient();
+  const normalizedClient =
+    toRemindersSubscriptionsClient(params.client) ??
+    getDefaultRemindersSubscriptionsClient();
+
+  remindersUnregisterSubscriptionsShim(normalizedClient);
+
+  const reminderManager =
+    toReminderManager(params.client) ??
+    toReminderManager(normalizedClient as ReminderAwareClient | StreamChat | null) ??
+    toReminderManager(defaultClient);
+
+  const clearTimersTarget =
+    reminderManager ?? normalizedClient?.reminders ?? defaultClient?.reminders;
+
+  try {
+    clearTimersTarget?.clearTimers?.();
+  } catch {
+    // ignore custom client errors
+  }
+
+  clearAllReminderTimers();
+  resetReminderManagerState(
+    reminderManager ?? (clearTimersTarget as ReminderManagerLike | undefined),
+  );
 };
 
 const deleteReminder = async ({
@@ -4051,6 +4191,7 @@ export const chatAPI = {
   markUnread,
   createReminder,
   reminders: {
+    unregisterSubscriptions: remindersUnregisterSubscriptions,
     initTimers: remindersInitTimers,
     clearTimers: remindersClearTimers,
     scheduledOffsetsMs: remindersScheduledOffsetsMs,

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -73,10 +73,10 @@ export const useChat = ({
     void chatAPI.reminders.initTimers({ client });
 
     return () => {
-        client.threads.unregisterSubscriptions();
-        void chatAPI.polls.unregisterSubscriptions({ client });
-        client.reminders.unregisterSubscriptions();
-        void chatAPI.reminders.clearTimers({ client });
+      client.threads.unregisterSubscriptions();
+      void chatAPI.polls.unregisterSubscriptions({ client });
+      void chatAPI.reminders.unregisterSubscriptions({ client });
+      void chatAPI.reminders.clearTimers({ client });
     };
   }, [client]);
 

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -636,7 +636,7 @@
     "stubName": "reminders.unregisterSubscriptions",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.reminders.unregisterSubscriptions helper that clears reminder timers and local stores before delegating to the client
- update the chat cleanup hook to call the new helper instead of reaching into client.reminders directly
- cover the reminder cleanup path with a dedicated unit test and mark the wireup manifest entry as complete

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/chatAPI.reminders.unregisterSubscriptions.test.ts *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d842a3d0c48326947584e8af12dc48