### PR TITLE
feat(stopAIResponse): wire up shim-only helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -39,6 +39,62 @@ import type {
 } from '../chatSDKShim';
 import type { EventTargetLike } from '../client';
 
+type ChannelWithEmitter = Channel & {
+  emit?: (eventType: string, payload: Record<string, unknown>) => void;
+  aiResponseAbortController?: AbortController;
+};
+
+const activeAIResponseControllers = new Map<string, AbortController>();
+
+export const trackAIResponseAbortController = (
+  cid: string,
+  controller: AbortController,
+): void => {
+  activeAIResponseControllers.set(cid, controller);
+};
+
+const takeActiveAIResponseController = (
+  cid: string,
+  channel?: ChannelWithEmitter,
+): AbortController | undefined => {
+  const registered = activeAIResponseControllers.get(cid);
+  if (registered) {
+    activeAIResponseControllers.delete(cid);
+    return registered;
+  }
+
+  const candidate = channel?.aiResponseAbortController;
+  if (candidate instanceof AbortController) {
+    delete channel.aiResponseAbortController;
+    return candidate;
+  }
+
+  return undefined;
+};
+
+const getChannelByCid = (cid: string): ChannelWithEmitter | undefined => {
+  if (!cid) return undefined;
+
+  const client = getLocalClient() as
+    | (StreamChat & {
+        state?: { channels?: Map<string, ChannelWithEmitter> };
+        activeChannels?: Record<string, ChannelWithEmitter>;
+      })
+    | undefined;
+
+  const fromState = client?.state?.channels?.get?.(cid);
+  if (fromState) {
+    return fromState as ChannelWithEmitter;
+  }
+
+  const fromActive = client?.activeChannels?.[cid];
+  if (fromActive) {
+    return fromActive;
+  }
+
+  return undefined;
+};
+
 export type {
   ClientEventHandler,
   ClientKnownEvent,
@@ -4940,6 +4996,37 @@ const resolveNotificationsStore = ({
   };
 };
 
+const emitAIIndicatorClear = (
+  cid: string,
+  channel?: ChannelWithEmitter,
+): void => {
+  const payload: Record<string, unknown> = { type: 'ai_indicator.clear', cid };
+
+  if (channel?.id) {
+    payload.channel_id = channel.id;
+  }
+  if (channel?.type) {
+    payload.channel_type = channel.type;
+  }
+
+  channel?.emit?.('ai_indicator.clear', payload);
+};
+
+async function stopAIResponse(cid: string): Promise<void> {
+  if (typeof cid !== 'string' || !cid) {
+    return;
+  }
+
+  const channel = getChannelByCid(cid);
+  const controller = takeActiveAIResponseController(cid, channel);
+
+  if (controller && !controller.signal.aborted) {
+    controller.abort();
+  }
+
+  emitAIIndicatorClear(cid, channel);
+}
+
 export const chatAPI = {
   channel: {
     countUnread: channelCountUnread,
@@ -4996,6 +5083,7 @@ export const chatAPI = {
     scheduledOffsetsMs: remindersScheduledOffsetsMs,
     deleteReminder,
   },
+  stopAIResponse,
   notifications: {
     store: resolveNotificationsStore,
   },

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -2777,8 +2777,15 @@ export async function search(
 }
 
 export async function stopAIResponse(channel?: {
+  cid?: string;
   stopAIResponse?: () => Promise<void>;
 }): Promise<void> {
+  const cid = channel?.cid;
+  if (typeof cid === 'string' && cid) {
+    await chatAPI.stopAIResponse(cid);
+    return;
+  }
+
   await channel?.stopAIResponse?.();
 }
 

--- a/libs/stream-chat-shim/src/components/MessageInput/MessageInputFlat.tsx
+++ b/libs/stream-chat-shim/src/components/MessageInput/MessageInputFlat.tsx
@@ -30,7 +30,7 @@ import { useComponentContext } from '../../context/ComponentContext';
 import { useAttachmentManagerState } from './hooks/useAttachmentManagerState';
 import { useMessageContext } from '../../context';
 import { WithDragAndDropUpload } from './WithDragAndDropUpload';
-import { stopAIResponse } from '../../chatSDKShim';
+import { chatAPI } from '../../api/chatAPI';
 
 export const MessageInputFlat = () => {
   const { message } = useMessageContext();
@@ -62,8 +62,9 @@ export const MessageInputFlat = () => {
   const { aiState } = useAIState(channel);
 
   const stopGenerating = useCallback(() => {
-    stopAIResponse(channel);
-  }, [channel]);
+    if (!channel?.cid) return;
+    void chatAPI.stopAIResponse(channel.cid);
+  }, [channel?.cid]);
 
   const [
     showRecordingPermissionDeniedNotification,

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -689,8 +689,8 @@
     "operationId": "shim::stopAIResponse",
     "stubName": "stopAIResponse",
     "ticketType": "shim",
-    "todoCount": 1,
-    "status": "missing"
+    "todoCount": 0,
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- implement a local AI response cancellation registry in `chatAPI`, expose a `stopAIResponse` helper, and emit `ai_indicator.clear` when invoked
- delegate the shim `stopAIResponse` wrapper to the new API helper and update the message input to call it via channel `cid`
- mark the stopAIResponse entry in the wireup manifest as complete

## Testing
- `pnpm --filter frontend lint` *(fails: missing Next.js binary in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d8774028608326a8035e96ce69647b