### PR TITLE
Security PR2: Harden websocket authentication and event isolation

### DIFF
--- a/backend/SECURITY.md
+++ b/backend/SECURITY.md
@@ -20,3 +20,17 @@ The origin and host variables are comma-separated allowlists; wildcard values
 are rejected. Production TLS is expected to terminate at a proxy that sets
 `X-Forwarded-Proto: https`; this is used only because production settings
 explicitly configure Django to trust that proxy header.
+
+## WebSocket boundary
+
+WebSocket connections require a valid Supabase JWT before the server accepts
+the socket. The active frontend uses `/ws/<cid>/`; `/ws/chat/` remains a
+documented generic compatibility route because backend Stream-parity tests use
+it to select a CID with `channel.watch`. Generic routing does not bypass room
+authorization: watch, message creation, and typing require membership, and send
+or typing additionally require a successful watch on that socket.
+
+Authentication failures close with code 4401. Operation-level authorization
+failures return an error frame so a generic socket may still watch a different
+room it is authorized to access. Global lobby presence is disabled; the
+existing `user.join` acknowledgement is sent only to the connecting socket.

--- a/backend/jatte/tests/urls_security.py
+++ b/backend/jatte/tests/urls_security.py
@@ -2,11 +2,13 @@ from django.urls import path
 
 from stream_server_django.chat import api
 from stream_server_django.chat.views import TokenView
+from stream_server_django.chat.views_auth import WebsocketAuthView
 
 
 urlpatterns = [
     path("api/token/", TokenView.as_view(), name="token-obtain"),
     path("api/ws-auth/", api.ws_auth, name="ws-auth"),
+    path("api/ws-auth/live/", WebsocketAuthView.as_view(), name="ws-auth-live"),
     path("api/connection-id/", api.connection_id, name="connection-id"),
     path("api/editing-audit-state/", api.editing_audit_state, name="editing-audit-state"),
 ]

--- a/backend/stream_server_django/accounts_supabase/authentication.py
+++ b/backend/stream_server_django/accounts_supabase/authentication.py
@@ -4,9 +4,7 @@ import jwt
 from jwt import PyJWKClient
 from jwt.exceptions import (
     PyJWTError,
-    InvalidTokenError,
     ExpiredSignatureError,
-    InvalidSignatureError,
 )
 from django.conf import settings
 from rest_framework import authentication, exceptions
@@ -14,6 +12,66 @@ from django.contrib.auth import get_user_model
 from rest_framework.authentication import SessionAuthentication
 
 User = get_user_model()
