### PR TITLE
Security PR5: Enforce admin, agent, notification, and SMS authorization

### DIFF
--- a/backend/audit/pr5-service-auth-inventory.md
+++ b/backend/audit/pr5-service-auth-inventory.md
@@ -1,0 +1,67 @@
+# PR5 privileged-route authorization inventory
+
+All paths are relative to the application root. Supabase JWT means the shared
+Bearer-token authentication path; service auth means the constant-time checked
+`X-Chat-Service-Token` credential configured by
+`CHAT_INTERNAL_SERVICE_TOKEN`.
+
+## Agent routes
+
+| Path | View | Before PR5 | Actor and side effects | PR5 policy |
+| --- | --- | --- | --- | --- |
+| `/api/chat/agent/<cid>/invoke[/]` | `AgentLLMInvokeView` | Any authenticated user | Enqueues an LLM/RAG job and creates agent state | Supabase JWT plus room access; ordinary room participants may invoke because this is the frontend chat action |
+| `/api/chat/agent/<cid>/invoke-echo/` | `AgentInvokeView` | Any authenticated user | Creates and broadcasts an agent message | Supabase JWT plus room access |
+| `/api/chat/agent/rag/`, `/chat/agent/rag/` | `AgentRagView` | Any authenticated user | Runs synchronous RAG generation and persists replies | Supabase JWT plus room access |
+| `/api/rooms/<cid>/agent/cancel/` | `AgentCancelView` | Any authenticated user | Cancels active agent state/run | Room agent or staff/superuser |
+| `/chat/agent/<cid>/` | `AgentStatusView` | Any authenticated user | Reads enablement state | Supabase JWT plus room access |
+| `/chat/agent/<cid>/enable/`, `/disable/` | `AgentEnableView`, `AgentDisableView` | Any authenticated user | Changes room agent enablement and policy | Room agent or staff/superuser |
+| `/chat/agent/policy` | `AgentPolicyView` | Any authenticated user | Reads or changes model/tool/turn/handoff policy | Room agent or staff/superuser |
+| `/chat/agent/skills` | `AgentSkillPolicyView` | Any authenticated user | Reads or changes enabled skills | Room agent or staff/superuser |
+| `/chat/agent/memory` | `AgentMemoryListView` | Any authenticated user | Exposes room-scoped agent memory | Room agent or staff/superuser |
+| `/chat/agent/runs` | `AgentRunListView` | Any authenticated user | Exposes run status, cost, token, and tool data | Room agent or staff/superuser |
+| `/chat/agent/simulate` | `AgentSimulateView` | Any authenticated user | Executes a potentially expensive simulation | Room agent or staff/superuser |
+
+The compatibility paths produced by the nested agent URL include use the same
+views and therefore inherit the same policy. Agent lookups resolve existing
+rooms only; authorization checks never create a guessed room.
+
+## Admin console routes
+
+| Path | View | Before PR5 | Actor and side effects | PR5 policy |
+| --- | --- | --- | --- | --- |
+| `/chat/admin/queue/` | `AdminQueueView` | Supabase JWT plus staff | Lists operational queue and ownership | Staff/superuser only |
+| `/chat/admin/agent-runs/` | `AgentRunDebugView` | Supabase JWT plus staff | Exposes run/debug data | Staff/superuser only |
+| `/chat/admin/rooms/<cid>/claim/` | `ClaimRoomView` | Supabase JWT plus staff | Assigns room ownership | Staff/superuser only |
+| `/chat/admin/rooms/<uuid>/reset/`, `/reset-new/` | `ResetRoomView`, `ResetNewRoomView` | Supabase JWT plus staff | Deletes room state/messages and may replace a room | Staff/superuser only |
+| `/chat/admin/gating-rules/` | `GatingRulesView` | Supabase JWT plus staff | Reads/changes intake policy | Staff/superuser only |
+| `/chat/admin/intake/` | `IntakeListView` | Supabase JWT plus staff | Lists gated messages | Staff/superuser only |
+| `/chat/admin/intake/<id>/approve/`, `/reject/` | `ApproveIntakeView`, `RejectIntakeView` | Supabase JWT plus staff | Publishes or rejects gated messages | Staff/superuser only |
+| `/chat/admin/audit/` | `AuditTrailListView` | Supabase JWT plus staff | Exposes privileged audit records | Staff/superuser only |
+
+Internal service credentials deliberately do not grant admin-console access.
+
+## Notifications and operational routes
+
+| Path | View | Before PR5 | Actor and side effects | PR5 policy |
+| --- | --- | --- | --- | --- |
+| `/chat/notifications/intake/` | `IntakeSummaryView` | Supabase JWT plus staff | Exposes operational counts | Staff/superuser or internal service |
+| `/chat/notifications/oncall/` | `OnCallConfigView` | Supabase JWT plus staff | Reads/changes on-call contact data | Staff/superuser or internal service |
+| `/chat/notifications/presence/` | `AdminHeartbeatView` | Supabase JWT plus staff | Changes operational presence state | Staff/superuser or internal service |
+| `/chat/notifications/escalate/` | `EscalateRoomView` | Supabase JWT plus staff | Creates notifications and can send SMS/email | Staff/superuser or internal service |
+
+Service requests materialize a reserved non-staff service actor only after the
+service token succeeds. Browser JWTs are never treated as service credentials.
+
+## SMS integration routes
+
+| Path | View | Before PR5 | Actor and side effects | PR5 policy |
+| --- | --- | --- | --- | --- |
+| `/chat/integrations/sms/webhook/` | `SmsWebhookView` | Body HMAC; duplicate IDs returned success | Creates rooms/users/messages, broadcasts, may invoke autoresponse and send consent replies | External provider only: `X-Signature` HMAC-SHA256 over `Base64(raw_body)`, exact-body validation, and 409 replay rejection by inbound `external_id` |
+| `/chat/integrations/sms/send/` | `SmsSendView` | Supabase JWT plus staff | Sends provider SMS and creates relay/message state | Staff/superuser or internal service |
+| `/chat/integrations/sms/receipt/` | `SmsReceiptView` | Unauthenticated | Changes delivery state and broadcasts updates | Provider body signature or internal service token; only the first transition from pending is accepted |
+
+The repository's provider-v1 signing contract does not include a signed
+timestamp, so PR5 does not invent one. It verifies the exact raw body and uses
+the provider's unique external ID/status as the replay boundary. Production
+startup requires both `SMS_WEBHOOK_SECRET` and
+`CHAT_INTERNAL_SERVICE_TOKEN`; missing or placeholder values fail closed.

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -113,6 +113,11 @@ SMS_PROVIDER_TOKEN = os.environ.get("SMS_PROVIDER_TOKEN", "")
 OPENPHONE_API_KEY = os.environ.get("OPENPHONE_API_KEY", "")
 OPENPHONE_FROM_PHONE_ID = os.environ.get("OPENPHONE_FROM_PHONE_ID", "")
 OPENPHONE_BASE_URL = os.environ.get("OPENPHONE_BASE_URL", "https://api.openphone.com")
