### PR TITLE
feat: wire up shim unpinMessage

### DIFF
--- a/libs/stream-chat-shim/src/api/chatAPI.ts
+++ b/libs/stream-chat-shim/src/api/chatAPI.ts
@@ -2726,6 +2726,20 @@ export type PinMessageResult = {
   message: Record<string, unknown>;
 };
 
+export type UnpinMessageParams = {
+  channel?: ChannelPinLike | null;
+  cid?: string | null;
+  messageId: string | number;
+  message?: Record<string, unknown> | null;
+  now?: Date;
+};
+
+export type UnpinMessageResult = {
+  pinned: false;
+  at: string;
+  message: Record<string, unknown>;
+};
+
 const normalizeMessageId = (value: unknown): string | undefined => {
   if (typeof value === "string" && value) {
     return value;
@@ -3841,6 +3855,126 @@ export const pinMessage = async ({
 
   return {
     pinned: true as const,
+    at: timestamp.toISOString(),
+    message: normalizedMessage,
+  };
+};
+
+export const unpinMessage = async ({
+  channel,
+  cid,
+  message,
+  messageId,
+  now,
+}: UnpinMessageParams): Promise<UnpinMessageResult> => {
+  const normalizedId =
+    normalizeMessageId(messageId) ??
+    normalizeMessageId((message as { id?: unknown } | null | undefined)?.id);
+
+  if (!normalizedId) {
+    throw new Error("Invalid message id provided to unpinMessage");
+  }
+
+  const baseMessage =
+    (message && typeof message === "object" ? (message as Record<string, unknown>) : undefined) ??
+    findMessageById(channel, normalizedId);
+
+  const workingMessage: Record<string, unknown> = baseMessage
+    ? { ...baseMessage }
+    : { id: normalizedId };
+
+  workingMessage.id = normalizedId;
+
+  const resolvedChannel = channel ?? undefined;
+
+  const resolvedCid =
+    (typeof workingMessage.cid === "string" && workingMessage.cid) ??
+    (typeof resolvedChannel?.cid === "string" ? resolvedChannel.cid : undefined) ??
+    (typeof cid === "string" ? cid : undefined);
+
+  if (resolvedCid) {
+    workingMessage.cid = resolvedCid;
+  }
+
+  const timestamp = resolveDate(now);
+
+  workingMessage.pinned = false;
+  workingMessage.pinned_at = null;
+  workingMessage.pinned_by = null;
+  workingMessage.pin_expires = null;
+
+  let normalizedMessage: Record<string, unknown>;
+  if (resolvedChannel) {
+    try {
+      normalizedMessage = await loadMessageIntoChannelState(
+        resolvedChannel as any,
+        workingMessage,
+      );
+    } catch {
+      normalizedMessage = { ...workingMessage };
+    }
+  } else {
+    normalizedMessage = { ...workingMessage };
+  }
+
+  normalizedMessage.pinned = false;
+  normalizedMessage.pinned_at = null;
+  normalizedMessage.pin_expires = null;
+  normalizedMessage.pinned_by = null;
+
+  if (resolvedChannel) {
+    applyChannelUnpinLocally(resolvedChannel);
+
+    const state = resolvedChannel.state;
+    if (isRecord(state)) {
+      const rawPinned = state.pinnedMessages;
+      if (Array.isArray(rawPinned)) {
+        const nextPinned = rawPinned.filter((item) => {
+          if (!item || typeof item !== "object") {
+            return true;
+          }
+          const record = item as Record<string, unknown>;
+          const candidateId = normalizeMessageId((record as { id?: unknown }).id);
+          return candidateId !== normalizedId;
+        });
+
+        if (nextPinned.length !== rawPinned.length) {
+          (state as Record<string, unknown>).pinnedMessages = nextPinned;
+          resolvedChannel.stateStore?.dispatch?.({ pinnedMessages: nextPinned });
+        }
+      }
+    }
+  }
+
+  const eventPayload: Record<string, unknown> = {
+    type: "message.updated",
+    message: normalizedMessage,
+  };
+
+  if (resolvedCid) {
+    eventPayload.cid = resolvedCid;
+  }
+
+  if (resolvedChannel && typeof resolvedChannel.emit === "function") {
+    resolvedChannel.emit("message.updated", eventPayload);
+  }
+
+  const client = resolvedChannel?.getClient?.();
+  if (client) {
+    if (typeof (client as { emit?: unknown }).emit === "function") {
+      (client as { emit: (event: string, payload: Record<string, unknown>) => void }).emit(
+        "message.updated",
+        eventPayload,
+      );
+    } else if (typeof (client as { dispatchEvent?: unknown }).dispatchEvent === "function") {
+      (client as { dispatchEvent: (event: Record<string, unknown>) => void }).dispatchEvent(
+        eventPayload,
+      );
+    }
+  }
+
+  return {
+    pinned: false as const,
     at: timestamp.toISOString(),
     message: normalizedMessage,
   };
@@ -5121,6 +5255,7 @@ export const chatAPI = {
     store: resolveNotificationsStore,
   },
   pinMessage,
+  unpinMessage,
   flagMessage,
   sendReaction,
   deleteReaction,

--- a/libs/stream-chat-shim/src/chatSDKShim.ts
+++ b/libs/stream-chat-shim/src/chatSDKShim.ts
@@ -37,6 +37,7 @@ import {
   type UserAgentInfo,
   type ChannelUnpinResult,
   type PinMessageResult,
+  type UnpinMessageResult,
   type QueryAnswersParams as QueryAnswersAPIParams,
   type QueryAnswersPoll as QueryAnswersAPIPoll,
   type QueryAnswersResult as QueryAnswersAPIResult,
@@ -2383,10 +2384,41 @@ export async function pinMessage(
   });
 }
 
-export async function unpinMessage(messageId: string): Promise<void> {
-  await fetch(`/api/messages/${encodeURIComponent(messageId)}/unpin/`, {
-    method: 'DELETE',
-    credentials: 'same-origin',
+type UnpinMessageOptions = {
+  channel?: Channel | null;
+  message?: Record<string, unknown> | null;
+  cid?: string | null;
+  now?: Date;
+};
+
+export async function unpinMessage(
+  messageId: string,
+  options?: UnpinMessageOptions,
+): Promise<UnpinMessageResult> {
+  const { channel, message, cid, now } = options ?? {};
+
+  const resolvedChannel = channel as
+    | (Channel & { [key: string]: unknown })
+    | undefined;
+
+  const resolvedMessage =
+    message && typeof message === 'object'
+      ? (message as Record<string, unknown>)
+      : undefined;
+
+  const resolvedCid =
+    (typeof cid === 'string' && cid) ??
+    (typeof resolvedChannel?.cid === 'string' ? resolvedChannel.cid : undefined) ??
+    (typeof resolvedMessage?.['cid'] === 'string'
+      ? (resolvedMessage['cid'] as string)
+      : undefined);
+
+  return chatAPI.unpinMessage({
+    messageId,
+    channel: resolvedChannel as any,
+    message: resolvedMessage,
+    cid: resolvedCid ?? null,
+    now,
   });
 }
 

--- a/libs/stream-chat-shim/src/components/Message/hooks/usePinHandler.ts
+++ b/libs/stream-chat-shim/src/components/Message/hooks/usePinHandler.ts
@@ -96,7 +96,7 @@ export const usePinHandler = (
 
         updateMessage(optimisticMessage);
 
-        await unpinMessage(message.id);
+        await unpinMessage(message.id, { channel, message });
       } catch (e) {
         const errorMessage =
           getErrorNotification && validateAndGetMessage(getErrorNotification, [message]);

--- a/openapi/wireup_manifest.json
+++ b/openapi/wireup_manifest.json
@@ -726,6 +726,6 @@
     "stubName": "unpinMessage",
     "ticketType": "shim",
     "todoCount": 1,
-    "status": "missing"
+    "status": "ok"
   }
 ]


### PR DESCRIPTION
## Summary
- add a shim-only `chatAPI.unpinMessage` helper that updates local message and channel state
- route the chat SDK shim and pin handler through the new helper so UI state reflects unpinning
- mark the `shim::unpinMessage` wireup as complete in the manifest

## Testing
- pnpm --filter stream-chat-shim test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d89af14a9883268ff6c292594a62e0