+
+
+def decode_supabase_token(token: str) -> dict:
+    """Validate a Supabase JWT using the same rules for HTTP and WebSockets."""
+
+    try:
+        algorithm = jwt.get_unverified_header(token).get("alg")
+        if algorithm == "HS256":
+            return jwt.decode(
+                token,
+                settings.SUPABASE_JWT_SECRET,
+                algorithms=["HS256"],
+                options={"verify_aud": False},
+                leeway=30,
+            )
+        if algorithm == "RS256":
+            jwks_url = settings.SUPABASE_JWKS_URL
+            if not jwks_url:
+                raise exceptions.AuthenticationFailed("Invalid token")
+            signing_key = PyJWKClient(jwks_url).get_signing_key_from_jwt(token)
+            return jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                options={"verify_aud": False},
+                leeway=30,
+            )
+        raise exceptions.AuthenticationFailed("Invalid token algorithm")
+    except ExpiredSignatureError:
+        raise exceptions.AuthenticationFailed("Token expired")
+    except PyJWTError as exc:
+        raise exceptions.AuthenticationFailed(f"Invalid token: {exc}") from exc
+
+
+def resolve_supabase_user(decoded: dict):
+    """Resolve validated JWT claims to the shared Django user identity."""
+
+    uid = decoded.get("sub")
+    if not uid:
+        raise exceptions.AuthenticationFailed("No 'sub' claim found")
+
+    email = decoded.get("email") or ""
+    user, created = User.objects.get_or_create(
+        username=uid,
+        defaults={"email": email, "supabase_uid": uid},
+    )
+    if not created and not user.supabase_uid:
+        user.supabase_uid = uid
+        user.save(update_fields=["supabase_uid"])
+    if email and not user.email:
+        user.email = email
+        user.save(update_fields=["email"])
+    return user
+
+
+def authenticate_supabase_token(token: str):
+    """Validate ``token`` and return the same user REST authentication uses."""
+
+    return resolve_supabase_user(decode_supabase_token(token))
+
 
 class CsrfExemptSessionAuthentication(SessionAuthentication):
     """Deprecated compatibility name; session auth always enforces CSRF.
@@ -39,57 +97,7 @@ class SupabaseJWTAuthentication(authentication.BaseAuthentication):
         except ValueError:
             return None
 
-        try:
-            decoded = jwt.decode(
-                token,
-                settings.SUPABASE_JWT_SECRET,
-                algorithms=["HS256"],
-                options={"verify_aud": False},
-                leeway=30,   # allow 30-second clock skew
-            )
-        except ExpiredSignatureError:
-            raise exceptions.AuthenticationFailed("Token expired")
-        except InvalidSignatureError:
-            jwks_url = settings.SUPABASE_JWKS_URL
-            if not jwks_url:
-                raise exceptions.AuthenticationFailed("Invalid token")
-            try:
-                signing_key = PyJWKClient(jwks_url).get_signing_key_from_jwt(token)
-                decoded = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["RS256"],
-                    options={"verify_aud": False},
-                )
-            except PyJWTError as e:
-                raise exceptions.AuthenticationFailed(f"Invalid token: {e}")
-        except PyJWTError as e:
-            raise exceptions.AuthenticationFailed(f"Invalid token: {e}")
-
-        uid = decoded.get("sub")
-        if not uid:
-            raise exceptions.AuthenticationFailed("No 'sub' claim found")
-
-        email = decoded.get("email") or ""  # anonymous users often have empty email
-        # email = decoded.get("email")
-        # if not email:
-        #     raise exceptions.AuthenticationFailed("No 'email' claim found")
-
-        # Use get_or_create, and ensure supabase_uid is set
-        user, created = User.objects.get_or_create(
-            username=uid,
-            defaults={"email": email, "supabase_uid": uid},
-        )
-        # ensure supabase_uid set
-        if not created and not user.supabase_uid:
-            user.supabase_uid = uid
-            user.save(update_fields=["supabase_uid"])
-
-        # OPTIONAL: if the user later becomes “real” (email login) and email arrives,
-        # populate it once.
-        if email and not user.email:
-            user.email = email
-            user.save(update_fields=["email"])
+        user = authenticate_supabase_token(token)
 
         # Return the original JWT so views can forward it if needed
         return (user, token)

--- a/backend/stream_server_django/chat/consumers.py
+++ b/backend/stream_server_django/chat/consumers.py
@@ -1,12 +1,18 @@
 import logging
 import time
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
+from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from channels.layers import get_channel_layer
 from django.conf import settings
 from urllib.parse import parse_qs
-import jwt
+from rest_framework.exceptions import AuthenticationFailed
+
+from stream_server_django.accounts_supabase.authentication import (
+    authenticate_supabase_token,
+)
+from stream_server_django.rooms.utils import user_has_room_access
 
 from .models import Channel, Message, Room
 from .serializers import MessageSerializer
@@ -17,11 +23,16 @@ from .views import RoomMembersCIDView
 class ChatConsumer(AsyncJsonWebsocketConsumer):
     """Minimal websocket consumer that mirrors Stream's channel API."""
 
-    lobby_group = "ws_chat_lobby"
+    unauthenticated_close_code = 4401
+    # Legacy integration tests use /ws/chat/ as a generic socket. The active
+    # frontend uses room-specific keys. Generic sockets still authorize each
+    # operation and may act only on rooms successfully watched by this client.
+    generic_room_keys = {"chat"}
 
     async def connect(self):
         self.joined_cids: set[str] = set()