+CHAT_INTERNAL_SERVICE_TOKEN = os.environ.get("CHAT_INTERNAL_SERVICE_TOKEN", "")
+CHAT_INTERNAL_SERVICE_USERNAME = os.environ.get(
+    "CHAT_INTERNAL_SERVICE_USERNAME", "__chat_internal_service__"
+)
+SMS_WEBHOOK_SECRET = os.environ.get("SMS_WEBHOOK_SECRET", "")
 
 CHANNEL_LAYERS = {
     "default": {

--- a/backend/jatte/settingsprod.py
+++ b/backend/jatte/settingsprod.py
@@ -36,6 +36,11 @@ SMS_PROVIDER_TOKEN = os.environ.get("SMS_PROVIDER_TOKEN", "")
 OPENPHONE_API_KEY = os.environ.get("OPENPHONE_API_KEY", "")
 OPENPHONE_FROM_PHONE_ID = os.environ.get("OPENPHONE_FROM_PHONE_ID", "")
 OPENPHONE_BASE_URL = os.environ.get("OPENPHONE_BASE_URL", "https://api.openphone.com")
+CHAT_INTERNAL_SERVICE_TOKEN = required_secret("CHAT_INTERNAL_SERVICE_TOKEN")
+CHAT_INTERNAL_SERVICE_USERNAME = os.environ.get(
+    "CHAT_INTERNAL_SERVICE_USERNAME", "__chat_internal_service__"
+)
+SMS_WEBHOOK_SECRET = required_secret("SMS_WEBHOOK_SECRET")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/backend/jatte/tests/test_security_boundary.py
+++ b/backend/jatte/tests/test_security_boundary.py
@@ -20,6 +20,8 @@ class ProductionSettingsHelperTests(TestCase):
         "DJANGO_ALLOWED_HOSTS": "chat.example,api.example",
         "DJANGO_CORS_ALLOWED_ORIGINS": "https://app.example",
         "DJANGO_WS_ALLOWED_ORIGINS": "https://app.example",
+        "CHAT_INTERNAL_SERVICE_TOKEN": "real-internal-service-secret",
+        "SMS_WEBHOOK_SECRET": "real-sms-webhook-secret",
     }
 
     def _load_production_settings(self, environ):
@@ -75,6 +77,17 @@ class ProductionSettingsHelperTests(TestCase):
         self.assertEqual(configured.CORS_ALLOWED_ORIGINS, ["https://app.example"])
         self.assertEqual(configured.DJANGO_WS_ALLOWED_ORIGINS, ["https://app.example"])
         self.assertFalse(configured.CORS_ALLOW_CREDENTIALS)
+
+    def test_production_settings_require_service_and_webhook_secrets(self):
+        for required_name in (
+            "CHAT_INTERNAL_SERVICE_TOKEN",
+            "SMS_WEBHOOK_SECRET",
+        ):
+            with self.subTest(required_name=required_name):
+                environ = dict(self.production_environ)
+                environ.pop(required_name)
+                with self.assertRaises(ProductionConfigurationError):
+                    self._load_production_settings(environ)
 
 
 @override_settings(ROOT_URLCONF="jatte.tests.urls_security", DEBUG=False)

--- a/backend/stream_server_django/chat/broadcast.py
+++ b/backend/stream_server_django/chat/broadcast.py
@@ -1,0 +1,31 @@
+"""Small channel-layer broadcast helper shared by chat add-ons."""
+
+from __future__ import annotations
+
+import logging
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from .utils import canonical_cid, group_name_for_cid
+
+
+logger = logging.getLogger(__name__)
+
+
+def _broadcast_to_cid(cid: str, payload: dict) -> None:
+    """Send ``payload`` only to subscribers of the canonical room group."""
+
+    try:
+        channel_layer = get_channel_layer()
+        if channel_layer is None:
+            return
+        canonical = canonical_cid(cid)
+        event_payload = dict(payload)
+        event_payload.setdefault("cid", canonical)
+        async_to_sync(channel_layer.group_send)(
+            group_name_for_cid(canonical),
+            {"type": "chat.message", "payload": event_payload},
+        )
+    except Exception:  # pragma: no cover - delivery must not break HTTP writes
+        logger.exception("chat.broadcast.failed", extra={"cid": cid})

--- a/backend/stream_server_django/chat/serializers.py
+++ b/backend/stream_server_django/chat/serializers.py
@@ -131,6 +131,8 @@ class MessageSerializer(serializers.ModelSerializer):
         ]
 
     def validate_attachments(self, value: list[dict]) -> list[dict]:
+        if not value:
+            return []
         room = self.context.get("attachment_room")
         request = self.context.get("request")
         user = self.context.get("attachment_user") or getattr(request, "user", None)

--- a/backend/stream_server_django/chat_addons/admin_console/tests/test_admin_authorization.py
+++ b/backend/stream_server_django/chat_addons/admin_console/tests/test_admin_authorization.py
@@ -1,0 +1,49 @@
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat.models import Room
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="stream_server_django.chat_addons.tests.pr5_urls",
+    CHAT_INTERNAL_SERVICE_TOKEN="service-secret",
+)
+class AdminAuthorizationTests(APITestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="admin-staff", supabase_uid="admin-staff", is_staff=True
+        )
+        self.member = User.objects.create_user(
+            username="admin-member", supabase_uid="admin-member"
+        )
+        Room.objects.create(uuid="admin-secret-room", client="client")
+        self.url = reverse("list-admin-queue")
+
+    def auth(self, user) -> dict[str, str]:
+        token = jwt.encode(
+            {"sub": user.supabase_uid},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_queue_is_staff_only_and_does_not_leak_to_other_actors(self):
+        allowed = self.client.get(self.url, **self.auth(self.staff))
+        member = self.client.get(self.url, **self.auth(self.member))
+        anonymous = self.client.get(self.url)
+        service = self.client.get(
+            self.url, HTTP_X_CHAT_SERVICE_TOKEN="service-secret"
+        )
+
+        self.assertEqual(allowed.status_code, 200)
+        self.assertIn("results", allowed.data)
+        for response in (member, anonymous, service):
+            self.assertIn(response.status_code, {401, 403})
+            self.assertNotIn("results", response.data)

--- a/backend/stream_server_django/chat_addons/agent/tests/test_agent_authorization.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_agent_authorization.py
@@ -1,0 +1,161 @@
+from unittest.mock import Mock, patch
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat.models import Channel, Message, Room
+from stream_server_django.chat_addons.agent.models import RoomAgentFlag
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="stream_server_django.chat_addons.tests.pr5_urls"
+)
+class AgentAuthorizationTests(APITestCase):
+    def setUp(self):
+        self.member = User.objects.create_user(
+            username="room-member", supabase_uid="room-member"
+        )
+        self.outsider = User.objects.create_user(
+            username="room-outsider", supabase_uid="room-outsider"
+        )
+        self.agent = User.objects.create_user(
+            username="room-agent", supabase_uid="room-agent"
+        )
+        self.staff = User.objects.create_user(
+            username="chat-staff", supabase_uid="chat-staff", is_staff=True
+        )
+        self.room = Room.objects.create(
+            uuid="agent-auth-room",
+            client=self.member.username,
+            agent=self.agent,
+        )
+        channel = Channel.objects.create(
+            uuid=self.room.uuid, client=self.room.client
+        )
+        self.message = Message.objects.create(
+            channel=channel,
+            body="Please help",
+            sent_by=self.member.username,
+        )
+        self.room.messages.add(self.message)
+        RoomAgentFlag.objects.create(room=self.room, agent_enabled=True)
+
+    def token(self, user) -> str:
+        return jwt.encode(
+            {"sub": user.supabase_uid, "email": user.email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+
+    def auth(self, user) -> dict[str, str]:
+        return {"HTTP_AUTHORIZATION": f"Bearer {self.token(user)}"}
+
+    @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
+    def test_member_can_invoke_own_room_but_outsider_cannot(self, service_factory):
+        service = Mock()
+        service.enqueue_generate.return_value = "job-pr5"
+        service_factory.return_value = service
+        url = reverse("agent-invoke", kwargs={"cid": self.room.cid})
+        payload = {
+            "room_uuid": self.room.uuid,
+            "last_human_message_id": self.message.id,
+        }
+
+        denied = self.client.post(
+            url, payload, format="json", **self.auth(self.outsider)
+        )
+        self.assertEqual(denied.status_code, 403)
+        service.enqueue_generate.assert_not_called()
+
+        allowed = self.client.post(
+            url, payload, format="json", **self.auth(self.member)
+        )
+        self.assertEqual(allowed.status_code, 202, allowed.data)
+        service.enqueue_generate.assert_called_once()
+
+    def test_agent_controls_require_room_agent_or_staff(self):
+        enable_url = reverse("enable-agent", kwargs={"cid": self.room.cid})
+        disable_url = reverse("disable-agent", kwargs={"cid": self.room.cid})
+
+        member_denied = self.client.post(
+            enable_url, {}, format="json", **self.auth(self.member)
+        )
+        self.assertEqual(member_denied.status_code, 403)
+
+        agent_allowed = self.client.post(
+            enable_url, {}, format="json", **self.auth(self.agent)
+        )
+        self.assertEqual(agent_allowed.status_code, 200)
+
+        staff_allowed = self.client.post(
+            disable_url, {}, format="json", **self.auth(self.staff)
+        )
+        self.assertEqual(staff_allowed.status_code, 200)
+
+        member_cancel = self.client.post(
+            reverse("agent-cancel", kwargs={"cid": self.room.cid}),
+            {},
+            format="json",
+            **self.auth(self.member),
+        )
+        agent_cancel = self.client.post(
+            reverse("agent-cancel", kwargs={"cid": self.room.cid}),
+            {},
+            format="json",
+            **self.auth(self.agent),
+        )
+        self.assertEqual(member_cancel.status_code, 403)
+        self.assertEqual(agent_cancel.status_code, 204)
+
+    def test_status_requires_room_access_and_guesses_do_not_create_rooms(self):
+        status_url = reverse("agent-status", kwargs={"cid": self.room.cid})
+        allowed = self.client.get(status_url, **self.auth(self.member))
+        denied = self.client.get(status_url, **self.auth(self.outsider))
+        anonymous = self.client.get(status_url)
+
+        before = Room.objects.count()
+        missing = self.client.get(
+            reverse("agent-status", kwargs={"cid": "messaging:guessed-room"}),
+            **self.auth(self.staff),
+        )
+
+        self.assertEqual(allowed.status_code, 200)
+        self.assertEqual(denied.status_code, 403)
+        self.assertEqual(anonymous.status_code, 403)
+        self.assertEqual(missing.status_code, 404)
+        self.assertEqual(Room.objects.count(), before)
+
+    @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
+    def test_member_cannot_simulate_or_change_policy(self, service_factory):
+        simulate = self.client.post(
+            reverse("agent-simulate"),
+            {"cid": self.room.cid, "prompt": "expensive"},
+            format="json",
+            **self.auth(self.member),
+        )
+        policy = self.client.put(
+            reverse("agent-policy"),
+            {"cid": self.room.cid, "agent_enabled": False},
+            format="json",
+            **self.auth(self.member),
+        )
+
+        self.assertEqual(simulate.status_code, 403)
+        self.assertEqual(policy.status_code, 403)
+        service_factory.assert_not_called()
+
+    def test_run_and_memory_operational_data_require_room_control_role(self):
+        for route_name in ("agent-runs", "agent-memory"):
+            with self.subTest(route_name=route_name):
+                url = reverse(route_name) + f"?cid={self.room.cid}"
+                member = self.client.get(url, **self.auth(self.member))
+                agent = self.client.get(url, **self.auth(self.agent))
+                self.assertEqual(member.status_code, 403)
+                self.assertEqual(agent.status_code, 200)

--- a/backend/stream_server_django/chat_addons/agent/tests/test_orchestrator.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_orchestrator.py
@@ -1,37 +1,20 @@
 from __future__ import annotations
 
 import json
-import os
-import sys
 from decimal import Decimal
-from pathlib import Path
 from unittest import mock
-
-BASE_DIR = Path(__file__).resolve().parents[3]
-if str(BASE_DIR) not in sys.path:
-    sys.path.insert(0, str(BASE_DIR))
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.jatte.settings")
-
-import django
-
-django.setup()
 
 import jwt
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.management import call_command
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from stream_server_django.chat.models import Message
+from stream_server_django.chat.models import Message, Room
 from stream_server_django.chat_addons.agent.models import AgentRoomPolicy, AgentRun
 from stream_server_django.chat_addons.agent.services.agent_service import AgentService
 from stream_server_django.chat_addons.agent.services.llm_client import LLMClient
-
-call_command("migrate", run_syncdb=True, verbosity=0)
-
 
 class _SequencedProvider:
     def __init__(self, responses):
@@ -66,6 +49,10 @@ class AgentPolicyApiTests(APITestCase):
                 "is_staff": True,
             },
         )
