### PR TITLE
Normalize chat chrome contrast for light/dark themes

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -40,3 +40,105 @@ a {
     color-scheme: dark;
   }
 }
+
+/*
+ * Portable chat chrome contrast defaults.
+ *
+ * Keep these colors neutral so the shared chat kit remains usable across sites
+ * without assuming a host brand palette. The Stream shim CSS is imported before
+ * this file, so these rules intentionally normalize only transient chrome
+ * (AI/typing/status/system surfaces), not message content bubbles.
+ */
+.str-chat {
+  --jatte-chat-chrome-bg: #f3f4f6;
+  --jatte-chat-chrome-border: #d1d5db;
+  --jatte-chat-chrome-text: #1f2937;
+  --jatte-chat-chrome-muted-text: #374151;
+  --jatte-chat-chrome-hover-bg: #e5e7eb;
+}
+
+.str-chat__theme-light {
+  --jatte-chat-chrome-bg: #f3f4f6;
+  --jatte-chat-chrome-border: #d1d5db;
+  --jatte-chat-chrome-text: #1f2937;
+  --jatte-chat-chrome-muted-text: #374151;
+  --jatte-chat-chrome-hover-bg: #e5e7eb;
+}
+
+.str-chat__theme-dark {
+  --jatte-chat-chrome-bg: #1f2937;
+  --jatte-chat-chrome-border: #374151;
+  --jatte-chat-chrome-text: #f9fafb;
+  --jatte-chat-chrome-muted-text: #d1d5db;
+  --jatte-chat-chrome-hover-bg: #374151;
+}
+
+.str-chat .chat-footer-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 1.75rem;
+  padding: 0 1rem;
+  color: var(--jatte-chat-chrome-muted-text);
+}
+
+.str-chat .str-chat__ai-state-indicator-container {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.5rem;
+  border: 1px solid var(--jatte-chat-chrome-border);
+  border-radius: 999px;
+  background: var(--jatte-chat-chrome-bg);
+  color: var(--jatte-chat-chrome-text);
+}
+
+.str-chat .str-chat__ai-state-indicator-text {
+  margin: 0;
+  color: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+}
+
+.str-chat .str-chat__typing-indicator {
+  --str-chat__typing-indicator-dot-background-color: currentColor;
+
+  background: var(--jatte-chat-chrome-bg);
+  color: var(--jatte-chat-chrome-muted-text);
+  border-block-start: 1px solid var(--jatte-chat-chrome-border);
+}
+
+.str-chat .str-chat__typing-indicator__dot {
+  background-color: currentColor;
+}
+
+.str-chat .str-chat__message--system,
+.str-chat .str-chat__date-separator {
+  color: var(--jatte-chat-chrome-muted-text);
+}
+
+.str-chat .chat-footer-status-row .str-chat__stop-ai-generation-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--jatte-chat-chrome-border);
+  border-radius: 999px;
+  background: var(--jatte-chat-chrome-bg);
+  color: var(--jatte-chat-chrome-text);
+  cursor: pointer;
+}
+
+.str-chat .chat-footer-status-row .str-chat__stop-ai-generation-button:hover {
+  background: var(--jatte-chat-chrome-hover-bg);
+}
+
+.str-chat .chat-footer-status-row .str-chat__stop-ai-generation-button::before {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 0.125rem;
+  background: currentColor;
+  content: "";
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
-import "./globals.css";
-
 import '@iliad/stream-chat-shim/dist/css/v2/index.css'; // ← v1 if you prefer
+import "./globals.css";
 
 import { SessionProvider } from "@/lib/SessionProvider";
 import AuthBootstrap from "./AuthBootstrap";

--- a/frontend/src/lib/AgentChatWindow.tsx
+++ b/frontend/src/lib/AgentChatWindow.tsx
@@ -185,16 +185,7 @@ export default function AgentChatWindow({ Avatar }: AgentChatWindowProps) {
                 )}
               />
               <TypingIndicator />
-              <div
-                className="chat-footer-status-row"
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 8,
-                  padding: '0 16px',
-                  minHeight: 28,
-                }}
-              >
+              <div className="chat-footer-status-row">
                 {isAgentBusy && <StopAIGenerationButton onClick={handleStopAgent} />}
                 <AIStateIndicator />
               </div>


### PR DESCRIPTION
### Motivation
- Make transient chat chrome (AI status / generating, typing indicators, stop-generation control, system/date separators, footer status row) legible in both light and dark themes without changing message content styling. 
- Keep defaults neutral and portable across hosts, and avoid modifying vendor Stream UI sources.

### Description
- Load the vendored Stream shim CSS before app globals to allow app-level overrides to apply without editing vendor files (`frontend/src/app/layout.tsx`).
- Add neutral, theme-aware CSS tokens and overrides scoped to `.str-chat` and `.str-chat__theme-light` / `.str-chat__theme-dark` in `frontend/src/app/globals.css` to improve contrast of AI state pills, typing indicators, system/date separators, and footer/status chrome while preserving message bubble styles.
- Replace inline footer status row styles in the agent UI with the shared `.chat-footer-status-row` class so the new CSS tokens apply (`frontend/src/lib/AgentChatWindow.tsx`).
- Style the stop-generation control as a neutral pill with a current-color stop glyph so it remains readable in both themes and avoids brand colors (`frontend/src/app/globals.css`).

### Testing
- Ran a focused vitest subset: `vitest run src/app/agent/__tests__/AgentMessage.test.tsx src/lib/stream-adapter/__tests__/channelAgentExtensions.test.ts`; both suites passed. 
- Ran `git diff --check` to validate whitespace/format; no issues found.
- Full unit test run (`pnpm --dir frontend test`) was executed; many failing adapter/unit tests surfaced that are unrelated to the visual changes (request URL/header expectations, test typing/mocks), so the failures are pre-existing in the test suite and not introduced by these CSS/markup changes. 
- Typecheck (`pnpm --dir frontend exec tsc --noEmit`) and full `pnpm --dir frontend build` were attempted; both encountered existing project-level type/build issues (test mock typings and a Next.js compile error due to `@supabase/realtime-js` requiring optional server `ws`), so they did not complete successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0baa5297948326bd60d8093bc1ffb8)