### PR TITLE
feat(reminders.upsertReminder): wire up shim-only n/a

### DIFF
--- a/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
+++ b/libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts
@@ -56,6 +56,111 @@ describe('reminders.upsertReminder', () => {
     expect(res).toBe('ok');
   });
 
+  it('adds the reminder to the manager store when using HTTP fallback', async () => {
+    const reminder = {
+      cid: 'messaging:test',
+      message_id: 55,
+      remind_at: '2024-01-01T00:00:00Z',
+    };
+    const createdReminder = {
+      id: 77,
+      message_id: 55,
+      remind_at: '2024-01-01T00:00:00Z',
+    };
+    const response = {
+      ok: true,
+      json: jest.fn().mockResolvedValue(createdReminder),
+    };
+    const fetchMock = jest.fn().mockResolvedValue(response);
+    (globalThis as any).fetch = fetchMock;
+
+    const dispatch = jest.fn();
+    const manager = {
+      store: {
+        getLatestValue: jest.fn().mockReturnValue({ reminders: [] }),
+        dispatch,
+      },
+      initTimers: jest.fn(),
+    } as any;
+
+    const res = await chatAPI.reminders.upsertReminder({ reminder, reminders: manager });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      reminders: [{ reminder: createdReminder }],
+    });
+    expect(manager.initTimers).toHaveBeenCalled();
+    expect(res).toEqual(createdReminder);
+  });
+
+  it('merges reminders into existing store and state entries', async () => {
+    const reminder = {
+      cid: 'messaging:test',
+      message_id: 99,
+      remind_at: '2024-01-02T00:00:00Z',
+    };
+    const serverReminder = {
+      id: 1,
+      message_id: 99,
+      remind_at: '2024-01-02T00:00:00Z',
+    };
+    const response = {
+      ok: true,
+      json: jest.fn().mockResolvedValue(serverReminder),
+    };
+    (globalThis as any).fetch = jest.fn().mockResolvedValue(response);
+
+    const timerHandle = Symbol('timer') as unknown as ReturnType<typeof setTimeout>;
+    const existingEntry = {
+      reminder: {
+        id: 1,
+        message_id: 99,
+        remind_at: '2023-12-31T00:00:00Z',
+      },
+      timer: timerHandle,
+    };
+
+    const storeDispatch = jest.fn();
+    const store = {
+      getLatestValue: jest.fn().mockReturnValue({ reminders: [existingEntry] }),
+      dispatch: storeDispatch,
+    } as any;
+
+    const mapContainer = new Map<string, any>([['99', existingEntry]]);
+    const stateDispatch = jest.fn();
+    const stateStore = {
+      getLatestValue: jest.fn().mockReturnValue({ reminders: mapContainer }),
+      dispatch: stateDispatch,
+    } as any;
+
+    const res = await chatAPI.reminders.upsertReminder({
+      reminder,
+      reminders: { store, state: stateStore } as any,
+    });
+
+    expect(res).toEqual(serverReminder);
+    expect(mapContainer.get('99')?.reminder?.remind_at).toBe('2023-12-31T00:00:00Z');
+
+    const storePatch = storeDispatch.mock.calls[0]?.[0];
+    expect(storePatch?.reminders).toHaveLength(1);
+    expect(storePatch?.reminders?.[0]?.reminder).toMatchObject(serverReminder);
+    expect(storePatch?.reminders?.[0]?.timer).toBe(timerHandle);
+
+    const statePatch = stateDispatch.mock.calls[0]?.[0];
+    expect(statePatch?.reminders).toBeInstanceOf(Map);
+    const entries = Array.from(
+      (statePatch?.reminders as Map<string, any>).entries(),
+    );
+    expect(entries).toEqual([
+      [
+        '99',
+        expect.objectContaining({
+          reminder: expect.objectContaining(serverReminder),
+        }),
+      ],
+    ]);
+  });
+
   it('delegates through remindersUpsertReminder', async () => {
     const reminder = {
       cid: 'messaging:test',

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -3598,6 +3598,34 @@ export const listRoomDrafts = async ({
   return Array.isArray(data) ? (data as RoomDraft[]) : [];
 };
 
+type ReminderEntryLike = {
+  reminder?: Partial<Reminder> & {
+    id?: number | string | null;
+    message_id?: number | string | null;
+  };
+  timer?: ReturnType<typeof setTimeout> | null;
+};
+
+type ReminderManagerLike = {
+  upsertReminder?: (messageId: string, remind_at: string) => Promise<unknown>;
+  deleteReminder?: (id: string) => Promise<unknown>;
+  store?: StateStore<{ reminders?: ReminderEntryLike[] }>;
+  state?: StateStore<{ reminders?: unknown }>;
+  scheduledOffsetsMs?: number[];
+  initTimers?: () => void;
+};
+
+export type ReminderAwareClient =
+  | { reminders?: ReminderManagerLike }
+  | null
+  | undefined;
+
+export type RemindersUpsertReminderParams = {
+  reminder: CreateReminderInput;
+  reminders?: ReminderManagerLike | null;
+  client?: ReminderAwareClient | StreamChat | null;
+};
+
 async function createReminder(body: CreateReminderInput): Promise<Reminder> {
   const response = await fetch("/api/reminders/", {
     method: "POST",
@@ -3618,6 +3646,124 @@ async function createReminder(body: CreateReminderInput): Promise<Reminder> {
   return (await response.json()) as Reminder;
 }
 
+const normalizeReminderId = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value) return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+};
+
+const upsertReminderStoreEntry = (
+  manager: ReminderManagerLike | undefined,
+  reminder: Reminder,
+): ReminderEntryLike | undefined => {
+  const store = manager?.store;
+  const getLatest = store?.getLatestValue ?? store?.getSnapshot;
+
+  if (!store || typeof getLatest !== "function") {
+    return undefined;
+  }
+
+  const snapshot = getLatest.call(store);
+  const currentEntries = Array.isArray(snapshot?.reminders)
+    ? (snapshot?.reminders as ReminderEntryLike[])
+    : [];
+
+  const reminderId = normalizeReminderId(reminder.id);
+  const nextEntries: ReminderEntryLike[] = [];
+  let updatedEntry: ReminderEntryLike | undefined;
+  let replaced = false;
+
+  for (const entry of currentEntries) {
+    const entryId = normalizeReminderId(entry?.reminder?.id);
+    if (reminderId && entryId === reminderId) {
+      const merged: ReminderEntryLike = {
+        ...entry,
+        reminder: {
+          ...(entry.reminder ?? {}),
+          ...reminder,
+        },
+      };
+      nextEntries.push(merged);
+      updatedEntry = merged;
+      replaced = true;
+    } else {
+      nextEntries.push(entry);
+    }
+  }
+
+  if (!replaced) {
+    updatedEntry = { reminder: { ...reminder } };
+    nextEntries.push(updatedEntry);
+  }
+
+  dispatchStateStorePatch(store, { reminders: nextEntries });
+  return updatedEntry;
+};
+
+const upsertReminderStateEntry = (
+  manager: ReminderManagerLike | undefined,
+  entry: ReminderEntryLike | undefined,
+) => {
+  if (!entry?.reminder) return;
+  const stateStore = manager?.state;
+  const getLatest = stateStore?.getLatestValue ?? stateStore?.getSnapshot;
+
+  if (!stateStore || typeof getLatest !== "function") {
+    return;
+  }
+
+  const snapshot = getLatest.call(stateStore);
+  if (!snapshot || typeof snapshot !== "object") {
+    return;
+  }
+
+  const container = (snapshot as { reminders?: unknown }).reminders;
+  const messageId = normalizeReminderId(entry.reminder.message_id);
+
+  if (!container || !messageId) {
+    return;
+  }
+
+  if (container instanceof Map) {
+    const next = new Map(container);
+    next.set(messageId, entry);
+    dispatchStateStorePatch(stateStore, { reminders: next });
+    return;
+  }
+
+  if (Array.isArray(container)) {
+    const next = container.slice();
+    let replaced = false;
+
+    for (let index = 0; index < next.length; index += 1) {
+      const existing = next[index] as ReminderEntryLike | undefined;
+      const existingId = normalizeReminderId(existing?.reminder?.message_id);
+      if (existingId === messageId) {
+        next[index] = { ...existing, ...entry };
+        replaced = true;
+        break;
+      }
+    }
+
+    if (!replaced) {
+      next.push(entry);
+    }
+
+    dispatchStateStorePatch(stateStore, { reminders: next });
+    return;
+  }
+
+  if (typeof container === "object") {
+    const clone: Record<string, unknown> = {
+      ...(container as Record<string, unknown>),
+    };
+    clone[messageId] = entry;
+    dispatchStateStorePatch(stateStore, { reminders: clone });
+  }
+};
+
 const remindersUpsertReminder = async ({
   reminder,
   reminders,
@@ -3633,34 +3779,19 @@ const remindersUpsertReminder = async ({
     return reminderManager.upsertReminder(String(messageId), reminder.remind_at);
   }
 
-  return createReminder(reminder);
-};
+  const createdReminder = await createReminder(reminder);
 
-type ReminderEntryLike = {
-  reminder?: Partial<Reminder> & {
-    id?: number | string | null;
-    message_id?: number | string | null;
-  };
-  timer?: ReturnType<typeof setTimeout> | null;
-};
+  if (reminderManager) {
+    const entry = upsertReminderStoreEntry(reminderManager, createdReminder);
+    upsertReminderStateEntry(reminderManager, entry);
+    try {
+      reminderManager.initTimers?.();
+    } catch {
+      // ignore reminder manager timer errors
+    }
+  }
 
-type ReminderManagerLike = {
-  upsertReminder?: (messageId: string, remind_at: string) => Promise<unknown>;
-  deleteReminder?: (id: string) => Promise<unknown>;
-  store?: StateStore<{ reminders?: ReminderEntryLike[] }>;
-  state?: StateStore<{ reminders?: unknown }>;
-  scheduledOffsetsMs?: number[];
-};
-
-export type ReminderAwareClient =
-  | { reminders?: ReminderManagerLike }
-  | null
-  | undefined;
-
-export type RemindersUpsertReminderParams = {
-  reminder: CreateReminderInput;
-  reminders?: ReminderManagerLike | null;
-  client?: ReminderAwareClient | StreamChat | null;
+  return createdReminder;
 };
 
 export type RemindersUnregisterSubscriptionsParams = {
@@ -3720,14 +3851,6 @@ const toReminderManager = (
     typeof (client as ReminderAwareClient)?.reminders === "object"
   ) {
     return (client as ReminderAwareClient).reminders as ReminderManagerLike;
-  }
-  return undefined;
-};
-
-const normalizeReminderId = (value: unknown): string | undefined => {
-  if (typeof value === "string" && value) return value;
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
   }
   return undefined;
 };


### PR DESCRIPTION
## Summary
- ensure the reminders.upsertReminder shim updates the reminder manager store/state and reinitializes timers when falling back to HTTP
- extend the unit suite to cover store, state, and timer updates returned by the shim helper

## Testing
- pnpm exec jest libs/stream-chat-shim/__tests__/reminders.upsertReminder.test.ts *(fails: ts-jest cannot resolve existing chat-shim aliases in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d8500f803483268bb0c592cb667058