### PR TITLE
feat: add threads.unregisterSubscriptions shim helper

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -7,6 +7,7 @@ import {
   loadMessageIntoChannelState,
   pollsFromState as pollsFromStateShim,
   pollsUnregisterSubscriptions as pollsUnregisterSubscriptionsShim,
+  threadsUnregisterSubscriptions as threadsUnregisterSubscriptionsShim,
   remindersInitTimers as remindersInitTimersShim,
   remindersClearTimers as remindersClearTimersShim,
   remindersUnregisterSubscriptions as remindersUnregisterSubscriptionsShim,
@@ -1178,6 +1179,30 @@ export const queryOptionVotes = async ({
   }
 
   return responseData;
+};
+
+type ThreadsSubscriptionsClient = {
+  threads?: { unregisterSubscriptions?: () => void };
+};
+
+export type ThreadsUnregisterSubscriptionsParams = {
+  client?: ThreadsSubscriptionsClient | StreamChat | null;
+};
+
+const toThreadsSubscriptionsClient = (
+  client: ThreadsUnregisterSubscriptionsParams['client'],
+): ThreadsSubscriptionsClient | undefined => {
+  if (!client) return undefined;
+  if (typeof client === 'object') {
+    return client as ThreadsSubscriptionsClient;
+  }
+  return undefined;
+};
+
+const threadsUnregisterSubscriptions = async ({
+  client,
+}: ThreadsUnregisterSubscriptionsParams = {}): Promise<void> => {
+  threadsUnregisterSubscriptionsShim(toThreadsSubscriptionsClient(client));
 };
 
 type PollsSubscriptionsClient = {
@@ -5066,6 +5091,9 @@ export const chatAPI = {
       state: ({ cid, limit, before }: ClientThreadsStateParams) =>
         clientThreadsState({ cid, limit, before }),
     },
+  },
+  threads: {
+    unregisterSubscriptions: threadsUnregisterSubscriptions,
   },
   polls: {
     unregisterSubscriptions: pollsUnregisterSubscriptions,

--- a/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
+++ b/libs/stream-chat-shim/src/components/Chat/hooks/useChat.ts
@@ -73,7 +73,7 @@ export const useChat = ({
     void chatAPI.reminders.initTimers({ client });
 
     return () => {
-      client.threads.unregisterSubscriptions();
+      void chatAPI.threads.unregisterSubscriptions({ client });
       void chatAPI.polls.unregisterSubscriptions({ client });
       void chatAPI.reminders.unregisterSubscriptions({ client });
       void chatAPI.reminders.clearTimers({ client });


### PR DESCRIPTION
## Summary
- add a typed chatAPI.threads.unregisterSubscriptions helper that unwraps the client shim
- update the chat hook cleanup to invoke the new helper instead of the direct client call

## Testing
- pnpm --filter frontend test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8969b87cc832687ce271c567f582a