### PR TITLE
feat(reminders.upsertReminder): wire up shim-only handler

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
@@ -1,39 +1,75 @@
 import { chatAPI } from '../src/api/chatAPI';
 import { remindersUpsertReminder } from '../src/chatSDKShim';
 
-jest.mock('../src/api/chatAPI', () => ({
-  chatAPI: {
-    createReminder: jest.fn().mockResolvedValue('ok'),
-  },
-}));
+describe('reminders.upsertReminder', () => {
+  const originalFetch = globalThis.fetch;
 
-describe('remindersUpsertReminder', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalFetch) {
+      (globalThis as any).fetch = originalFetch;
+    } else {
+      delete (globalThis as any).fetch;
+    }
   });
 
-  it('calls reminders.upsertReminder when available', async () => {
+  it('uses reminder manager when available', async () => {
     const fn = jest.fn().mockResolvedValue('ok');
-    const res = await remindersUpsertReminder(
-      { upsertReminder: fn } as any,
-      { cid: 'messaging:test', message_id: 42, remind_at: '2024-01-01T00:00:00Z' },
-    );
+    const reminder = {
+      cid: 'messaging:test',
+      message_id: 42,
+      remind_at: '2024-01-01T00:00:00Z',
+    };
+
+    const res = await chatAPI.reminders.upsertReminder({
+      reminders: { upsertReminder: fn },
+      reminder,
+    });
+
     expect(fn).toHaveBeenCalledWith('42', '2024-01-01T00:00:00Z');
     expect(res).toBe('ok');
   });
 
-  it('falls back to HTTP request when not implemented', async () => {
-    (chatAPI.createReminder as jest.Mock).mockResolvedValueOnce('ok');
-    const res = await remindersUpsertReminder(undefined, {
+  it('falls back to HTTP request when reminder manager is missing', async () => {
+    const response = {
+      ok: true,
+      json: jest.fn().mockResolvedValue('ok'),
+    };
+    const fetchMock = jest.fn().mockResolvedValue(response);
+    (globalThis as any).fetch = fetchMock;
+
+    const reminder = {
       cid: 'messaging:test',
       message_id: 42,
       remind_at: '2024-01-01T00:00:00Z',
+    };
+
+    const res = await chatAPI.reminders.upsertReminder({ reminder });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/reminders/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reminder),
     });
-    expect(chatAPI.createReminder).toHaveBeenCalledWith({
+    expect(response.json).toHaveBeenCalled();
+    expect(res).toBe('ok');
+  });
+
+  it('delegates through remindersUpsertReminder', async () => {
+    const reminder = {
       cid: 'messaging:test',
       message_id: 42,
       remind_at: '2024-01-01T00:00:00Z',
-    });
+    };
+    const reminders = { upsertReminder: jest.fn() };
+    const spy = jest
+      .spyOn(chatAPI.reminders, 'upsertReminder')
+      .mockResolvedValue('ok');
+
+    const res = await remindersUpsertReminder(reminders as any, reminder);
+
+    expect(spy).toHaveBeenCalledWith({ reminders, reminder });
     expect(res).toBe('ok');
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -3618,6 +3618,24 @@ async function createReminder(body: CreateReminderInput): Promise<Reminder> {
   return (await response.json()) as Reminder;
 }
 
+const remindersUpsertReminder = async ({
+  reminder,
+  reminders,
+  client,
+}: RemindersUpsertReminderParams): Promise<any> => {
+  const reminderManager =
+    reminders ??
+    toReminderManager(client) ??
+    toReminderManager(getDefaultRemindersClient());
+
+  if (reminderManager?.upsertReminder) {
+    const messageId = reminder.message_id ?? "";
+    return reminderManager.upsertReminder(String(messageId), reminder.remind_at);
+  }
+
+  return createReminder(reminder);
+};
+
 type ReminderEntryLike = {
   reminder?: Partial<Reminder> & {
     id?: number | string | null;
@@ -3627,6 +3645,7 @@ type ReminderEntryLike = {
 };
 
 type ReminderManagerLike = {
+  upsertReminder?: (messageId: string, remind_at: string) => Promise<unknown>;
   deleteReminder?: (id: string) => Promise<unknown>;
   store?: StateStore<{ reminders?: ReminderEntryLike[] }>;
   state?: StateStore<{ reminders?: unknown }>;
@@ -3637,6 +3656,12 @@ export type ReminderAwareClient =
   | { reminders?: ReminderManagerLike }
   | null
   | undefined;
+
+export type RemindersUpsertReminderParams = {
+  reminder: CreateReminderInput;
+  reminders?: ReminderManagerLike | null;
+  client?: ReminderAwareClient | StreamChat | null;
+};
 
 export type RemindersUnregisterSubscriptionsParams = {
   client?: ReminderAwareClient | StreamChat | null;
@@ -4191,6 +4216,7 @@ export const chatAPI = {
   markUnread,
   createReminder,
   reminders: {
+    upsertReminder: remindersUpsertReminder,
     unregisterSubscriptions: remindersUnregisterSubscriptions,
     initTimers: remindersInitTimers,
     clearTimers: remindersClearTimers,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -2744,13 +2744,10 @@ export async function remindersUpsertReminder(
     | undefined,
   params: CreateReminderInput,
 ): Promise<any> {
-  if (reminders?.upsertReminder) {
-    return reminders.upsertReminder(
-      String(params.message_id ?? ''),
-      params.remind_at,
-    );
-  }
-  return chatAPI.createReminder(params);
+  return chatAPI.reminders.upsertReminder({
+    reminders,
+    reminder: params,
+  });
 }
 
 export async function search(

--- a/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
+++ b/libs/stream-chat-shim/src/components/MessageActions/RemindMeSubmenu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useChatContext, useMessageContext, useTranslationContext } from '../../context';
 import { chatAPI, type CreateReminderInput } from '../../api/chatAPI';
-import { remindersUpsertReminder } from '../../chatSDKShim';
 import { ButtonWithSubmenu } from '../Dialog';
 import type { ComponentProps } from 'react';
 
@@ -55,7 +54,10 @@ export const RemindMeSubmenu = () => {
             if (typeof rawMessageId === 'number' && !Number.isNaN(rawMessageId)) {
               reminderInput.message_id = rawMessageId;
             }
-            remindersUpsertReminder(client.reminders, reminderInput);
+            void chatAPI.reminders.upsertReminder({
+              client,
+              reminder: reminderInput,
+            });
           }}
         >
           {t('duration/Remind Me', { milliseconds: offsetMs })}

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -645,7 +645,7 @@
     "stubName": "reminders.upsertReminder",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.reminders.upsertReminder helper that invokes the local reminder manager when available and falls back to the HTTP shim
- update the shim wrapper, reminder UI submenu, and tests to route through the new helper
- mark the reminders.upsertReminder wire-up manifest entry as complete

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts *(fails: TypeScript compilation errors in existing shim sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d84822b6f0832694a6775346ce6762