### PR TITLE
feat(sendReaction): wire up shim handler

### DIFF
--- a/libs/stream-chat-shim/__tests__/sendReaction.test.ts
+++ b/libs/stream-chat-shim/__tests__/sendReaction.test.ts
@@ -1,24 +1,24 @@
+jest.mock('../src/api/chatAPI', () => {
+  const actual = jest.requireActual('../src/api/chatAPI');
+  return {
+    ...actual,
+    chatAPI: {
+      ...actual.chatAPI,
+      sendReaction: jest.fn().mockResolvedValue('ok'),
+    },
+  };
+});
+
+import { chatAPI } from '../src/api/chatAPI';
 import { sendReaction } from '../src/chatSDKShim';
 
 describe('sendReaction', () => {
-  it('calls channel.sendReaction when available', async () => {
-    const fn = jest.fn().mockResolvedValue('ok');
-    const res = await sendReaction({ sendReaction: fn } as any, 'm1', 'like');
-    expect(fn).toHaveBeenCalledWith('m1', 'like');
-    expect(res).toBe('ok');
-  });
+  it('delegates to chatAPI.sendReaction', async () => {
+    const res = await sendReaction('m1', 'like');
 
-  it('POSTs to /api/messages/ when not implemented', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve('ok') });
-    // @ts-ignore
-    global.fetch = fetchMock;
-    const res = await sendReaction(undefined as any, 'm1', 'like');
-    expect(fetchMock).toHaveBeenCalledWith('/api/messages/m1/reactions/', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type: 'like' }),
-    });
+    expect(chatAPI.sendReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'm1', type: 'like' }),
+    );
     expect(res).toBe('ok');
   });
 });

--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -2529,7 +2529,7 @@ const applyChannelPinLocally = (
   }
 };
 
