### PR TITLE
Fix assistant display name in chat kit

### DIFF
--- a/frontend/src/app/agent/AgentMessage.tsx
+++ b/frontend/src/app/agent/AgentMessage.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import { MessageSimple, type MessageProps } from '@iliad/stream-chat-shim';
+import { AGENT_DISPLAY_NAME, hasAgentMessageMarker } from '../../lib/stream-adapter/channelAgentExtensions';
 import {
   getSidecarItemById,
   type SidecarItemDef,
@@ -56,8 +57,8 @@ export type AgentMessageProps = MessageProps & {
 };
 
 export function AgentMessage(props: AgentMessageProps) {
-  const { currentUserId: _currentUserId, onFormClick, currentStateSlug, ...messageProps } = props;
-  const { message } = messageProps;
+  const { currentUserId: _currentUserId, onFormClick, currentStateSlug, botUserId, ...baseMessageProps } = props;
+  const { message } = baseMessageProps;
   const router = useRouter();
 
   if (!message) {
@@ -79,8 +80,23 @@ export function AgentMessage(props: AgentMessageProps) {
 
   const authorId = getAuthorId(message);
   const isAgent =
-    (props.botUserId && authorId === props.botUserId) ||
-    Boolean((message as any).custom_data?.ai_generated);
+    (botUserId && authorId === botUserId) ||
+    hasAgentMessageMarker(message as any);
+
+  const messageProps = isAgent
+    ? {
+        ...baseMessageProps,
+        message: {
+          ...(message as any),
+          user_id: (message as any).user_id ?? authorId,
+          user: {
+            ...((message as any).user ?? {}),
+            ...(authorId ? { id: authorId } : {}),
+            name: AGENT_DISPLAY_NAME,
+          },
+        },
+      }
+    : baseMessageProps;
 
   const customData = (message as any)?.custom_data ?? {};
   const rag = customData?.rag as

--- a/frontend/src/app/agent/__tests__/AgentMessage.test.tsx
+++ b/frontend/src/app/agent/__tests__/AgentMessage.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
-import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentMessage } from '../AgentMessage';
 
@@ -9,11 +8,20 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+afterEach(() => cleanup());
+
 vi.mock('@iliad/stream-chat-shim', () => ({
-  MessageSimple: (props: Record<string, unknown>) => (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <div data-testid="message-simple" {...props} />
-  ),
+  MessageSimple: (props: Record<string, unknown>) => {
+    const message = props.message as any;
+    return (
+      <div
+        data-testid="message-simple"
+        data-user-id={message?.user?.id ?? ''}
+        data-user-id-field={message?.user_id ?? ''}
+        data-user-name={message?.user?.name ?? ''}
+      />
+    );
+  },
 }));
 
 describe('AgentMessage', () => {
@@ -33,7 +41,25 @@ describe('AgentMessage', () => {
 
     render(<AgentMessage message={message as any} botUserId="agent-1" />);
 
-    expect(screen.getByRole('button', { name: 'View dashboard' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Go to planner' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View dashboard' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Go to planner' })).toBeTruthy();
   });
+
+  it('passes Iris to MessageSimple for agent messages while preserving user ids', () => {
+    const message = {
+      id: 'message-2',
+      text: 'I can help with that.',
+      user_id: 'ai-bot-room-1',
+      user: { id: 'ai-bot-room-1', name: 'Guest AI-B' },
+      custom_data: { ai_generated: true },
+    };
+
+    render(<AgentMessage message={message as any} botUserId="ai-bot-room-1" />);
+
+    const simple = screen.getByTestId('message-simple');
+    expect(simple.getAttribute('data-user-name')).toBe('Iris');
+    expect(simple.getAttribute('data-user-id')).toBe('ai-bot-room-1');
+    expect(simple.getAttribute('data-user-id-field')).toBe('ai-bot-room-1');
+  });
+
 });

--- a/frontend/src/lib/stream-adapter/__tests__/channelAgentExtensions.test.ts
+++ b/frontend/src/lib/stream-adapter/__tests__/channelAgentExtensions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@iliad/stream-chat-shim', () => ({
+  AIStates: {
+    Thinking: 'AI_STATE_THINKING',
+    Generating: 'AI_STATE_GENERATING',
+    Idle: 'AI_STATE_IDLE',
+  },
+}));
+
+import { resolveDisplayNameForMessage } from '../channelAgentExtensions';
+
+function makeChannel({
+  currentUserId = 'current-user',
+  botUserId = 'ai-bot-room-1',
+  agentEnabled = true,
+}: {
+  currentUserId?: string;
+  botUserId?: string;
+  agentEnabled?: boolean;
+} = {}) {
+  return {
+    agentConfig: agentEnabled
+      ? { enabled: true, botUserId, displayName: 'Assistant' }
+      : { enabled: false, botUserId, displayName: 'Assistant' },
+    getCurrentUserId: vi.fn(() => currentUserId),
+  } as any;
+}
+
+describe('resolveDisplayNameForMessage', () => {
+  it('returns Iris when the author id matches the botUserId', () => {
+    const channel = makeChannel({ botUserId: 'ai-bot-room-1' });
+
+    expect(
+      resolveDisplayNameForMessage(channel, {
+        id: 'm1',
+        text: 'Hello',
+        user_id: 'ai-bot-room-1',
+        created_at: '2026-01-01T00:00:00Z',
+        user: { id: 'ai-bot-room-1', name: 'Guest AI-B' },
+      } as any),
+    ).toBe('Iris');
+  });
+
+  it('returns Iris for custom_data.ai_generated messages without a botUserId match', () => {
+    const channel = makeChannel({ botUserId: 'ai-bot-room-1' });
+
+    expect(
+      resolveDisplayNameForMessage(channel, {
+        id: 'm2',
+        text: 'Generated answer',
+        user_id: 'assistant-shadow-id',
+        created_at: '2026-01-01T00:00:00Z',
+        custom_data: { ai_generated: true },
+      } as any),
+    ).toBe('Iris');
+  });
+
+  it('returns You for the current user', () => {
+    const channel = makeChannel({ currentUserId: 'human-1' });
+
+    expect(
+      resolveDisplayNameForMessage(channel, {
+        id: 'm3',
+        text: 'My message',
+        user_id: 'human-1',
+        created_at: '2026-01-01T00:00:00Z',
+      } as any),
+    ).toBe('You');
+  });
+
+  it('keeps the guest fallback for true non-bot guests', () => {
+    const channel = makeChannel({ currentUserId: 'human-1', botUserId: 'ai-bot-room-1' });
+
+    expect(
+      resolveDisplayNameForMessage(channel, {
+        id: 'm4',
+        text: 'Guest message',
+        user_id: 'guest-b531',
+        created_at: '2026-01-01T00:00:00Z',
+      } as any),
+    ).toBe('Guest GUES');
+  });
+});

--- a/frontend/src/lib/stream-adapter/channelAgentExtensions.ts
+++ b/frontend/src/lib/stream-adapter/channelAgentExtensions.ts
@@ -72,18 +72,39 @@ export function getBotUserIdForChannel(channel: Channel): string | null {
 
 
 
+export const AGENT_DISPLAY_NAME = 'Iris';
+
+export function hasAgentMessageMarker(message: Message | Record<string, any> | null | undefined) {
+    const customData = (message as any)?.custom_data ?? {};
+
+    return Boolean(
+        (message as any)?.ai_generated ||
+        customData.ai_generated ||
+        customData.ai_state ||
+        customData.agent,
+    );
+}
+
 export function resolveDisplayNameForMessage(channel: Channel, message: Message) {
     const user = (message as any).user ?? {};
     const authorId = user.id ?? (message as any).user_id ?? (message as any).sent_by;
     const botUserId = getBotUserIdForChannel(channel);
     const currentUserId = (channel as any).getCurrentUserId();
 
+    if (user.name === 'System' || authorId === 'system') {
+        return 'System';
+    }
+
     if (authorId && botUserId && authorId === botUserId) {
-        return 'AI assistant';
+        return AGENT_DISPLAY_NAME;
     }
 
     if (currentUserId && authorId === currentUserId) {
         return 'You';
+    }
+
+    if (hasAgentMessageMarker(message)) {
+        return AGENT_DISPLAY_NAME;
     }
 
     if (user.name) {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,14 @@
+import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@iliad/stream-chat-shim': path.resolve(__dirname, '../libs/stream-chat-shim/src'),
+      '@iliad/stream-chat-shim/': `${path.resolve(__dirname, '../libs/stream-chat-shim/src')}/`,
+      'chat-shim': path.resolve(__dirname, '../libs/chat-shim'),
+    },
+  },
   test: {
     setupFiles: './vitest.setup.ts',
     environment: 'jsdom',


### PR DESCRIPTION
### Motivation
- Agent/bot messages were rendering as vendor fallbacks like "Guest AI-B" or "AI assistant" instead of the product name, causing inconsistent UX.
- Ensure agent identity is normalized to a single human-friendly label everywhere messages are rendered, while preserving current-user, system, and guest behavior.

### Description
- Normalize display-name logic in `frontend/src/lib/stream-adapter/channelAgentExtensions.ts` by adding `AGENT_DISPLAY_NAME = 'Iris'` and `hasAgentMessageMarker()` and returning `Iris` when `authorId === botUserId` or the message has AI markers (`ai_generated`, `custom_data.ai_generated`, `ai_state`, or `agent`), while keeping `You` for current user and `System` for system messages.
- Add a UI-level safeguard in `frontend/src/app/agent/AgentMessage.tsx` that, when a message is detected as an agent, clones the `message` prop for `MessageSimple` and forces `message.user.name = 'Iris'` while preserving `user.id` / `user_id` so Stream's renderer never falls back to guest names.
- Add unit tests: `frontend/src/lib/stream-adapter/__tests__/channelAgentExtensions.test.ts` to cover botUserId match, `custom_data.ai_generated` marker, current-user → `You`, and guest fallback; and update `frontend/src/app/agent/__tests__/AgentMessage.test.tsx` to assert the `MessageSimple` receives `Iris` and preserved ids.
- Add test-time aliases in `frontend/vitest.config.ts` so the local shim imports resolve during Vitest runs.

### Testing
- Ran the focused unit tests with `pnpm --dir frontend exec vitest run src/lib/stream-adapter/__tests__/channelAgentExtensions.test.ts src/app/agent/__tests__/AgentMessage.test.tsx` and the modified tests passed.
- Ran TypeScript check with `pnpm --dir frontend exec tsc --noEmit --pretty false` which failed due to pre-existing, repo-wide typing/shim issues unrelated to this change (not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8b4ef9588326b36a15535b9bba87)