### PR TITLE
feat(stopTyping): wire up shim-only stopTyping

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -5027,6 +5027,10 @@ async function stopAIResponse(cid: string): Promise<void> {
   emitAIIndicatorClear(cid, channel);
 }
 
+async function stopTyping(): Promise<void> {
+  await chatSDKShim.stopTyping();
+}
+
 export const chatAPI = {
   channel: {
     countUnread: channelCountUnread,
@@ -5084,6 +5088,7 @@ export const chatAPI = {
     deleteReminder,
   },
   stopAIResponse,
+  stopTyping,
   notifications: {
     store: resolveNotificationsStore,
   },

--- a/libs/stream-chat-shim/src/components/MessageInput/hooks/useSubmitHandler.ts
+++ b/libs/stream-chat-shim/src/components/MessageInput/hooks/useSubmitHandler.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { MessageComposer } from 'chat-shim';
 import { useMessageComposer } from './useMessageComposer';
+import { chatAPI } from '../../../api/chatAPI';
 import { useChannelActionContext } from '../../../context/ChannelActionContext';
 import { useTranslationContext } from '../../../context/TranslationContext';
-import { stopTyping } from 'chat-shim/typing'
 
 import type { MessageInputProps } from '../MessageInput';
 
@@ -79,7 +79,7 @@ export const useSubmitHandler = (props: MessageInputProps) => {
           // if (messageComposer.config.text.publishTypingEvents)
           if (messageComposer.config.text.publishTypingEvents) {
             // safe no-op today; real SDK call tomorrow
-            await stopTyping();
+            await chatAPI.stopTyping();
           }          
         } catch (err) {
           restoreComposerStateSnapshot();

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -699,7 +699,7 @@
     "stubName": "stopTyping",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   },
   {
     "method": "",


### PR DESCRIPTION
## Summary
- add a shim-level chatAPI.stopTyping helper and expose it via the chat API surface
- route the message submit handler through chatAPI.stopTyping when publishing typing events
- mark the stopTyping wire-up ticket as complete in the wireup manifest

## Testing
- pnpm --filter stream-chat-shim run test

------
https://chatgpt.com/codex/tasks/task_e_68d891c027508326a23e33965e5087d3