-        self.user = "anonymous"
+        self.authenticated_user = None
+        self.user = ""
         self._bucket_capacity = max(1, getattr(settings, "WS_BUCKET_CAPACITY", 30))
         self._bucket_refill_per_sec = max(
             0.0, float(getattr(settings, "WS_BUCKET_REFILL_PER_SEC", 5))
@@ -30,24 +41,31 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         self._bucket_last_refill = time.monotonic()
         query = parse_qs(self.scope.get("query_string", b"").decode())
         token = (query.get("token") or [None])[0]
-        if token:
-            try:
-                decoded = jwt.decode(
-                    token,
-                    settings.SUPABASE_JWT_SECRET,
-                    algorithms=["HS256"],
-                    options={"verify_aud": False},
-                )
-                self.user = decoded.get("sub", "anonymous")
-            except Exception:
-                pass
+        if not token:
+            await self.close(code=self.unauthenticated_close_code)
+            return
+
+        try:
+            self.authenticated_user = await database_sync_to_async(
+                authenticate_supabase_token
+            )(token)
+        except AuthenticationFailed:
+            await self.close(code=self.unauthenticated_close_code)
+            return
+
+        self.user = self.authenticated_user.username
+        route_key = self.scope.get("url_route", {}).get("kwargs", {}).get("room_key")
+        self.route_key = str(route_key or "").strip()
+        self.route_cid = (
+            None
+            if self.route_key in self.generic_room_keys
+            else self._normalize_cid(self.route_key)
+        )
 
         await self.accept()
-        await self.channel_layer.group_add(self.lobby_group, self.channel_name)
-        await self.channel_layer.group_send(
-            self.lobby_group,
-            {"type": "chat.presence", "payload": {"type": "user.join", "user": self.user}},
-        )
+        # Preserve the existing acknowledgement for this client only. Global
+        # lobby presence is intentionally disabled to prevent cross-room leaks.
+        await self.send_json({"type": "user.join", "user": self.user})
 
     async def receive_json(self, content, **kwargs):
         if not self._consume_ws_token():
@@ -82,34 +100,30 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         return False
 
     async def chat_message(self, event):
-        await self.send_json(event["payload"])
+        await self._send_authorized_room_event(event)
 
     async def chat_typing(self, event):
-        await self.send_json(event["payload"])
+        await self._send_authorized_room_event(event)
 
     async def chat_presence(self, event):
-        await self.send_json(event["payload"])
+        await self._send_authorized_room_event(event)
 
     async def disconnect(self, code):
         for cid in list(self.joined_cids):
             await self.channel_layer.group_discard(self._group_name(cid), self.channel_name)
-        await self.channel_layer.group_discard(self.lobby_group, self.channel_name)
-        await self.channel_layer.group_send(
-            self.lobby_group,
-            {"type": "chat.presence", "payload": {"type": "user.leave", "user": self.user}},
-        )
         await super().disconnect(code)
 
     async def _handle_channel_watch(self, content: dict) -> None:
-        cid = self._normalize_cid(content.get("cid"))
+        cid = await self._operation_cid(content)
         if not cid:
-            await self.send_json({"type": "error", "code": "invalid_cid"})
             return
 
         try:
-            messages, next_cursor, members = await sync_to_async(self._room_state)(cid)
-        except Exception:
-            await self.send_json({"type": "error", "code": "state_unavailable", "cid": cid})
+            messages, next_cursor, members = await database_sync_to_async(
+                self._authorized_room_state
+            )(cid)
+        except (Room.DoesNotExist, PermissionError):
+            await self._send_forbidden(cid)
             return
 
         payload = {
@@ -127,13 +141,17 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         self.joined_cids.add(cid)
 
     async def _handle_message_new(self, content: dict) -> None:
-        cid = self._normalize_cid(content.get("cid") or next(iter(self.joined_cids), None))
+        cid = await self._operation_cid(content, require_watched=True)
         if not cid:
             return
 
         text = content.get("text", "")
 
-        await self._create_message(cid, text)
+        try:
+            await database_sync_to_async(self._create_message)(cid, text)
+        except (Room.DoesNotExist, PermissionError):
+            await self._send_forbidden(cid)
+            return
 
         payload = {"type": "message.new", "cid": cid, "text": text, "user": self.user}
         await self.channel_layer.group_send(
@@ -142,36 +160,43 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         )
 
     async def _handle_typing_event(self, msg_type: str, content: dict) -> None:
-        cid = self._normalize_cid(content.get("cid") or next(iter(self.joined_cids), None))
-        group = self._group_name(cid) if cid else self.lobby_group
+        cid = await self._operation_cid(content, require_watched=True)
+        if not cid:
+            return
+        if not await database_sync_to_async(self._can_access_room)(cid):
+            await self._send_forbidden(cid)
+            return
+
+        group = self._group_name(cid)
         payload = {"type": msg_type, "user_id": self.user}
-        if cid:
-            payload["cid"] = cid
+        payload["cid"] = cid
         await self.channel_layer.group_send(
             group,
             {"type": "chat.typing", "payload": payload},
         )
 
-    async def _create_message(self, cid: str, text: str) -> Message:
-        def _create() -> Message:
-            room_uuid = self._room_uuid(cid)
-            channel, _ = Channel.objects.get_or_create(uuid=room_uuid, defaults={"client": "stream"})
-            room, _ = Room.objects.get_or_create(uuid=room_uuid, defaults={"client": "stream"})
-            message = Message.objects.create(channel=channel, body=text, sent_by=self.user)
-            room.messages.add(message)
-            return message
-
-        return await sync_to_async(_create)()
-
-    def _room_state(self, cid: str, message_limit: int = 30, member_limit: int = 50):
+    def _create_message(self, cid: str, text: str) -> Message:
         room_uuid = self._room_uuid(cid)
+        room = Room.objects.get(uuid=room_uuid)
+        if not user_has_room_access(self.authenticated_user, room):
+            raise PermissionError
         channel, _ = Channel.objects.get_or_create(
-            uuid=room_uuid, defaults={"client": "stream"}
+            uuid=room_uuid, defaults={"client": room.client or self.user}
         )
-        room, _ = Room.objects.get_or_create(uuid=room_uuid, defaults={"client": "stream"})
+        message = Message.objects.create(channel=channel, body=text, sent_by=self.user)
+        room.messages.add(message)
+        return message
+
+    def _authorized_room_state(
+        self, cid: str, message_limit: int = 30, member_limit: int = 50
+    ):
+        room_uuid = self._room_uuid(cid)
+        room = Room.objects.get(uuid=room_uuid)
+        if not user_has_room_access(self.authenticated_user, room):
+            raise PermissionError
 
         qs = list(
-            Message.objects.filter(channel=channel).order_by("-id")[: message_limit + 1]
+            room.messages.order_by("-id")[: message_limit + 1]
         )
         has_more = len(qs) > message_limit
         messages = qs[:message_limit]
@@ -184,6 +209,49 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         member_list = list(member_payload[:member_limit])
 
         return message_payload, next_cursor, member_list
+
+    def _can_access_room(self, cid: str) -> bool:
+        try:
+            room = Room.objects.get(uuid=self._room_uuid(cid))
+        except Room.DoesNotExist:
+            return False
+        return user_has_room_access(self.authenticated_user, room)
+
+    async def _operation_cid(
+        self, content: dict, *, require_watched: bool = False
+    ) -> str | None:
+        raw_cid = content.get("cid") or self.route_cid
+        if not raw_cid and require_watched:
+            # Preserve the generic Stream-compatible socket behavior: after a
+            # successful watch, send/typing frames may omit cid. The fallback
+            # is constrained to a room this socket has already authorized.
+            raw_cid = next(iter(self.joined_cids), None)
+        cid = self._normalize_cid(raw_cid) if isinstance(raw_cid, str) else None
+        if not cid:
+            await self.send_json({"type": "error", "code": "invalid_cid"})
+            return None
+        if self.route_cid and cid != self.route_cid:
+            await self.send_json({"type": "error", "code": "cid_mismatch", "cid": cid})
+            return None
+        if require_watched and cid not in self.joined_cids:
+            await self.send_json({"type": "error", "code": "not_watched", "cid": cid})
+            return None
+        return cid
+
+    async def _send_forbidden(self, cid: str) -> None:
+        await self.send_json({"type": "error", "code": "forbidden", "cid": cid})
+
+    async def _send_authorized_room_event(self, event: dict) -> None:
+        """Forward a group event only while this socket remains authorized."""
+
+        payload = event.get("payload") or {}
+        raw_cid = payload.get("cid")
+        cid = self._normalize_cid(raw_cid) if isinstance(raw_cid, str) else None
+        if not cid or cid not in self.joined_cids:
+            return
+        if not await database_sync_to_async(self._can_access_room)(cid):
+            return
+        await self.send_json(payload)
 
     @staticmethod
     def _normalize_cid(cid: str | None) -> str | None:

--- a/backend/stream_server_django/chat/tests/test_supabase_auth.py
+++ b/backend/stream_server_django/chat/tests/test_supabase_auth.py
@@ -1,11 +1,11 @@
 from django.urls import reverse
+from django.test import override_settings
 from rest_framework.test import APITestCase
 from unittest.mock import patch
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 from jwt.utils import base64url_encode
 import jwt
-from django.conf import settings
 
 
 def make_keys():
@@ -22,6 +22,7 @@ def make_keys():
     return priv, {"keys": [jwk]}
 
 
+@override_settings(SUPABASE_JWKS_URL="https://supabase.test/auth/v1/keys")
 class SupabaseAuthAPITests(APITestCase):
     def test_rs256_jwt_via_jwks(self):
         priv, jwks = make_keys()
@@ -41,6 +42,4 @@ class SupabaseAuthAPITests(APITestCase):
             res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data["userID"], 1)
-        payload = jwt.decode(res.data["userToken"], settings.SUPABASE_JWT_SECRET, algorithms=["HS256"])
-        self.assertEqual(payload["user_id"], 1)
-
+        self.assertEqual(res.data["userToken"], token)

--- a/backend/stream_server_django/chat/tests/test_websocket.py
+++ b/backend/stream_server_django/chat/tests/test_websocket.py
@@ -5,7 +5,7 @@ from channels.testing import WebsocketCommunicator
 from django.conf import settings
 from django.test import override_settings
 from jatte.asgi import application
-from stream_server_django.chat.models import Channel, Message
+from stream_server_django.chat.models import Channel, Message, Room
 
 
 @override_settings(CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}})