+        if not self.operator.is_staff:
+            self.operator.is_staff = True
+            self.operator.save(update_fields=["is_staff"])
+        Room.objects.get_or_create(uuid="policy-room", defaults={"client": "stream"})
 
     def make_headers(self) -> dict[str, str]:
         token = jwt.encode(

--- a/backend/stream_server_django/chat_addons/agent/tests/test_skills_registry.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_skills_registry.py
@@ -1,23 +1,5 @@
 from __future__ import annotations
 
-import os
-import sys
-from pathlib import Path
-
-BASE_DIR = Path(__file__).resolve().parents[4]
-if str(BASE_DIR) not in sys.path:
-    sys.path.insert(0, str(BASE_DIR))
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.jatte.settings")
-
-import django
-
-django.setup()
-
-from django.core.management import call_command
-
-call_command("migrate", run_syncdb=True, verbosity=0)
-
 import jwt
 from django.conf import settings
 from django.urls import reverse
@@ -28,6 +10,7 @@ from rest_framework.test import APITestCase
 
 from django.contrib.auth import get_user_model
 
+from stream_server_django.chat.models import Room
 from stream_server_django.chat_addons.agent import registry
 from stream_server_django.chat_addons.agent.models import AgentRoomPolicy
 User = get_user_model()
@@ -84,6 +67,11 @@ class SkillPolicyViewTests(APITestCase):
         if not self.operator.has_usable_password():
             self.operator.set_password("secret")
             self.operator.save(update_fields=["password"])
+        if not self.operator.is_staff:
+            self.operator.is_staff = True
+            self.operator.save(update_fields=["is_staff"])
+        Room.objects.get_or_create(uuid="room-a", defaults={"client": "stream"})
+        Room.objects.get_or_create(uuid="room-b", defaults={"client": "stream"})
 
     def make_token(self) -> str:
         return jwt.encode(

--- a/backend/stream_server_django/chat_addons/agent/tests/test_views.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_views.py
@@ -2,24 +2,7 @@ from __future__ import annotations
 
 from unittest import mock
 
-import os
-import sys
-import time
-from pathlib import Path
 from decimal import Decimal
-
-BASE_DIR = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(BASE_DIR))
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.jatte.settings")
-
-import django
-
-django.setup()
-
-from django.core.management import call_command
-
-call_command("migrate", run_syncdb=True, verbosity=0)
 
 import jwt
 from django.conf import settings
@@ -49,6 +32,9 @@ class AgentViewsTests(APITestCase):
         if not self.operator.has_usable_password():
             self.operator.set_password("secret")
             self.operator.save(update_fields=["password"])
+        if not self.operator.is_staff:
+            self.operator.is_staff = True
+            self.operator.save(update_fields=["is_staff"])
 
     def make_token(self) -> str:
         return jwt.encode(
@@ -94,19 +80,15 @@ class AgentViewsTests(APITestCase):
         flag.refresh_from_db()
         self.assertFalse(flag.agent_enabled)
 
-    @mock.patch("chat_addons.agent.tasks._broadcast_to_cid")
-    @mock.patch("chat_addons.agent.tasks.get_agent_service")
-    def test_invoke_creates_message(
-        self,
-        mock_get_service: mock.MagicMock,
-        mock_broadcast: mock.MagicMock,
+    @mock.patch("stream_server_django.chat_addons.agent.tasks._broadcast_to_cid")
+    def test_echo_invoke_creates_message(
+        self, mock_broadcast: mock.MagicMock
     ) -> None:
         Room.objects.create(uuid="invoke-room", client="stream")
-        service = mock.Mock()
-        service.generate.return_value = "pong"
-        mock_get_service.return_value = service
 
-        url = reverse("invoke-agent", kwargs={"cid": "messaging:invoke-room"})
+        url = reverse(
+            "agent-invoke-echo", kwargs={"cid": "messaging:invoke-room"}
+        )
         response = self.client.post(
             url,
             {"prompt": "ping"},
@@ -114,17 +96,16 @@ class AgentViewsTests(APITestCase):
             **self.auth_headers(),
         )
 
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         payload = response.json()
-        self.assertEqual(payload["status"], "queued")
-        self.assertIn("run_id", payload)
+        self.assertEqual(payload["reason"], "echo")
 
         messages = Message.objects.filter(
             channel__uuid="invoke-room",
             sent_by=agent_user_id_for_room("invoke-room"),
         )
         self.assertEqual(messages.count(), 1)
-        self.assertEqual(messages.first().body, "pong")
+        self.assertEqual(messages.first().body, "Echo: ping")
         mock_broadcast.assert_called()
 
     def test_rag_invocation_persists_agent_reply(self) -> None:
@@ -157,7 +138,7 @@ class AgentViewsTests(APITestCase):
         )
         self.assertEqual(agent_messages.count(), 1)
 
-    @mock.patch("chat_addons.agent.views.get_agent_service")
+    @mock.patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_llm_invoke_enqueues_job_and_returns_queued_status(
         self, mock_get_service: mock.MagicMock
     ) -> None:
@@ -197,9 +178,8 @@ class AgentViewsTests(APITestCase):
         self.assertEqual(kwargs["text"], user_message.body)
         self.assertEqual(kwargs["request_id"], "trace-1")
         self.assertEqual(kwargs["meta"].get("job_request_id"), "trace-1")
-        self.assertEqual(kwargs["meta"].get("job_id"), "job-123")
 
-    @mock.patch("chat_addons.agent.views.get_agent_service")
+    @mock.patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_llm_invoke_returns_500_when_enqueue_fails(
         self, mock_get_service: mock.MagicMock
     ) -> None:
@@ -230,6 +210,7 @@ class AgentViewsTests(APITestCase):
         self.assertIn("Agent invocation failed", payload["detail"])
 
     def test_list_runs_with_pagination(self) -> None:
+        Room.objects.create(uuid="test-room", client="stream")
         AgentRun.objects.create(
             run_id="r-1",
             cid="messaging:test-room",
@@ -285,6 +266,7 @@ class AgentViewsTests(APITestCase):
         self.assertEqual(next_payload["results"][0]["run_id"], "r-1")
 
     def test_memory_list_endpoint(self) -> None:
+        Room.objects.create(uuid="memory-room", client="stream")
         service = MemoryService(max_lines=6)
         for idx in range(4):
             service.add_line(
@@ -307,10 +289,11 @@ class AgentViewsTests(APITestCase):
         self.assertEqual([item["text"] for item in next_payload["results"]], ["memory 1", "memory 0"])
         self.assertIsNone(next_payload["next"])
 
-    @mock.patch("chat_addons.agent.views.get_agent_service")
+    @mock.patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_simulate_invokes_service_without_messages(
         self, mock_get_service: mock.MagicMock
     ) -> None:
+        Room.objects.create(uuid="sim-room", client="stream")
         service = mock.Mock()
         service.simulate.return_value = AgentSimulationResult(
             reply="It's 14.",

--- a/backend/stream_server_django/chat_addons/agent/views.py
+++ b/backend/stream_server_django/chat_addons/agent/views.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from django.db.models import Q
 from rest_framework import serializers, status
 from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import APIException, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,6 +18,11 @@ from stream_server_django.common.identity import get_chat_identity
 from stream_server_django.accounts_supabase.authentication import DevTokenOrJWTAuthentication
 from stream_server_django.chat.models import Message, Room
 from stream_server_django.chat.utils import canonical_cid
+from stream_server_django.rooms.utils import (
+    can_admin_room,
+    get_room_or_404,
+    require_room_access,
+)
 
 from ..common_audit.decorators import audit_action
 from ..common_audit.models import AuditTrail
@@ -73,7 +79,7 @@ class AgentStatusView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request, cid: str) -> Response:
-        canonical, room = _resolve_room(cid)
+        canonical, room = _resolve_room_for_member(request, cid)
         flag = RoomAgentFlag.objects.filter(room=room).first()
         enabled = agent_enabled_for_room(canonical, room)
         payload = {
@@ -94,7 +100,7 @@ class AgentEnableView(APIView):
 
     @audit_action(action=AuditTrail.Action.AGENT_ENABLE, cid_kwarg="cid")
     def post(self, request: Request, cid: str) -> Response:
-        canonical, room = _resolve_room(cid)
+        canonical, room = _resolve_room_for_control(request, cid)
         request._audit_context = {"cid": canonical}
         with transaction.atomic():
             flag, _ = RoomAgentFlag.objects.select_for_update().get_or_create(
@@ -131,7 +137,7 @@ class AgentDisableView(APIView):
 
     @audit_action(action=AuditTrail.Action.AGENT_DISABLE, cid_kwarg="cid")
     def post(self, request: Request, cid: str) -> Response:
-        canonical, room = _resolve_room(cid)
+        canonical, room = _resolve_room_for_control(request, cid)
         request._audit_context = {"cid": canonical}
         with transaction.atomic():
             flag, _ = RoomAgentFlag.objects.select_for_update().get_or_create(
@@ -168,7 +174,7 @@ class AgentInvokeView(APIView):
 
     @audit_action(action=AuditTrail.Action.AGENT_INVOKE, cid_kwarg="cid")
     def post(self, request: Request, cid: str) -> Response:
-        canonical, room = _resolve_room(cid)
+        canonical, room = _resolve_room_for_member(request, cid)
         RoomAgentFlag.objects.get_or_create(room=room)
         request._audit_context = {"cid": canonical}
         data = request.data or {}
@@ -279,7 +285,7 @@ class AgentLLMInvokeView(APIView):
             identity = get_chat_identity(request)
 
             # Normalize CID + room and mark that this room has ever used an agent
-            canonical, room = _resolve_room(cid)
+            canonical, room = _resolve_room_for_member(request, cid)
             RoomAgentFlag.objects.get_or_create(room=room)
             request._audit_context = {"cid": canonical}
 
@@ -375,6 +381,8 @@ class AgentLLMInvokeView(APIView):
             response = Response(payload, status=status.HTTP_202_ACCEPTED)
             return _log_http_end(response, job_id=job_id)
 
+        except APIException:
+            raise
         except Exception:
             # This is the safety net we were missing: log the full stack trace.
             logger.exception(
@@ -397,7 +405,7 @@ class AgentCancelView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request: Request, cid: str) -> Response:
-        canonical, room = _resolve_room(cid)
+        canonical, room = _resolve_room_for_control(request, cid)
 
         if not room.agent_busy:
             return Response(status=status.HTTP_204_NO_CONTENT)
@@ -451,7 +459,7 @@ class AgentRagView(APIView):
         serializer.is_valid(raise_exception=True)
 
         room_identifier = serializer.validated_data["room_uuid"]
-        canonical, room = _resolve_room(room_identifier)
+        canonical, room = _resolve_room_for_member(request, room_identifier)
         identity = get_chat_identity(request)
         if not agent_enabled_for_room(canonical, room):
             return Response(
@@ -517,11 +525,21 @@ class AgentRagView(APIView):
 
 def _resolve_room(cid: str) -> tuple[str, Room]:
     canonical = canonical_cid(cid)
-    if ":" in canonical:
-        _, room_uuid = canonical.split(":", 1)
-    else:
-        room_uuid = canonical
-    room, _ = Room.objects.get_or_create(uuid=room_uuid, defaults={"client": "stream"})
+    room = get_room_or_404(canonical)
+    return canonical, room
+
+
+def _resolve_room_for_member(request: Request, cid: str) -> tuple[str, Room]:
+    canonical, room = _resolve_room(cid)
+    require_room_access(request.user, room)
+    return canonical, room
+
+
+def _resolve_room_for_control(request: Request, cid: str) -> tuple[str, Room]:
+    canonical, room = _resolve_room(cid)
+    require_room_access(request.user, room)
+    if not can_admin_room(request.user, room):
+        raise PermissionDenied("Room agent or staff privileges required.")
     return canonical, room
 
 
@@ -561,7 +579,7 @@ class AgentSkillPolicyView(APIView):
         if not cid_param:
             raise serializers.ValidationError({"cid": "This query parameter is required."})
 
-        canonical, _ = _resolve_room(cid_param)
+        canonical, _ = _resolve_room_for_control(request, cid_param)
         policy = AgentRoomPolicy.objects.filter(cid=canonical).first()
         configured = policy.enabled_skills if policy else None
         payload = _build_skill_payload(canonical, configured)
@@ -572,7 +590,7 @@ class AgentSkillPolicyView(APIView):
         serializer.is_valid(raise_exception=True)
 
         cid = serializer.validated_data["cid"]
-        canonical, room = _resolve_room(cid)
+        canonical, room = _resolve_room_for_control(request, cid)
         requested = serializer.validated_data["skills"]
 
         metas = registry.list_all()
@@ -623,7 +641,7 @@ class AgentPolicyView(APIView):
         if not cid_param:
             raise serializers.ValidationError({"cid": "This query parameter is required."})
 
-        canonical, room = _resolve_room(cid_param)
+        canonical, room = _resolve_room_for_control(request, cid_param)
         flag = RoomAgentFlag.objects.filter(room=room).first()
         defaults = {"agent_enabled": bool(flag.agent_enabled) if flag else False}
         policy, created = AgentRoomPolicy.objects.get_or_create(
@@ -645,7 +663,7 @@ class AgentPolicyView(APIView):
         if not cid_value:
             raise serializers.ValidationError({"cid": "This field is required."})
 
-        canonical, room = _resolve_room(cid_value)
+        canonical, room = _resolve_room_for_control(request, cid_value)
         policy, _ = AgentRoomPolicy.objects.get_or_create(cid=canonical)
 
         serializer = AgentRoomPolicySerializer(policy, data=data, partial=True)
@@ -701,7 +719,9 @@ class AgentRunListView(APIView):
         serializer = AgentRunListQuerySerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
-        canonical = canonical_cid(serializer.validated_data["cid"])
+        canonical, _ = _resolve_room_for_control(
+            request, serializer.validated_data["cid"]
+        )
         limit = serializer.validated_data.get("limit") or 25
         cursor = serializer.validated_data.get("cursor")
 
@@ -740,7 +760,9 @@ class AgentMemoryListView(APIView):
         serializer = AgentMemoryListQuerySerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
-        canonical = canonical_cid(serializer.validated_data["cid"])
+        canonical, _ = _resolve_room_for_control(
+            request, serializer.validated_data["cid"]
+        )
         limit = serializer.validated_data.get("limit") or 20
         cursor = serializer.validated_data.get("cursor")
 
@@ -761,7 +783,9 @@ class AgentSimulateView(APIView):
         serializer = AgentSimulateRequestSerializer(data=request.data or {})
         serializer.is_valid(raise_exception=True)
 
-        canonical = canonical_cid(serializer.validated_data["cid"])
+        canonical, _ = _resolve_room_for_control(
+            request, serializer.validated_data["cid"]
+        )
         prompt = serializer.validated_data["prompt"]
         meta = serializer.validated_data.get("meta", {})
 

--- a/backend/stream_server_django/chat_addons/notifications/tests/test_notifications.py
+++ b/backend/stream_server_django/chat_addons/notifications/tests/test_notifications.py
@@ -54,8 +54,12 @@ class NotificationEscalationTests(APITestCase):
         data = fetched.json()
         self.assertEqual(data["email"], "ops@example.com")
 
-    @patch("backend.chat_addons.notifications.views.NotificationService.send_email")
-    @patch("backend.chat_addons.notifications.views.NotificationService.send_sms")
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_email"
+    )
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_sms"
+    )
     def test_escalate_with_active_admin_creates_in_app_only(
         self, mocked_sms, mocked_email
     ) -> None:
@@ -82,8 +86,12 @@ class NotificationEscalationTests(APITestCase):
         self.assertIsNone(record.delivered_at)
         self.assertGreater(Notification.objects.count(), 0)
 
-    @patch("backend.chat_addons.notifications.views.NotificationService.send_email")
-    @patch("backend.chat_addons.notifications.views.NotificationService.send_sms")
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_email"
+    )
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_sms"
+    )
     def test_escalate_without_active_admin_triggers_sms(
         self, mocked_sms, mocked_email
     ) -> None:
@@ -107,7 +115,9 @@ class NotificationEscalationTests(APITestCase):
         self.assertIsNotNone(record.delivered_at)
         self.assertGreater(Notification.objects.count(), 0)
 
-    @patch("backend.chat_addons.notifications.views.NotificationService.send_sms")
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_sms"
+    )
     def test_escalation_respects_cooldown(self, mocked_sms) -> None:
         mocked_sms.return_value = None
         self.client.put(self.oncall_url, {"phone_e164": "+15553330000"}, format="json")

--- a/backend/stream_server_django/chat_addons/notifications/tests/test_service_authorization.py
+++ b/backend/stream_server_django/chat_addons/notifications/tests/test_service_authorization.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="stream_server_django.chat_addons.tests.pr5_urls",
+    CHAT_INTERNAL_SERVICE_TOKEN="service-secret",
+)
+class NotificationServiceAuthorizationTests(APITestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="notification-staff",
+            supabase_uid="notification-staff",
+            is_staff=True,
+        )
+        self.member = User.objects.create_user(
+            username="notification-member", supabase_uid="notification-member"
+        )
+        self.intake_url = reverse("intake-summary")
+        self.oncall_url = reverse("notifications-oncall")
+
+    def auth(self, user) -> dict[str, str]:
+        token = jwt.encode(
+            {"sub": user.supabase_uid},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_staff_and_service_are_accepted(self):
+        staff = self.client.get(self.intake_url, **self.auth(self.staff))
+        service = self.client.get(
+            self.intake_url, HTTP_X_CHAT_SERVICE_TOKEN="service-secret"
+        )
+
+        self.assertEqual(staff.status_code, 200)
+        self.assertEqual(service.status_code, 200)
+
+    def test_missing_wrong_and_browser_member_credentials_are_rejected(self):
+        missing = self.client.get(self.intake_url)
+        wrong = self.client.get(
+            self.intake_url, HTTP_X_CHAT_SERVICE_TOKEN="wrong-secret"
+        )
+        member = self.client.get(self.intake_url, **self.auth(self.member))
+
+        for response in (missing, wrong, member):
+            self.assertIn(response.status_code, {401, 403})
+
+    def test_service_actor_can_update_oncall_without_staff_impersonation(self):
+        response = self.client.put(
+            self.oncall_url,
+            {"email": "ops@example.com"},
+            format="json",
+            HTTP_X_CHAT_SERVICE_TOKEN="service-secret",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        actor = User.objects.get(username="__chat_internal_service__")
+        self.assertFalse(actor.is_staff)
+        self.assertFalse(actor.is_superuser)
+
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_email"
+    )
+    @patch(
+        "stream_server_django.chat_addons.notifications.views.NotificationService.send_sms"
+    )
+    def test_service_actor_can_trigger_explicit_operational_escalation(
+        self, send_sms, send_email
+    ):
+        response = self.client.post(
+            reverse("notifications-escalate"),
+            {"cid": "messaging:ops-room", "reason": "provider alarm"},
+            format="json",
+            HTTP_X_CHAT_SERVICE_TOKEN="service-secret",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        send_sms.assert_not_called()
+        send_email.assert_not_called()

--- a/backend/stream_server_django/chat_addons/notifications/views.py
+++ b/backend/stream_server_django/chat_addons/notifications/views.py
@@ -9,14 +9,17 @@ from django.db import models
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.authentication import BaseAuthentication
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from stream_server_django.accounts_supabase.authentication import DevTokenOrJWTAuthentication
 from stream_server_django.common.identity import get_chat_identity
-from stream_server_django.chat_addons.permissions import IsChatStaff
+from stream_server_django.chat_addons.permissions import IsStaffOrService
+from stream_server_django.chat_addons.service_auth import (
+    InternalServiceAuthentication,
+    is_internal_service_request,
+)
 
 from stream_server_django.chat_addons.admin_console.models import MessageIntake
 
@@ -29,8 +32,11 @@ ESCALATION_COOLDOWN_SEC = getattr(settings, "ESCALATION_COOLDOWN_SEC", 300)
 
 
 class NotificationsBaseView(APIView):
-    authentication_classes: List[type[BaseAuthentication]] = [DevTokenOrJWTAuthentication]
-    permission_classes = [IsAuthenticated, IsChatStaff]
+    authentication_classes: List[type[BaseAuthentication]] = [
+        InternalServiceAuthentication,
+        DevTokenOrJWTAuthentication,
+    ]
+    permission_classes = [IsStaffOrService]
 
 
 class IntakeSummaryView(NotificationsBaseView):
@@ -83,14 +89,18 @@ def _active_admin_exists(now: datetime) -> bool:
     return AdminPresence.objects.filter(last_seen_at__gte=cutoff).exists()
 
 
-def _notification_recipients(request_user) -> Iterable[settings.AUTH_USER_MODEL]:
+def _notification_recipients(request_user=None) -> Iterable[settings.AUTH_USER_MODEL]:
     UserModel = get_user_model()
     staff = list(
         UserModel.objects.filter(
             models.Q(is_staff=True) | models.Q(is_superuser=True)
         ).distinct()
     )
-    if request_user.is_authenticated and request_user not in staff:
+    if (
+        request_user is not None
+        and request_user.is_authenticated
+        and request_user not in staff
+    ):
         staff.append(request_user)
     return staff
 
@@ -123,7 +133,9 @@ class EscalateRoomView(NotificationsBaseView):
         service = self.service_class()
 
         note_text = f"[Escalation] {cid} – {reason}"
-        recipients = _notification_recipients(user)
+        recipients = _notification_recipients(
+            None if is_internal_service_request(request) else user
+        )
         notifications = service.create_notification_item(text=note_text, users=recipients)
         notification = notifications[0] if notifications else None
 

--- a/backend/stream_server_django/chat_addons/permissions.py
+++ b/backend/stream_server_django/chat_addons/permissions.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from rest_framework.permissions import BasePermission
 from stream_server_django.common.identity import get_chat_identity
 
+from .service_auth import is_internal_service_request
+
 
 class IsChatStaff(BasePermission):
     """
@@ -29,3 +31,14 @@ class IsChatStaff(BasePermission):
             return False
 
         return bool(getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))
+
+
+class IsStaffOrService(BasePermission):
+    """Allow staff JWTs or the explicit internal-service credential."""
+
+    message = "Staff or internal service credentials required."
+
+    def has_permission(self, request, view) -> bool:  # type: ignore[override]
+        if is_internal_service_request(request):
+            return True
+        return IsChatStaff().has_permission(request, view)

--- a/backend/stream_server_django/chat_addons/service_auth.py
+++ b/backend/stream_server_django/chat_addons/service_auth.py
@@ -1,0 +1,58 @@
+"""Authentication for explicitly internal chat service routes."""
+
+from __future__ import annotations
+
+import hmac
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+SERVICE_TOKEN_HEADER = "X-Chat-Service-Token"
+
+
+@dataclass(frozen=True)
+class InternalServiceCredentials:
+    """Marker stored in ``request.auth`` for service-token requests."""
+
+    service_name: str = "chat-internal-service"
+
+
+def is_internal_service_request(request) -> bool:
+    return isinstance(getattr(request, "auth", None), InternalServiceCredentials)
+
+
+class InternalServiceAuthentication(BaseAuthentication):
+    """Authenticate a service token only on views that opt into this class."""
+
+    def authenticate(self, request):
+        supplied = request.headers.get(SERVICE_TOKEN_HEADER)
+        if supplied is None:
+            return None
+
+        expected = str(getattr(settings, "CHAT_INTERNAL_SERVICE_TOKEN", "") or "")
+        if not expected or not hmac.compare_digest(supplied, expected):
+            raise AuthenticationFailed("Invalid internal service credentials.")
+
+        username = str(
+            getattr(
+                settings,
+                "CHAT_INTERNAL_SERVICE_USERNAME",
+                "__chat_internal_service__",
+            )
+        ).strip() or "__chat_internal_service__"
+        User = get_user_model()
+        user, created = User.objects.get_or_create(
+            username=username,
+            defaults={"supabase_uid": f"service:{username}"},
+        )
+        if created:
+            user.set_unusable_password()
+            user.save(update_fields=["password"])
+        return user, InternalServiceCredentials()
+
+    def authenticate_header(self, request) -> str:
+        return SERVICE_TOKEN_HEADER

--- a/backend/stream_server_django/chat_addons/sms_bridge/auth.py
+++ b/backend/stream_server_django/chat_addons/sms_bridge/auth.py
@@ -1,0 +1,46 @@
+"""Fail-closed authentication for SMS provider callbacks."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+from hashlib import sha256
+
+from django.conf import settings
+from rest_framework import status
+from rest_framework.exceptions import APIException, PermissionDenied
+
+
+class SmsWebhookNotConfigured(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = "Webhook secret not configured"
+
+
+class SmsWebhookReplay(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = "Webhook event already processed"
+
+
+def sms_provider_signature(secret: str, payload: bytes) -> str:
+    """Return the configured provider-v1 HMAC for the exact raw body."""
+
+    encoded = base64.b64encode(payload)
+    return hmac.new(secret.encode("utf-8"), encoded, sha256).hexdigest()
+
+
+def verify_sms_provider_signature(request) -> None:
+    """Require a valid ``X-Signature`` over the unmodified request body.
+
+    The provider contract available in this repository does not include a
+    signed timestamp. Replay protection is therefore enforced with the
+    provider's unique external event/message identifier after JSON validation.
+    """
+
+    secret = str(getattr(settings, "SMS_WEBHOOK_SECRET", "") or "")
+    if not secret:
+        raise SmsWebhookNotConfigured()
+
+    supplied = request.headers.get("X-Signature", "")
+    expected = sms_provider_signature(secret, request.body or b"")
+    if not supplied or not hmac.compare_digest(supplied.lower(), expected.lower()):
+        raise PermissionDenied("Invalid webhook signature")

--- a/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_authorization.py
+++ b/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_authorization.py
@@ -1,0 +1,179 @@
+import json
+from unittest.mock import patch
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat_addons.sms_bridge.auth import sms_provider_signature
+from stream_server_django.chat_addons.sms_bridge.models import SmsRelay
+from stream_server_django.chat_addons.sms_bridge.services.provider import (
+    SmsProviderResponse,
+)
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="stream_server_django.chat_addons.tests.pr5_urls",
+    CHAT_INTERNAL_SERVICE_TOKEN="service-secret",
+    SMS_WEBHOOK_SECRET="webhook-secret",
+)
+class SmsAuthorizationTests(APITestCase):
+    def setUp(self):
+        self.member = User.objects.create_user(
+            username="sms-member", supabase_uid="sms-member"
+        )
+        self.staff = User.objects.create_user(
+            username="sms-staff", supabase_uid="sms-staff", is_staff=True
+        )
+        self.webhook_url = reverse("sms-inbound-webhook")
+        self.receipt_url = reverse("sms-delivery-receipt")
+        self.send_url = reverse("sms-send")
+        self.webhook_payload = {
+            "from": "+15551230000",
+            "to": "+15559870000",
+            "text": "Hello",
+            "external_id": "provider-event-1",
+            "event": "message",
+        }
+
+    def jwt_auth(self, user) -> dict[str, str]:
+        token = jwt.encode(
+            {"sub": user.supabase_uid},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def signed_post(self, url, payload):
+        body = json.dumps(payload).encode("utf-8")
+        return self.client.post(
+            url,
+            body,
+            content_type="application/json",
+            HTTP_X_SIGNATURE=sms_provider_signature("webhook-secret", body),
+        )
+
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    def test_webhook_requires_exact_signature_and_rejects_replay(self, broadcast):
+        missing = self.client.post(
+            self.webhook_url, self.webhook_payload, format="json"
+        )
+        invalid = self.client.post(
+            self.webhook_url,
+            self.webhook_payload,
+            format="json",
+            HTTP_X_SIGNATURE="invalid",
+        )
+
+        original_body = json.dumps(self.webhook_payload).encode("utf-8")
+        modified = dict(self.webhook_payload, text="modified")
+        modified_body = json.dumps(modified).encode("utf-8")
+        modified_response = self.client.post(
+            self.webhook_url,
+            modified_body,
+            content_type="application/json",
+            HTTP_X_SIGNATURE=sms_provider_signature(
+                "webhook-secret", original_body
+            ),
+        )
+        browser_only = self.client.post(
+            self.webhook_url,
+            self.webhook_payload,
+            format="json",
+            **self.jwt_auth(self.staff),
+        )
+
+        valid = self.signed_post(self.webhook_url, self.webhook_payload)
+        replay = self.signed_post(self.webhook_url, self.webhook_payload)
+
+        for response in (missing, invalid, modified_response, browser_only):
+            self.assertEqual(response.status_code, 403)
+        self.assertEqual(valid.status_code, 200)
+        self.assertEqual(replay.status_code, 409)
+        self.assertEqual(SmsRelay.objects.filter(direction="inbound").count(), 1)
+        broadcast.assert_called_once()
+
+    @override_settings(SMS_WEBHOOK_SECRET="")
+    def test_missing_webhook_secret_fails_closed(self):
+        response = self.client.post(
+            self.webhook_url, self.webhook_payload, format="json"
+        )
+        self.assertEqual(response.status_code, 503)
+
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    def test_receipt_requires_provider_signature_or_service_token(self, broadcast):
+        SmsRelay.objects.create(
+            cid="messaging:receipt-a",
+            direction=SmsRelay.DIRECTION_OUTBOUND,
+            external_id="receipt-a",
+            status=SmsRelay.STATUS_PENDING,
+        )
+        payload = {"external_id": "receipt-a", "status": "delivered"}
+
+        browser_only = self.client.post(
+            self.receipt_url,
+            payload,
+            format="json",
+            **self.jwt_auth(self.staff),
+        )
+        signed = self.signed_post(self.receipt_url, payload)
+        replay = self.signed_post(self.receipt_url, payload)
+
+        SmsRelay.objects.create(
+            cid="messaging:receipt-b",
+            direction=SmsRelay.DIRECTION_OUTBOUND,
+            external_id="receipt-b",
+            status=SmsRelay.STATUS_PENDING,
+        )
+        service = self.client.post(
+            self.receipt_url,
+            {"external_id": "receipt-b", "status": "failed"},
+            format="json",
+            HTTP_X_CHAT_SERVICE_TOKEN="service-secret",
+        )
+
+        self.assertEqual(browser_only.status_code, 403)
+        self.assertEqual(signed.status_code, 200)
+        self.assertEqual(replay.status_code, 409)
+        self.assertEqual(service.status_code, 200)
+        self.assertEqual(broadcast.call_count, 2)
+
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    def test_sms_send_accepts_staff_or_service_but_not_browser_member(
+        self, provider_send, broadcast
+    ):
+        provider_send.side_effect = [
+            SmsProviderResponse(external_id="send-service"),
+            SmsProviderResponse(external_id="send-staff"),
+        ]
+        payload = {
+            "cid": "messaging:sms-auth-room",
+            "to": "+15551239999",
+            "text": "Operational message",
+        }
+
+        member = self.client.post(
+            self.send_url, payload, format="json", **self.jwt_auth(self.member)
+        )
+        service = self.client.post(
+            self.send_url,
+            payload,
+            format="json",
+            HTTP_X_CHAT_SERVICE_TOKEN="service-secret",
+        )
+        staff = self.client.post(
+            self.send_url, payload, format="json", **self.jwt_auth(self.staff)
+        )
+
+        self.assertEqual(member.status_code, 403)
+        self.assertEqual(service.status_code, 202)
+        self.assertEqual(staff.status_code, 202)
+        self.assertEqual(provider_send.call_count, 2)
+        self.assertEqual(broadcast.call_count, 2)

--- a/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_bridge.py
+++ b/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_bridge.py
@@ -56,7 +56,7 @@ class SmsBridgeWebhookTests(APITestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(Message.objects.count(), 0)
 
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
     def test_valid_webhook_creates_message(self, mocked_broadcast) -> None:
         signature = make_signature("super-secret", self.payload)
         response = self.post_payload(self.payload, signature)
@@ -78,19 +78,21 @@ class SmsBridgeWebhookTests(APITestCase):
         self.assertEqual(link.phone_e164, "+15551230000")
         mocked_broadcast.assert_called_once()
 
-    def test_duplicate_external_id_noop(self) -> None:
+    def test_duplicate_external_id_is_rejected_as_replay(self) -> None:
         signature = make_signature("super-secret", self.payload)
         first = self.post_payload(self.payload, signature)
         self.assertEqual(first.status_code, 200)
         second = self.post_payload(self.payload, signature)
-        self.assertEqual(second.status_code, 200)
+        self.assertEqual(second.status_code, 409)
         self.assertEqual(Message.objects.count(), 1)
         self.assertEqual(SmsRelay.objects.count(), 1)
 
     @override_settings(SMS_AUTOREPLY_ENABLED=True, SMS_AUTOREPLY_ALLOWLIST=["+15551230000"])
-    @patch("backend.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay")
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay"
+    )
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_stop_creates_consent_and_confirmation(
         self,
         mocked_send,
@@ -122,9 +124,11 @@ class SmsBridgeWebhookTests(APITestCase):
         )
 
     @override_settings(SMS_AUTOREPLY_ENABLED=True, SMS_AUTOREPLY_ALLOWLIST=["+15551230000"])
-    @patch("backend.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay")
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay"
+    )
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_opted_out_blocks_autoreply(
         self,
         mocked_send,
@@ -150,9 +154,11 @@ class SmsBridgeWebhookTests(APITestCase):
         mocked_delay.assert_not_called()
 
     @override_settings(SMS_AUTOREPLY_ENABLED=True, SMS_AUTOREPLY_ALLOWLIST=["+15551230000"])
-    @patch("backend.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay")
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay"
+    )
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_start_clears_opt_out_and_allows_autoreply(
         self,
         mocked_send,
@@ -210,8 +216,8 @@ class SmsBridgeSendTests(APITestCase):
         self.agent.save(update_fields=["is_staff"])
         self.url = reverse("sms-send")
 
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_send_creates_pending_message(self, mocked_send, mocked_broadcast) -> None:
         mocked_send.return_value = SmsProviderResponse(external_id="ext-2")
         self.client.force_authenticate(user=self.agent)
@@ -274,10 +280,12 @@ class SmsBridgeReceiptTests(APITestCase):
         )
         self.url = reverse("sms-delivery-receipt")
 
-    @patch("backend.chat_addons.sms_bridge.views.broadcast_message_update")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.views.broadcast_message_update"
+    )
     def test_receipt_updates_message(self, mocked_broadcast) -> None:
         payload = {"external_id": "ext-receipt", "status": "delivered", "error_code": None}
-        response = self.client.post(self.url, payload, format="json")
+        response = self.post_signed(payload)
 
         self.assertEqual(response.status_code, 200)
         self.relay.refresh_from_db()
@@ -285,3 +293,12 @@ class SmsBridgeReceiptTests(APITestCase):
         self.message.refresh_from_db()
         self.assertEqual(self.message.custom_data.get("delivery_status"), "delivered")
         mocked_broadcast.assert_called_once_with(self.message)
+
+    def post_signed(self, payload: dict[str, object]):
+        body = json.dumps(payload)
+        return self.client.post(
+            self.url,
+            body,
+            content_type="application/json",
+            HTTP_X_SIGNATURE=make_signature("super-secret", payload),
+        )

--- a/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_consent.py
+++ b/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_consent.py
@@ -49,9 +49,11 @@ class SmsConsentWebhookTests(APITestCase):
         )
 
     @override_settings(SMS_AUTOREPLY_ENABLED=True, SMS_AUTOREPLY_ALLOWLIST=["+15551231234"])
-    @patch("backend.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay")
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay"
+    )
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_stop_opts_out_sends_confirmation_and_skips_autoreply(
         self,
         mocked_send,
@@ -82,9 +84,11 @@ class SmsConsentWebhookTests(APITestCase):
         self.assertTrue(SmsConsent.objects.filter(phone_e164="+15551231234").exists())
 
     @override_settings(SMS_AUTOREPLY_ENABLED=True, SMS_AUTOREPLY_ALLOWLIST=["+15551231234"])
-    @patch("backend.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay")
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay"
+    )
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_start_opts_in_sends_confirmation_and_skips_autoreply(
         self,
         mocked_send,
@@ -114,9 +118,11 @@ class SmsConsentWebhookTests(APITestCase):
         )
 
     @override_settings(SMS_AUTOREPLY_ENABLED=True, SMS_AUTOREPLY_ALLOWLIST=["+15551231234"])
-    @patch("backend.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay")
-    @patch("backend.chat_addons.sms_bridge.views._broadcast_to_cid")
-    @patch("backend.chat_addons.sms_bridge.views.SmsProviderClient.send")
+    @patch(
+        "stream_server_django.chat_addons.sms_bridge.services.autoreply.sms_autoreply_task.delay"
+    )
+    @patch("stream_server_django.chat_addons.sms_bridge.views._broadcast_to_cid")
+    @patch("stream_server_django.chat_addons.sms_bridge.views.SmsProviderClient.send")
     def test_opted_out_sender_never_enqueues_autoreply(
         self,
         mocked_send,

--- a/backend/stream_server_django/chat_addons/sms_bridge/views.py
+++ b/backend/stream_server_django/chat_addons/sms_bridge/views.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import base64
-import hmac
 import logging
 import uuid
-from hashlib import sha256
 
-from django.conf import settings
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.authentication import BaseAuthentication
-from rest_framework.exceptions import APIException, NotFound, PermissionDenied
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import APIException, NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -21,12 +17,20 @@ from stream_server_django.chat.broadcast import _broadcast_to_cid
 from stream_server_django.chat.models import Message
 from stream_server_django.chat.serializers import MessageSerializer
 from stream_server_django.chat.consumers import broadcast_message_update
-from stream_server_django.chat_addons.permissions import IsChatStaff
+from stream_server_django.chat_addons.permissions import IsStaffOrService
+from stream_server_django.chat_addons.service_auth import (
+    InternalServiceAuthentication,
+    is_internal_service_request,
+)
 
 from ..common_audit.decorators import audit_action
 from ..common_audit.models import AuditTrail
 from ..common_audit.throttling import SmsSendRateThrottle
 from .models import SmsRelay
+from .auth import (
+    SmsWebhookReplay,
+    verify_sms_provider_signature,
+)
 from .serializers import SmsReceiptSerializer, SmsSendSerializer, SmsWebhookSerializer
 from .services.autoreply import maybe_enqueue_sms_autoreply
 from .services.consent import (
@@ -47,27 +51,9 @@ from .services.provider import SmsProviderClient, SmsProviderError
 logger = logging.getLogger(__name__)
 
 
-class WebhookNotConfigured(APIException):
-    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-    default_detail = "Webhook secret not configured"
-
-
 class SmsProviderUnavailable(APIException):
     status_code = status.HTTP_502_BAD_GATEWAY
     default_detail = "SMS provider error"
-
-
-def _signature_secret() -> str:
-    secret = getattr(settings, "SMS_WEBHOOK_SECRET", "")
-    if not secret:
-        raise WebhookNotConfigured()
-    return secret
-
-
-def _compute_signature(secret: str, payload: bytes) -> str:
-    encoded = base64.b64encode(payload)
-    digest = hmac.new(secret.encode("utf-8"), encoded, sha256)
-    return digest.hexdigest()
 
 
 class SmsWebhookView(APIView):
@@ -75,13 +61,7 @@ class SmsWebhookView(APIView):
     permission_classes: list = []
 
     def post(self, request: Request) -> Response:
-        secret = _signature_secret()
-        header_signature = request.headers.get("X-Signature", "")
-        computed = _compute_signature(secret, request.body or b"")
-        if not header_signature or not hmac.compare_digest(
-            header_signature.lower(), computed.lower()
-        ):
-            raise PermissionDenied("Invalid webhook signature")
+        verify_sms_provider_signature(request)
 
         inbound_data = request.data or {}
         serializer = SmsWebhookSerializer(
@@ -97,26 +77,37 @@ class SmsWebhookView(APIView):
         payload = serializer.validated_data
 
         external_id = payload["external_id"]
-        if SmsRelay.objects.filter(
-            direction=SmsRelay.DIRECTION_INBOUND, external_id=external_id
-        ).exists():
-            return Response({"ok": True})
-
         from_phone = payload["from_phone"]
         text = payload["text"]
 
-        user = get_or_create_phone_user(from_phone)
-        sender_identifier = getattr(user, "supabase_uid", None) or user.username
+        try:
+            with transaction.atomic():
+                if SmsRelay.objects.filter(
+                    direction=SmsRelay.DIRECTION_INBOUND,
+                    external_id=external_id,
+                ).exists():
+                    raise SmsWebhookReplay()
 
-        link = ensure_link(phone_e164=from_phone, client_identifier=sender_identifier)
-        message = record_inbound_message(
-            cid=link.cid,
-            text=text,
-            sender_identifier=sender_identifier,
-            relay_external_id=external_id,
-        )
+                user = get_or_create_phone_user(from_phone)
+                sender_identifier = (
+                    getattr(user, "supabase_uid", None) or user.username
+                )
+                link = ensure_link(
+                    phone_e164=from_phone,
+                    client_identifier=sender_identifier,
+                )
+                message = record_inbound_message(
+                    cid=link.cid,
+                    text=text,
+                    sender_identifier=sender_identifier,
+                    relay_external_id=external_id,
+                )
+        except IntegrityError as exc:
+            raise SmsWebhookReplay() from exc
+
+        control_word = parse_control_word(text)
         room = message.rooms.order_by("pk").first()
-        if room:
+        if room and control_word not in {"stop", "start"}:
             maybe_enqueue_sms_autoreply(
                 room=room,
                 triggering_message=message,
@@ -129,7 +120,6 @@ class SmsWebhookView(APIView):
             {"type": "message.new", "cid": link.cid, "message": serialized},
         )
 
-        control_word = parse_control_word(text)
         if control_word == "stop":
             mark_opt_out(from_phone)
             confirmation_text = stop_confirmation_text()
@@ -194,8 +184,11 @@ class SmsWebhookView(APIView):
 
 
 class SmsSendView(APIView):
-    authentication_classes: list[type[BaseAuthentication]] = [DevTokenOrJWTAuthentication]
-    permission_classes = [IsAuthenticated, IsChatStaff]
+    authentication_classes: list[type[BaseAuthentication]] = [
+        InternalServiceAuthentication,
+        DevTokenOrJWTAuthentication,
+    ]
+    permission_classes = [IsStaffOrService]
     throttle_classes = [SmsSendRateThrottle]
 
     @audit_action(action=AuditTrail.Action.SMS_SEND)
@@ -249,10 +242,15 @@ class SmsSendView(APIView):
 
 
 class SmsReceiptView(APIView):
-    authentication_classes: list[type[BaseAuthentication]] = []
+    authentication_classes: list[type[BaseAuthentication]] = [
+        InternalServiceAuthentication
+    ]
     permission_classes: list = []
 
     def post(self, request: Request) -> Response:
+        if not is_internal_service_request(request):
+            verify_sms_provider_signature(request)
+
         serializer = SmsReceiptSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         payload = serializer.validated_data
@@ -265,8 +263,8 @@ class SmsReceiptView(APIView):
         except SmsRelay.DoesNotExist as exc:
             raise NotFound("Relay not found") from exc
 
-        if relay.status == payload["status"]:
-            return Response({"ok": True}, status=status.HTTP_200_OK)
+        if relay.status != SmsRelay.STATUS_PENDING:
+            raise SmsWebhookReplay()
 
         relay.status = payload["status"]
         relay.save(update_fields=["status"])

--- a/backend/stream_server_django/chat_addons/tests/pr5_urls.py
+++ b/backend/stream_server_django/chat_addons/tests/pr5_urls.py
@@ -1,0 +1,15 @@
+"""Focused URL configuration for privileged-route authorization tests."""
+
+from django.urls import include, path
+
+from stream_server_django.chat_addons.agent.views import AgentCancelView
+
+
+urlpatterns = [
+    path("", include("stream_server_django.chat_addons.urls")),
+    path(
+        "api/rooms/<path:cid>/agent/cancel/",
+        AgentCancelView.as_view(),
+        name="agent-cancel",
+    ),
+]


### PR DESCRIPTION
## Summary

Implements PR5 of the JATTE-headless security hardening sequence: admin, agent, notification, and SMS service authorization.

This PR is stacked on PR #1191 / `security/pr4-attachment-privacy-upload-hardening` because it follows the auth, WebSocket, REST, and attachment hardening stack.

## Changes

- Adds a privileged-route authorization inventory under `backend/audit/pr5-service-auth-inventory.md`.
- Adds explicit internal service-token authentication using `X-Chat-Service-Token`.
- Adds shared staff/service permission helpers.
- Preserves staff-only admin-console access and verifies service tokens do not grant admin-console privileges.
- Gates normal agent invocation by room access.
- Gates agent control, policy, memory, run, cancel, skill, and simulation operations by room agent or staff/superuser.
- Gates notification/on-call/presence/escalation routes by staff/superuser or internal service credentials.
- Gates SMS send by staff/superuser or internal service credentials.
- Requires signed provider authentication for inbound SMS webhooks and unsigned receipt callbacks.
- Adds replay rejection for inbound webhook and delivery receipt events.
- Requires production service/webhook secrets through `settingsprod.py`.
- Adds focused authorization tests for agent, admin, notification/service, and SMS route families.

## Testing

- 53 PR5 and affected compatibility tests passed.
- 62 PR1-PR4 security regression tests passed.
- Django system check passed.
- Changed files compile successfully.
- `git diff --check` passed.

## Known deferred issue

Broad `compileall backend` remains blocked by the pre-existing `test_reminders.py:59` syntax error. The broad legacy add-on collection also retains unrelated import-time migration and historical agent/eval failures. PR5 changed files compile cleanly.

## Out of scope

- WebSocket authorization already handled in PR #1189
- REST room/message authorization already handled in PR #1190
- Attachment privacy already handled in PR #1191
- Rewriting agent orchestration
- Replacing the SMS provider integration
- Broad performance work or LLM orchestration changes

## Review guidance

Review this PR as the privileged-route boundary for the prior security stack. The key question is whether normal browser JWTs are separated from staff/admin/service/provider authority and whether the SMS provider callbacks are fail-closed, signed, exact-body checked, and replay-protected.