-type ReactionUserLike = { id?: string | number | null } & Record<string, unknown>;
+type ReactionUserLike = ReactionUser;
 
 type ReactionResponseLike = {
   type?: string;
@@ -2586,6 +2586,8 @@ type ReactionGroupRecord = {
   [key: string]: unknown;
 };
 
+export type ReactionUser = { id?: string | number | null } & Record<string, unknown>;
+
 type ChannelReactionLike = {
   cid?: string;
   state?: { messages?: Array<Record<string, unknown>> | undefined } | null;
@@ -2601,6 +2603,20 @@ type ChannelPinLike = ChannelReactionLike & {
   );
   pin?: (message?: Record<string, unknown> | string) => Promise<unknown>;
 };
+
+export type SendReactionParams = {
+  channel?: ChannelReactionLike | null;
+  cid?: string;
+  messageId: string | number;
+  type: string;
+  message?: Record<string, unknown> | LocalMessage | null;
+  user?: ReactionUser | null;
+  userId?: string | number | null;
+  score?: number | null;
+  now?: Date;
+};
+
+export type SendReactionResult = { message: Record<string, unknown> };
 
 export type DeleteReactionParams = {
   channel?: ChannelReactionLike | null;
@@ -2822,6 +2838,120 @@ const removeFirstReaction = (
   return { list: consumed ? next : list, removed };
 };
 
+const addReactionToList = (
+  list: ReactionResponseLike[],
+  reaction: ReactionResponseLike,
+): ReactionResponseLike[] => {
+  const reactionType = typeof reaction.type === "string" ? reaction.type : undefined;
+  const reactionUserId =
+    normalizeUserId(reaction.user_id) ??
+    normalizeUserId((reaction.user as ReactionUserLike | undefined)?.id);
+
+  const next: ReactionResponseLike[] = [];
+  for (const existing of list) {
+    if (
+      reactionType &&
+      reactionUserId &&
+      typeof existing.type === "string" &&
+      existing.type === reactionType
+    ) {
+      const existingUserId =
+        normalizeUserId(existing.user_id) ??
+        normalizeUserId((existing.user as ReactionUserLike | undefined)?.id);
+      if (existingUserId === reactionUserId) {
+        continue;
+      }
+    }
+
+    next.push(existing);
+  }
+
+  next.unshift({ ...reaction });
+
+  return next;
+};
+
+const incrementReactionCounts = (
+  countsSource: unknown,
+  type: string,
+): { next: ReactionCountsRecord; changed: boolean } => {
+  const base = isRecord(countsSource)
+    ? ({ ...(countsSource as ReactionCountsRecord) } as ReactionCountsRecord)
+    : ({} as ReactionCountsRecord);
+  const current = isRecord(countsSource)
+    ? toFiniteNumber((countsSource as ReactionCountsRecord)[type]) ?? 0
+    : 0;
+
+  base[type] = current + 1;
+
+  return { next: base, changed: true };
+};
+
+const incrementReactionScores = (
+  scoresSource: unknown,
+  type: string,
+  score: number,
+): { next: ReactionScoresRecord; changed: boolean } => {
+  const base = isRecord(scoresSource)
+    ? ({ ...(scoresSource as ReactionScoresRecord) } as ReactionScoresRecord)
+    : ({} as ReactionScoresRecord);
+  const current = isRecord(scoresSource)
+    ? toFiniteNumber((scoresSource as ReactionScoresRecord)[type]) ?? 0
+    : 0;
+
+  base[type] = current + score;
+
+  return { next: base, changed: true };
+};
+
+const incrementReactionGroups = (
+  groupsSource: unknown,
+  type: string,
+  score: number,
+  timestamp: string,
+): { next: Record<string, ReactionGroupRecord>; changed: boolean } => {
+  const record = isRecord(groupsSource)
+    ? (groupsSource as Record<string, unknown>)
+    : undefined;
+
+  const nextGroups: Record<string, ReactionGroupRecord> = record
+    ? { ...(record as Record<string, ReactionGroupRecord>) }
+    : {};
+
+  const rawGroup = record && isRecord(record[type])
+    ? (record[type] as ReactionGroupRecord)
+    : undefined;
+
+  const currentCount = rawGroup ? toFiniteNumber(rawGroup.count) ?? 0 : 0;
+  const nextGroup: ReactionGroupRecord = rawGroup
+    ? { ...(rawGroup as ReactionGroupRecord) }
+    : {};
+
+  const nextCount = currentCount + 1;
+  nextGroup.count = nextCount;
+
+  if (
+    !("first_reaction_at" in nextGroup) ||
+    typeof (nextGroup as { first_reaction_at?: unknown }).first_reaction_at !== "string"
+  ) {
+    nextGroup.first_reaction_at = timestamp;
+  }
+  nextGroup.last_reaction_at = timestamp;
+
+  const currentSum = rawGroup && rawGroup.sum_scores !== undefined
+    ? toFiniteNumber(rawGroup.sum_scores)
+    : null;
+  const sumBase = currentSum ?? currentCount;
+  const nextSum = sumBase + score;
+  if (Number.isFinite(nextSum)) {
+    nextGroup.sum_scores = nextSum;
+  }
+
+  nextGroups[type] = nextGroup;
+
+  return { next: nextGroups, changed: true };
+};
+
 const updateReactionCounts = (
   countsSource: unknown,
   type: string,
@@ -3033,6 +3163,164 @@ export async function queryReactions({
 
   return toQueryReactionsResult(fallbackResponse) ?? { reactions: [] };
 }
+
+export const sendReaction = async ({
+  channel,
+  cid,
+  message,
+  messageId,
+  type,
+  user,
+  userId,
+  score,
+  now,
+}: SendReactionParams): Promise<SendReactionResult> => {
+  const normalizedId =
+    normalizeMessageId(messageId) ??
+    normalizeMessageId((message as { id?: unknown } | null | undefined)?.id);
+
+  if (!normalizedId) {
+    throw new Error("Invalid message id provided to sendReaction");
+  }
+
+  const baseMessage =
+    (message && typeof message === "object" ? (message as Record<string, unknown>) : undefined) ??
+    findMessageById(channel, normalizedId);
+
+  const workingMessage: Record<string, unknown> = baseMessage
+    ? { ...baseMessage }
+    : { id: normalizedId };
+
+  const messageCid =
+    typeof workingMessage.cid === "string"
+      ? workingMessage.cid
+      : typeof channel?.cid === "string"
+        ? channel.cid
+        : typeof cid === "string"
+          ? cid
+          : undefined;
+  if (messageCid) {
+    workingMessage.cid = messageCid;
+  }
+  workingMessage.id = normalizedId;
+
+  const reactionUser =
+    cloneReactionUser(user as ReactionUserLike | undefined) ??
+    cloneReactionUser(channel?.getClient?.()?.user as ReactionUserLike | undefined);
+
+  const resolvedUserId =
+    normalizeUserId(userId) ??
+    normalizeUserId((user as ReactionUserLike | undefined)?.id) ??
+    normalizeUserId(reactionUser?.id) ??
+    normalizeUserId(channel?.getClient?.()?.user?.id);
+
+  const timestamp = resolveDate(now).toISOString();
+  const reactionScore =
+    typeof score === "number" && Number.isFinite(score) ? score : 1;
+
+  const reactionPayload: ReactionResponseLike = {
+    type,
+    user: reactionUser,
+    user_id: resolvedUserId,
+    message_id: normalizedId,
+    score: reactionScore,
+    created_at: timestamp,
+  };
+
+  const ownList = toReactionList((baseMessage as { own_reactions?: unknown })?.own_reactions);
+  workingMessage.own_reactions = addReactionToList(ownList, reactionPayload);
+
+  const latestList = toReactionList(
+    (baseMessage as { latest_reactions?: unknown })?.latest_reactions,
+  );
+  workingMessage.latest_reactions = addReactionToList(latestList, reactionPayload);
+
+  const countsUpdate = incrementReactionCounts(
+    (baseMessage as { reaction_counts?: unknown })?.reaction_counts,
+    type,
+  );
+  if (countsUpdate.next) {
+    workingMessage.reaction_counts = countsUpdate.next;
+  }
+
+  const scoresUpdate = incrementReactionScores(
+    (baseMessage as { reaction_scores?: unknown })?.reaction_scores,
+    type,
+    reactionScore,
+  );
+  if (scoresUpdate.next) {
+    workingMessage.reaction_scores = scoresUpdate.next;
+  }
+
+  const groupsUpdate = incrementReactionGroups(
+    (baseMessage as { reaction_groups?: unknown })?.reaction_groups,
+    type,
+    reactionScore,
+    timestamp,
+  );
+  if (groupsUpdate.next) {
+    workingMessage.reaction_groups = groupsUpdate.next;
+  }
+
+  let normalizedMessage: Record<string, unknown>;
+  if (channel) {
+    try {
+      normalizedMessage = await loadMessageIntoChannelState(channel as any, workingMessage);
+    } catch {
+      normalizedMessage = { ...workingMessage };
+    }
+  } else {
+    normalizedMessage = { ...workingMessage };
+  }
+
+  const eventPayload: Record<string, unknown> = {
+    type: "reaction.new",
+    message: normalizedMessage,
+  };
+
+  const eventCid =
+    typeof channel?.cid === "string"
+      ? channel.cid
+      : typeof cid === "string"
+        ? cid
+        : normalizeMessageId((normalizedMessage as { cid?: unknown })?.cid);
+  if (eventCid) {
+    eventPayload.cid = eventCid;
+  }
+
+  const eventReaction: Record<string, unknown> = {
+    type,
+    message_id: normalizedMessage.id ?? normalizedId,
+    created_at: timestamp,
+    score: reactionScore,
+  };
+  if (resolvedUserId) {
+    eventReaction.user_id = resolvedUserId;
+  }
+  if (reactionUser) {
+    eventReaction.user = { ...reactionUser };
+  }
+
+  eventPayload.reaction = eventReaction;
+
+  if (channel && typeof channel.emit === "function") {
+    channel.emit("reaction.new", eventPayload);
+  }
+
+  const client = channel?.getClient?.();
+  if (
+    client &&
+    typeof (client as { emit?: (event: string, payload: Record<string, unknown>) => void }).emit ===
+      "function"
+  ) {
+    (client as { emit: (event: string, payload: Record<string, unknown>) => void }).emit(
+      "reaction.new",
+      eventPayload,
+    );
+  }
+
+  return { message: normalizedMessage };
+};
 
 export const deleteReaction = async ({
   channel,
@@ -4713,6 +5001,7 @@ export const chatAPI = {
   },
   pinMessage,
   flagMessage,
+  sendReaction,
   deleteReaction,
   sendAction,
   queryReactions,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -41,6 +41,8 @@ import {
   type QueryAnswersPoll as QueryAnswersAPIPoll,
   type QueryAnswersResult as QueryAnswersAPIResult,
   type SendActionResult,
+  type SendReactionParams,
+  type SendReactionResult,
   type SyncUserRequest,
   type SyncUserResponse,
   type RemindersScheduledOffsetsMsParams,
@@ -2390,18 +2392,16 @@ export async function unpinMessage(messageId: string): Promise<void> {
 
 export async function sendReaction(
   messageId: string,
-  type: string,
-): Promise<any> {
-  const resp = await fetch(
-    `/api/messages/${encodeURIComponent(messageId)}/reactions/`,
-    {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type }),
-    },
-  );
-  return resp.json();
+  reactionType: string,
+  options?: Partial<
+    Pick<SendReactionParams, 'channel' | 'cid' | 'message' | 'user' | 'userId' | 'score' | 'now'>
+  >,
+): Promise<SendReactionResult> {
+  return chatAPI.sendReaction({
+    messageId,
+    type: reactionType,
+    ...(options ?? {}),
+  });
 }
 
 export async function sendAction(

--- a/libs/stream-chat-shim/src/components/Message/hooks/useReactionHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/useReactionHandler.ts
@@ -8,7 +8,6 @@ import { useChannelStateContext } from '../../../context/ChannelStateContext';
 import { useChatContext } from '../../../context/ChatContext';
 
 import type { LocalMessage, ReactionResponse } from 'chat-shim';
-import { sendReaction } from '../../../chatSDKShim';
 import { chatAPI } from '../../../api/chatAPI';
 
 export const reactionHandlerWarning = `Reaction handler was called, but it is missing one of its required arguments.
@@ -90,7 +89,15 @@ export const useReactionHandler = (message?: LocalMessage) => {
       thread?.upsertReplyLocally({ message: tempMessage });
 
       const messageResponse = add
-        ? await sendReaction(id, type)
+        ? await chatAPI.sendReaction({
+            channel,
+            cid: channel.cid,
+            messageId: id,
+            message,
+            type,
+            user: client.user ?? undefined,
+            userId: client.userID ?? client.user?.id,
+          })
         : await chatAPI.deleteReaction({
             channel,
             cid: channel.cid,

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -680,8 +680,8 @@
     "operationId": "shim::sendReaction",
     "stubName": "sendReaction",
     "ticketType": "shim",
-    "todoCount": 1,
-    "status": "missing"
+    "todoCount": 0,
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a typed chatAPI.sendReaction helper that normalizes reactions, updates local state, and emits shim events
- route the message reaction handler and chatSDKShim wrapper through the new helper
- refresh the sendReaction unit test and mark the wireup manifest entry as complete

## Testing
- pnpm exec jest --runTestsByPath libs/stream-chat-shim/__tests__/sendReaction.test.ts *(fails: TypeScript configuration errors around missing chat-shim typings and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d8728d285c8326b247da35f3d1f7bf