@@ -13,8 +13,13 @@ from stream_server_django.chat.models import Channel, Message
 @pytest.mark.django_db(transaction=True)
 async def test_message_round_trip():
     channel = await sync_to_async(Channel.objects.create)(uuid="r1", client="c1")
+    await sync_to_async(Room.objects.create)(uuid="r1", client="u1")
     token = jwt.encode({"sub": "u1", "email": "u1@example.com"}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
-    communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
+    communicator = WebsocketCommunicator(
+        application,
+        f"/ws/chat/?token={token}",
+        headers=[(b"origin", b"http://localhost:3000")],
+    )
     connected, _ = await communicator.connect()
     assert connected
 
@@ -40,10 +45,23 @@ async def test_message_round_trip():
 @pytest.mark.django_db(transaction=True)
 async def test_two_clients_fanout():
     channel = await sync_to_async(Channel.objects.create)(uuid="r2", client="c1")
+    room = await sync_to_async(Room.objects.create)(uuid="r2", client="u1")
+    member_message = await sync_to_async(Message.objects.create)(
+        channel=channel, body="member seed", sent_by="u2"
+    )
+    await sync_to_async(room.messages.add)(member_message)
     token1 = jwt.encode({"sub": "u1", "email": "u1@example.com"}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
     token2 = jwt.encode({"sub": "u2", "email": "u2@example.com"}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
-    c1 = WebsocketCommunicator(application, f"/ws/chat/?token={token1}")
-    c2 = WebsocketCommunicator(application, f"/ws/chat/?token={token2}")
+    c1 = WebsocketCommunicator(
+        application,
+        f"/ws/chat/?token={token1}",
+        headers=[(b"origin", b"http://localhost:3000")],
+    )
+    c2 = WebsocketCommunicator(
+        application,
+        f"/ws/chat/?token={token2}",
+        headers=[(b"origin", b"http://localhost:3000")],
+    )
     assert (await c1.connect())[0]
     assert (await c2.connect())[0]
 
@@ -63,5 +81,3 @@ async def test_two_clients_fanout():
 
     await c1.disconnect()
     await c2.disconnect()
-
-

--- a/backend/stream_server_django/chat/tests/test_ws_handshake_parity.py
+++ b/backend/stream_server_django/chat/tests/test_ws_handshake_parity.py
@@ -44,16 +44,20 @@ async def test_ws_handshake_and_event_parity():
     await sync_to_async(room.messages.add)(seed_message)
 
     token = jwt.encode(
-        {"sub": str(user.id), "email": user.email},
+        {"sub": user.username, "email": user.email},
         settings.SUPABASE_JWT_SECRET,
         algorithm="HS256",
     )
-    communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
+    communicator = WebsocketCommunicator(
+        application,
+        f"/ws/chat/?token={token}",
+        headers=[(b"origin", b"http://localhost:3000")],
+    )
     connected, _ = await communicator.connect()
     assert connected
 
     join = await communicator.receive_json_from()
-    assert join == {"type": "user.join", "user": str(user.id)}
+    assert join == {"type": "user.join", "user": user.username}
 
     cid = f"messaging:{channel.uuid}"
     await communicator.send_json_to({"type": "channel.watch", "cid": cid})

--- a/backend/stream_server_django/chat/tests/test_ws_rate_limit.py
+++ b/backend/stream_server_django/chat/tests/test_ws_rate_limit.py
@@ -1,10 +1,11 @@
 import jwt
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, sync_to_async
 from channels.testing import WebsocketCommunicator
 from django.conf import settings
 from django.test import TransactionTestCase, override_settings
 
 from jatte.asgi import application
+from stream_server_django.chat.models import Room
 
 
 @override_settings(
@@ -16,7 +17,9 @@ class WebsocketRateLimitTests(TransactionTestCase):
     databases = {"default"}
 
     def test_websocket_rate_limit(self):
-        with self.assertLogs("chat.consumers", level="WARNING") as captured:
+        with self.assertLogs(
+            "stream_server_django.chat.consumers", level="WARNING"
+        ) as captured:
             async_to_sync(self._exercise_websocket)()
 
         messages = "\n".join(captured.output)
@@ -25,12 +28,17 @@ class WebsocketRateLimitTests(TransactionTestCase):
         assert "ws-user" in messages
 
     async def _exercise_websocket(self) -> None:
+        await sync_to_async(Room.objects.create)(uuid="rate-limit", client="ws-user")
         token = jwt.encode(
             {"sub": "ws-user", "email": "ws@example.com"},
             settings.SUPABASE_JWT_SECRET,
             algorithm="HS256",
         )
-        communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
+        communicator = WebsocketCommunicator(
+            application,
+            f"/ws/chat/?token={token}",
+            headers=[(b"origin", b"http://localhost:3000")],
+        )
 
         connected, _ = await communicator.connect()
         assert connected

--- a/backend/stream_server_django/chat/tests/test_ws_security.py
+++ b/backend/stream_server_django/chat/tests/test_ws_security.py
@@ -1,0 +1,278 @@
+import time
+
+import jwt
+import pytest
+from asgiref.sync import sync_to_async
+from channels.layers import get_channel_layer
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.conf import settings
+from django.test import override_settings
+
+from stream_server_django.chat.models import Message, Room
+from stream_server_django.chat.routing import websocket_urlpatterns
+from stream_server_django.chat.utils import group_name_for_cid
+
+
+application = URLRouter(websocket_urlpatterns)
+
+
+def make_token(sub="member", **claims):
+    payload = {"sub": sub, "email": f"{sub}@example.com", **claims}
+    return jwt.encode(payload, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+
+
+async def connect(room_key="chat", token=None):
+    suffix = f"?token={token}" if token is not None else ""
+    communicator = WebsocketCommunicator(application, f"/ws/{room_key}/{suffix}")
+    connected, code = await communicator.connect()
+    return communicator, connected, code
+
+
+async def create_room(uuid, client):
+    return await sync_to_async(Room.objects.create)(uuid=uuid, client=client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+    SUPABASE_JWKS_URL=None,
+)
+@pytest.mark.parametrize(
+    "token",
+    [
+        None,
+        "not-a-jwt",
+        jwt.encode(
+            {"sub": "expired", "exp": int(time.time()) - 120},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        ),
+        jwt.encode({"sub": "wrong-signature"}, "different-secret", algorithm="HS256"),
+        jwt.encode({"email": "missing-sub@example.com"}, settings.SUPABASE_JWT_SECRET, algorithm="HS256"),
+    ],
+    ids=["missing", "malformed", "expired", "invalid-signature", "missing-sub"],
+)
+async def test_websocket_rejects_invalid_authentication_before_accept(token):
+    communicator, connected, code = await connect(token=token)
+    assert not connected
+    assert code == 4401
+    await communicator.wait()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_valid_token_connects_and_generic_chat_route_is_preserved():
+    communicator, connected, _ = await connect(token=make_token())
+    assert connected
+    assert await communicator.receive_json_from() == {"type": "user.join", "user": "member"}
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_member_can_watch_but_nonmember_receives_no_room_state():
+    await create_room("allowed", "member")
+    await create_room("denied", "someone-else")
+
+    member, connected, _ = await connect(token=make_token())
+    assert connected
+    await member.receive_json_from()
+    await member.send_json_to({"type": "channel.watch", "cid": "messaging:allowed"})
+    initialized = await member.receive_json_from()
+    assert initialized["type"] == "initialized"
+    assert initialized["cid"] == "messaging:allowed"
+    assert set(initialized) >= {"messages", "next", "members"}
+
+    nonmember, connected, _ = await connect(token=make_token("outsider"))
+    assert connected
+    await nonmember.receive_json_from()
+    await nonmember.send_json_to({"type": "channel.watch", "cid": "messaging:denied"})
+    denied = await nonmember.receive_json_from()
+    assert denied == {
+        "type": "error",
+        "code": "forbidden",
+        "cid": "messaging:denied",
+    }
+    assert "messages" not in denied
+    assert "members" not in denied
+
+    await nonmember.send_json_to(
+        {"type": "message.new", "cid": "messaging:denied", "text": "blocked"}
+    )
+    assert await nonmember.receive_json_from() == {
+        "type": "error",
+        "code": "not_watched",
+        "cid": "messaging:denied",
+    }
+    assert await sync_to_async(Message.objects.count)() == 0
+
+    await member.disconnect()
+    await nonmember.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_send_requires_authorized_watch_and_failed_send_has_no_side_effects():
+    await create_room("send-room", "member")
+    communicator, connected, _ = await connect(token=make_token())
+    assert connected
+    await communicator.receive_json_from()
+
+    await communicator.send_json_to(
+        {"type": "message.new", "cid": "messaging:send-room", "text": "blocked"}
+    )
+    assert await communicator.receive_json_from() == {
+        "type": "error",
+        "code": "not_watched",
+        "cid": "messaging:send-room",
+    }
+    assert await sync_to_async(Message.objects.count)() == 0
+    assert await communicator.receive_nothing(timeout=0.05)
+
+    await communicator.send_json_to({"type": "channel.watch", "cid": "messaging:send-room"})
+    assert (await communicator.receive_json_from())["type"] == "initialized"
+    await communicator.send_json_to(
+        {"type": "message.new", "text": "allowed"}
+    )
+    event = await communicator.receive_json_from()
+    assert event == {
+        "type": "message.new",
+        "cid": "messaging:send-room",
+        "text": "allowed",
+        "user": "member",
+    }
+    assert await sync_to_async(Message.objects.count)() == 1
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_room_bound_route_rejects_watch_and_send_cid_mismatch():
+    await create_room("room-a", "member")
+    await create_room("room-b", "member")
+    communicator, connected, _ = await connect(
+        room_key="messaging:room-a", token=make_token()
+    )
+    assert connected
+    await communicator.receive_json_from()
+
+    await communicator.send_json_to({"type": "channel.watch", "cid": "messaging:room-b"})
+    assert (await communicator.receive_json_from())["code"] == "cid_mismatch"
+
+    await communicator.send_json_to({"type": "channel.watch", "cid": "messaging:room-a"})
+    assert (await communicator.receive_json_from())["type"] == "initialized"
+
+    await communicator.send_json_to(
+        {"type": "message.new", "cid": "messaging:room-b", "text": "pivot"}
+    )
+    assert (await communicator.receive_json_from())["code"] == "cid_mismatch"
+    assert await sync_to_async(Message.objects.count)() == 0
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_messages_and_typing_do_not_cross_room_groups():
+    await create_room("room-a", "member-a")
+    await create_room("room-b", "member-b")
+
+    client_a, connected, _ = await connect(
+        room_key="messaging:room-a", token=make_token("member-a")
+    )
+    assert connected
+    await client_a.receive_json_from()
+    await client_a.send_json_to({"type": "channel.watch", "cid": "messaging:room-a"})
+    await client_a.receive_json_from()
+
+    client_b, connected, _ = await connect(
+        room_key="messaging:room-b", token=make_token("member-b")
+    )
+    assert connected
+    await client_b.receive_json_from()
+    await client_b.send_json_to({"type": "channel.watch", "cid": "messaging:room-b"})
+    await client_b.receive_json_from()
+
+    await client_b.send_json_to(
+        {"type": "message.new", "cid": "messaging:room-b", "text": "room b"}
+    )
+    assert (await client_b.receive_json_from())["type"] == "message.new"
+    assert await client_a.receive_nothing(timeout=0.05)
+
+    await client_b.send_json_to({"type": "typing.start", "cid": "messaging:room-b"})
+    typing = await client_b.receive_json_from()
+    assert typing == {
+        "type": "typing.start",
+        "cid": "messaging:room-b",
+        "user_id": "member-b",
+    }
+    assert await client_a.receive_nothing(timeout=0.05)
+
+    await client_a.disconnect()
+    await client_b.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_connection_presence_acknowledgement_is_not_broadcast_globally():
+    first, connected, _ = await connect(token=make_token("first"))
+    assert connected
+    assert (await first.receive_json_from())["user"] == "first"
+
+    second, connected, _ = await connect(token=make_token("second"))
+    assert connected
+    assert (await second.receive_json_from())["user"] == "second"
+    assert await first.receive_nothing(timeout=0.05)
+
+    await first.disconnect()
+    await second.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_group_events_are_dropped_if_room_access_is_revoked():
+    room = await create_room("revoked", "member")
+    communicator, connected, _ = await connect(token=make_token())
+    assert connected
+    await communicator.receive_json_from()
+    await communicator.send_json_to({"type": "channel.watch", "cid": "messaging:revoked"})
+    assert (await communicator.receive_json_from())["type"] == "initialized"
+
+    room.client = "someone-else"
+    await sync_to_async(room.save)(update_fields=["client"])
+    channel_layer = get_channel_layer()
+    await channel_layer.group_send(
+        group_name_for_cid("messaging:revoked"),
+        {
+            "type": "chat.message",
+            "payload": {
+                "type": "message.new",
+                "cid": "messaging:revoked",
+                "text": "must not leak",
+            },
+        },
+    )
+    assert await communicator.receive_nothing(timeout=0.05)
+    await communicator.disconnect()

--- a/backend/stream_server_django/chat/tests/test_ws_watch.py
+++ b/backend/stream_server_django/chat/tests/test_ws_watch.py
@@ -14,7 +14,7 @@ from jatte.asgi import application
 @pytest.mark.django_db(transaction=True)
 async def test_channel_watch_initializes_state():
     channel = await sync_to_async(Channel.objects.create)(uuid="general", client="stream")
-    room = await sync_to_async(Room.objects.create)(uuid="general", client="stream")
+    room = await sync_to_async(Room.objects.create)(uuid="general", client="u1")
     message = await sync_to_async(Message.objects.create)(
         channel=channel,
         body="hello",
@@ -23,7 +23,11 @@ async def test_channel_watch_initializes_state():
     await sync_to_async(room.messages.add)(message)
 
     token = jwt.encode({"sub": "u1", "email": "u1@example.com"}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
-    communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
+    communicator = WebsocketCommunicator(
+        application,
+        f"/ws/chat/?token={token}",
+        headers=[(b"origin", b"http://localhost:3000")],
+    )
     connected, _ = await communicator.connect()
     assert connected
 


### PR DESCRIPTION
## Summary

Implements PR2 of the JATTE-headless security hardening sequence: WebSocket authentication, membership gates, and event isolation.

This PR follows PR #1188 and focuses only on WebSocket security behavior. It intentionally does not start the broader REST room/message authorization pass, attachment download policy, admin/service auth, or Stream route/response refactors.

## Changes

- Adds shared Supabase WebSocket authentication with HS256 and RS256/JWKS handling.
- Closes missing or invalid WebSocket JWTs with `4401` before socket acceptance.
- Requires room membership before state access and group subscription.
- Requires an authorized watch before message and typing operations.
- Preserves `/ws/chat/?token=...` as the intentional generic compatibility route.
- Rejects room-specific route / payload CID pivots.
- Disables global lobby presence.
- Re-authorizes incoming group events to prevent leakage after membership revocation.
- Preserves existing successful Stream-compatible payload shapes.
- Documents the generic WebSocket compatibility exception in `backend/SECURITY.md`.

## Testing

- 24 WebSocket/shared-auth tests passed.
- 10 PR1 security-boundary tests passed.
- Python compilation passed.
- `git diff --check` passed.

## Known deferred issue

`test_ws_handshake_parity.py` passes its secured WebSocket handshake/watch phase, then fails in an existing HTTP phase because `stream_server_django.chat.broadcast` is missing. That repair is deferred as out of PR2 scope.

## Out of scope

- Broad REST room/message authorization
- Attachment download privacy
- Admin, agent, notification, and SMS service authorization
- Stream compatibility route/response refactors
- Agent/broadcast module repair