### PR TITLE
Security PR6: Lock Stream compatibility contract

### DIFF
--- a/backend/audit/pr6-stream-compatibility-contract.md
+++ b/backend/audit/pr6-stream-compatibility-contract.md
@@ -1,0 +1,94 @@
+# PR6 Stream compatibility contract
+
+## Contract boundary
+
+JATTE-headless implements only the subset of Stream Chat used by the JATTE
+frontend. It is not a general Stream Chat server. Successful payloads below are
+public compatibility contracts; PR1-PR5 authorization remains a prerequisite
+and is not weakened by an alias or a compatibility response.
+
+`frontend/src/lib/api.ts` prefixes adapter paths with `/api`. Consequently an
+adapter constant such as `/rooms/` calls `/api/rooms/`. The lower-level search
+shim deliberately keeps `/search/messages/` relative, while the composer
+attachment manager deliberately calls the root `/attachments/` alias. The
+production `jatte.urls` includes `stream_server_django.chat_api.urls` first so
+the canonical API views win over older lightweight routes; historical aliases
+remain available.
+
+Room access is the policy documented in `backend/SECURITY.md`. Inaccessible
+authenticated requests return 403, missing objects return 404, and missing or
+invalid bearer authentication fails under PR1. Consumers must not infer room
+existence from counts, cursors, members, search results, or attachment metadata.
+
+## Frontend call inventory
+
+| Frontend caller | Backend route | Method | Auth | Request and successful response used by the caller | Route status |
+| --- | --- | --- | --- | --- | --- |
+| `ChatClient.connectUser` | `/api/client-id/`, `/api/sync-user/`, `/api/ws-auth/`, `/api/connection-id/`, `/api/session/` | GET/POST/DELETE | bearer | IDs plus the synchronized user; WS auth returns the legacy URL and `expires`; connection is `{connection_id}` | canonical |
+| Token/bootstrap helpers | `/api/token/`, `/api/get-client/`, `/api/state/`, `/api/init-state/`, `/api/recover-state/` | GET | bearer | `{userID,userToken}`, `{client}`, state envelopes, and composer defaults | canonical |
+| `ChatClient.queryChannels` | `/api/rooms/`, `/api/rooms/active/`, `/api/rooms/<uuid>/` | GET | bearer + room access for detail | room fields include `uuid,cid,type,name,client,agent,messages,visible,status` | canonical |
+| Room bootstrap | `/api/rooms/resolve/` | POST | bearer | `{label}` -> `{room_uuid,name}`; repeated resolution is stable per user/label | canonical |
+| `Channel.query` / `Channel.watch` | `/api/rooms/<uuid-or-cid>/messages/` | GET | bearer + room access | `{messages,next}`; message fields include `id,text,body,sent_by,created_at,attachments,parent_id,pinned` | canonical |
+| `Channel.sendMessage` | `/api/rooms/<uuid-or-cid>/messages/` | POST | bearer + send access | composer message fields -> full message object, not a nested `{message}` envelope | canonical |
+| message edit/delete/restore | `/api/messages/<id>/`, `/api/messages/<id>/restore/`, `/api/messages/<id>/hide/` | GET/PUT/DELETE/POST | bearer + parent-room access + mutation role | full message for get/update/delete/restore; hide returns `{status,message}` | canonical |
+| `Channel.getReplies` | `/api/messages/<id>/replies/` | GET | bearer + parent-room access | `{messages,next}` | canonical |
+| compatibility reply caller | `/messages/<id>/replies/` | GET | same | same envelope | alias |
+| `ChatClient.getThreads` | `/api/threads/` | GET | bearer + CID room access | `{results,next}` with `thread_id,cid,root_message,reply_count` | canonical |
+| compatibility thread caller | `/threads/` | GET | same | same envelope | alias |
+| member hydration | `/api/rooms/<uuid>/members/` | GET | bearer + room access | UUID form returns a list with `id` | canonical UUID form |
+| member query compatibility | `/api/rooms/<cid>/members/` | GET | bearer + room access | `{members}`; supports `limit,offset`; entries contain `user_id,role,banned` and optional `user` | canonical CID form |
+| `Channel.read` / mark read | `/api/rooms/<uuid>/read/`, `mark_read/`, `mark_unread/`, `count_unread/`, `last_read/` | GET/POST | bearer + room access | current-user read rows; `{status}`, `{unread}`, and `{last_read}` | canonical |
+| composer draft/config | `/api/rooms/<uuid>/draft/`, `/api/rooms/<uuid>/config-state/`, `/api/rooms/<cid>/config/`, `/api/rooms/<uuid>/cooldown/` | GET/POST/DELETE | bearer + room access | draft list/status; config-state has `config.composer`, `config.ai`, `has_ai_assistant`; basic config is `{name,type,muted}`; cooldown fields remain numeric | canonical |
+| composer helpers | `/api/text-composer/`, `/api/compose/`, `/api/has-sendable-data/`, `/api/composition-is-empty/` | POST | bearer | `{text}`, `{composition}`, `{has_sendable_data}`, `{is_empty}` | canonical |
+| reactions | `/api/messages/<id>/reactions/`, `/api/messages/<id>/reactions/<type>/` | GET/POST/DELETE | bearer + parent-room access | reaction list/object; typed operation returns `{status,message_id,type}` and is idempotent | canonical |
+| flags/pins/actions | `/api/messages/<id>/flag/`, `pin/`, `unpin/`, `actions/` | POST/DELETE | bearer + parent-room access; pin/action require room admin | `{flag}`, `{pin}`, 204, `{action}` | canonical |
+| message search shim | `/search/messages/` | GET | bearer; results filtered to accessible rooms | `{results,next}` with `id,text,user_id,created_at,cid`; no cross-room total count is exposed | root canonical |
+| `Channel.getConfigState` | `/api/rooms/<uuid>/config-state/` | GET | bearer + room access, except explicit public config-state carve-out | composer and AI configuration only | canonical |
+| composer legacy upload | `/attachments/` | POST | bearer | `{attachment}` placeholder retaining `id,name,filename,url,scan_status`; never a downloadable blob | frontend alias |
+| attachment clients | `/api/attachments/`, `/api/attachments/sign/`, `/api/attachments/commit/`, `/api/attachments/<id>/download/` | POST/GET | bearer + PR4 room/message binding | legacy metadata, signed PUT envelope, `{attachment}`, then private redirect for clean attachments | canonical |
+| attachment compatibility | `/attachments/sign/`, `/attachments/commit/` | POST | same | same successful shapes | aliases |
+| `invokeAgent` | `/api/chat/agent/<cid>/invoke/` | POST | bearer + room access | invocation -> 202 `{status:"queued",job_id,trace_id}` | canonical |
+| `requestAgentReply` | `/api/chat/agent/rag/` | POST | bearer + room access + enabled agent | `{messages,reason}` | canonical |
+| agent status/control | `/chat/agent/<cid>/`, `enable/`, `disable/` | GET/POST | bearer; control requires room agent/staff | `{cid,agent_enabled,updated_at}` | root compatibility |
+
+The frontend also calls room archive/unarchive/hide/show, pinned messages,
+notifications, polls, reminders, mutes, link previews, editing audit state, and
+subscription helpers. These retain their existing route and successful fields;
+they are outside the minimum PR6 fixture set when Stream UI does not inspect
+their response beyond success.
+
+## WebSocket contract
+
+Both `/ws/<cid>/?token=<jwt>` and the intentional generic
+`/ws/chat/?token=<jwt>` route use the same consumer. Authentication succeeds
+before acceptance. The generic route selects a room only through an authorized
+`channel.watch`; a room-specific route rejects a different payload CID.
+
+| Direction | Event | Required public fields |
+| --- | --- | --- |
+| server -> client | connection acknowledgement | `{type:"user.join",user}` |
+| client -> server | watch | `{type:"channel.watch",cid}` |
+| server -> client | initialized | `type,cid,initialized,messages,next,members` |
+| server -> client | new/update | `type,cid,message`; message uses the REST message subset |
+| server -> client | delete | `type,cid,message_id,deleted_by,ts` |
+| both | typing start/stop | `type,cid,user_id` |
+| server -> client | read | `type,cid,user,created_at`; `user` includes `id,channel_last_read_at,channel_unread_count` |
+
+REST message creation is the frontend's normal send path. Its channel-layer
+broadcast supplies the nested `message` used by `Channel.onmessage`. The
+consumer's direct `message.new` input remains a compatibility operation, but
+does not replace that REST contract.
+
+## Pagination and errors
+
+- Message and reply pagination uses `before`; responses always retain
+  `{messages,next}` and cursors are re-authorized against the requested room.
+- Search uses `before` and retains `{results,next}`.
+- Threads use `cursor` and retain `{results,next}`.
+- CID members use `limit` and `offset` inside `{members}`.
+- Variable timestamps, generated IDs, and optional fields are intentionally
+  asserted as public subsets rather than full-payload equality.
+- Frontend-dependent validation errors retain a JSON `detail` field. Agent
+  disabled and room-mismatch responses retain their current `detail` strings.
+- Security denials stay 403/404 or WebSocket `forbidden`, `not_watched`, and
+  `cid_mismatch`; compatibility aliases do not bypass those checks.

--- a/backend/jatte/urls.py
+++ b/backend/jatte/urls.py
@@ -6,6 +6,7 @@ from stream_server_django.chat_addons.agent.views import AgentCancelView, AgentL
 
 from stream_server_django.chat.views import TokenView  # real view
 from stream_server_django.chat.views_quoted import QuotedMessageView
+from stream_server_django.rooms.views import resolve_room
 from stream_server_django.chat.api_views import (
     RoomConfigView,
     RoomMarkReadView,
@@ -17,6 +18,18 @@ from stream_server_django.chat.api_views import (
 # from stream_server_django.chat.views import dev_token        # <- if you still need the dev stub
 
 urlpatterns = [
+    # Resolve must precede chat's /api/rooms/<uuid>/ detail route. Add-ons must
+    # precede chat's legacy invoke fallback so the frontend reaches the queued
+    # agent implementation. The chat routes then provide the canonical /api
+    # contract and root aliases without duplicating auth/core URL namespaces.
+    path("api/rooms/resolve/", resolve_room, name="room-resolve"),
+    re_path(r"^api/rooms/resolve/?$", resolve_room),
+    # Preserve PR1's shared-auth legacy handshake (including no-slash parity)
+    # ahead of chat.urls' minimal test handshake view.
+    path("api/ws-auth/", api.ws_auth, name="ws-auth"),
+    re_path(r"^api/ws-auth/?$", api.ws_auth),
+    path("", include("stream_server_django.chat_addons.urls")),
+    path("", include("stream_server_django.chat.urls")),
     path("", include("stream_server_django.auth.urls")),
     path("", include("stream_server_django.accounts_supabase.urls")),
     path("", include("stream_server_django.users.urls")),
@@ -28,7 +41,6 @@ urlpatterns = [
     path("", include("stream_server_django.reminders.urls")),
     path("", include("stream_server_django.events.urls")),
     path("", include("stream_server_django.state.urls")),
-    path("", include("stream_server_django.chat_addons.urls")),
     path("quoted-message/", QuotedMessageView.as_view(), name="quoted-message"),
     path("admin/", admin.site.urls),
 

--- a/backend/stream_server_django/chat/tests/test_stream_contract_rest.py
+++ b/backend/stream_server_django/chat/tests/test_stream_contract_rest.py
@@ -1,0 +1,479 @@
+"""Authorized REST contract coverage for the frontend Stream adapter subset."""
+
+from unittest.mock import patch
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.cache import caches
+from django.test import override_settings
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat.models import Channel, Message, Reaction, Room
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="jatte.urls",
+    PUBLIC_AGENT_ROOM_SLUGS=[],
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "stream-contract-default",
+        },
+        "throttles": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "stream-contract-throttles",
+        },
+    },
+)
+class StreamRestContractTests(APITestCase):
+    def setUp(self):
+        caches["default"].clear()
+        caches["throttles"].clear()
+        self.member = self._user("contract-member")
+        self.agent = self._user("contract-agent")
+        self.outsider = self._user("contract-outsider")
+        self.room = Room.objects.create(
+            uuid="contract-room",
+            client=self.member.username,
+            agent=self.agent,
+            data={"name": "Contract room"},
+            status=Room.ACTIVE,
+        )
+        self.channel = Channel.objects.create(
+            uuid=self.room.uuid, client=self.room.client
+        )
+        self.messages = [
+            self._message(f"contract message {index}") for index in range(4)
+        ]
+
+    def tearDown(self):
+        caches["default"].clear()
+        caches["throttles"].clear()
+        super().tearDown()
+
+    def _user(self, username, **extra):
+        return User.objects.create_user(
+            username=username,
+            email=f"{username}@example.com",
+            supabase_uid=username,
+            password="x",
+            **extra,
+        )
+
+    def _message(self, text, *, sender=None, reply_to=None):
+        message = Message.objects.create(
+            channel=self.channel,
+            body=text,
+            sent_by=(sender or self.member).username,
+            reply_to=reply_to,
+        )
+        self.room.messages.add(message)
+        return message
+
+    def token(self, user=None):
+        actor = user or self.member
+        return jwt.encode(
+            {"sub": actor.supabase_uid, "email": actor.email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+
+    def auth(self, user=None):
+        return {"HTTP_AUTHORIZATION": f"Bearer {self.token(user)}"}
+
+    def assert_message_contract(self, payload):
+        self.assertTrue(
+            {
+                "id",
+                "text",
+                "body",
+                "sent_by",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+                "attachments",
+                "custom_data",
+                "parent_id",
+                "pinned",
+            }.issubset(payload)
+        )
+
+    def test_bootstrap_routes_keep_frontend_fields_and_require_bearer_auth(self):
+        token = self.token()
+        headers = self.auth()
+
+        token_response = self.client.get("/api/token/", **headers)
+        self.assertEqual(token_response.status_code, 200)
+        self.assertEqual(token_response.data["userID"], self.member.id)
+        self.assertEqual(token_response.data["userToken"], token)
+
+        ws_auth = self.client.get("/api/ws-auth/", **headers)
+        connection = self.client.get("/api/connection-id/", **headers)
+        client = self.client.get("/api/get-client/", **headers)
+        state = self.client.get("/api/state/", **headers)
+        initial = self.client.get("/api/init-state/", **headers)
+        recovered = self.client.get("/api/recover-state/", **headers)
+
+        self.assertEqual(ws_auth.status_code, 200)
+        self.assertEqual(set(ws_auth.data), {"stream_server_django.auth", "expires"})
+        self.assertTrue(
+            ws_auth.data["stream_server_django.auth"].startswith(
+                "ws://testserver/ws/?token="
+            )
+        )
+        self.assertIsInstance(connection.data["connection_id"], str)
+        self.assertEqual(client.data["client"]["username"], self.member.username)
+        self.assertIn("stream_server_django.users", state.data)
+        self.assertEqual(
+            set(initial.data),
+            {"text", "attachments", "poll", "custom_data", "quoted_message"},
+        )
+        self.assertTrue(
+            {"stream_server_django.rooms", "notifications"}.issubset(recovered.data)
+        )
+        self.assertEqual(self.client.get("/api/get-client/").status_code, 403)
+
+    def test_room_bootstrap_payload_and_resolver_contract(self):
+        rooms = self.client.get("/api/rooms/", **self.auth())
+        active = self.client.get("/api/rooms/active/", **self.auth())
+        detail = self.client.get(f"/api/rooms/{self.room.uuid}/", **self.auth())
+
+        self.assertEqual(rooms.status_code, 200)
+        self.assertEqual([item["uuid"] for item in rooms.data], [self.room.uuid])
+        room_payload = rooms.data[0]
+        self.assertTrue(
+            {
+                "uuid",
+                "cid",
+                "type",
+                "name",
+                "client",
+                "agent",
+                "messages",
+                "visible",
+                "status",
+            }.issubset(room_payload)
+        )
+        self.assertEqual(room_payload["cid"], f"messaging:{self.room.uuid}")
+        self.assertEqual(room_payload["type"], "messaging")
+        self.assertEqual(active.data[0]["uuid"], self.room.uuid)
+        self.assertEqual(detail.data["name"], "Contract room")
+
+        first = self.client.post(
+            "/api/rooms/resolve/", {"label": "Agent Lab"}, format="json", **self.auth()
+        )
+        second = self.client.post(
+            "/api/rooms/resolve/", {"label": "Agent Lab"}, format="json", **self.auth()
+        )
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(first.data, second.data)
+        self.assertEqual(set(first.data), {"room_uuid", "name"})
+
+    @patch("stream_server_django.chat.api_views._broadcast_to_cid")
+    @patch(
+        "stream_server_django.chat.api_views.should_gate_first_message",
+        return_value="allow",
+    )
+    def test_message_crud_pagination_and_direct_payloads(self, _gate, _broadcast):
+        url = f"/api/rooms/messaging:{self.room.uuid}/messages/"
+        first = self.client.get(url, {"limit": 2}, **self.auth())
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(set(first.data), {"messages", "next"})
+        self.assertEqual(len(first.data["messages"]), 2)
+        self.assertIsNotNone(first.data["next"])
+        self.assert_message_contract(first.data["messages"][0])
+
+        second = self.client.get(
+            url, {"limit": 2, "before": first.data["next"]}, **self.auth()
+        )
+        self.assertEqual(second.status_code, 200)
+        self.assertTrue(
+            {item["id"] for item in first.data["messages"]}.isdisjoint(
+                {item["id"] for item in second.data["messages"]}
+            )
+        )
+
+        created = self.client.post(
+            url,
+            {"body": "created through adapter", "text": "created through adapter"},
+            format="json",
+            **self.auth(),
+        )
+        self.assertEqual(created.status_code, 201, created.data)
+        self.assert_message_contract(created.data)
+        self.assertEqual(created.data["text"], "created through adapter")
+
+        message_url = f"/api/messages/{created.data['id']}/"
+        fetched = self.client.get(message_url, **self.auth())
+        updated = self.client.put(
+            message_url,
+            {"body": "updated", "text": "updated"},
+            format="json",
+            **self.auth(),
+        )
+        deleted = self.client.delete(message_url, **self.auth())
+        for response in (fetched, updated, deleted):
+            self.assertEqual(response.status_code, 200)
+            self.assert_message_contract(response.data)
+        self.assertEqual(updated.data["text"], "updated")
+        self.assertIsNotNone(deleted.data["deleted_at"])
+
+    def test_member_uuid_and_cid_contracts_are_both_supported(self):
+        uuid_response = self.client.get(
+            f"/api/rooms/{self.room.uuid}/members/", **self.auth()
+        )
+        cid_response = self.client.get(
+            f"/api/rooms/messaging:{self.room.uuid}/members/",
+            {"limit": 1, "offset": 0},
+            **self.auth(),
+        )
+
+        self.assertEqual(uuid_response.status_code, 200)
+        self.assertIsInstance(uuid_response.data, list)
+        self.assertTrue(all("id" in item for item in uuid_response.data))
+        self.assertEqual(cid_response.status_code, 200)
+        self.assertEqual(set(cid_response.data), {"members"})
+        self.assertEqual(len(cid_response.data["members"]), 1)
+        self.assertTrue(
+            {"user_id", "role", "banned"}.issubset(cid_response.data["members"][0])
+        )
+
+    def test_read_draft_config_and_composer_shapes(self):
+        room_url = f"/api/rooms/{self.room.uuid}"
+        mark_read = self.client.post(f"{room_url}/mark_read/", **self.auth())
+        read = self.client.get(f"{room_url}/read/", **self.auth())
+        unread = self.client.get(f"{room_url}/count_unread/", **self.auth())
+        last_read = self.client.get(f"{room_url}/last_read/", **self.auth())
+        mark_unread = self.client.post(f"{room_url}/mark_unread/", **self.auth())
+
+        self.assertEqual(mark_read.data, {"status": "ok"})
+        self.assertTrue(
+            {"user", "last_read", "unread_messages"}.issubset(read.data[0])
+        )
+        self.assertEqual(set(unread.data), {"unread"})
+        self.assertEqual(set(last_read.data), {"last_read"})
+        self.assertEqual(mark_unread.data, {"status": "ok"})
+
+        draft_url = f"{room_url}/draft/"
+        self.assertEqual(
+            self.client.post(
+                draft_url, {"text": "draft text"}, format="json", **self.auth()
+            ).data,
+            {"status": "ok"},
+        )
+        draft = self.client.get(draft_url, **self.auth())
+        self.assertTrue({"id", "text", "body", "updated_at"}.issubset(draft.data[0]))
+        self.assertEqual(self.client.delete(draft_url, **self.auth()).data, {"status": "ok"})
+
+        config = self.client.get(
+            f"/api/rooms/messaging:{self.room.uuid}/config/", **self.auth()
+        )
+        config_state = self.client.get(f"{room_url}/config-state/", **self.auth())
+        cooldown = self.client.get(f"{room_url}/cooldown/", **self.auth())
+        self.assertEqual(
+            config.data,
+            {"name": "Contract room", "type": "messaging", "muted": False},
+        )
+        self.assertTrue({"config", "has_ai_assistant", "ai_assistant"}.issubset(config_state.data))
+        self.assertTrue({"composer", "ai"}.issubset(config_state.data["config"]))
+        self.assertEqual(cooldown.data, {"cooldown": 0})
+
+        composer_cases = [
+            ("/api/text-composer/", {"text": "hello"}, {"text": "hello"}),
+            ("/api/compose/", {"text": "hello"}, {"composition": {"text": "hello"}}),
+            ("/api/has-sendable-data/", {"text": "hello"}, {"has_sendable_data": True}),
+            ("/api/composition-is-empty/", {"text": "  "}, {"is_empty": True}),
+        ]
+        for path, payload, expected in composer_cases:
+            with self.subTest(path=path):
+                response = self.client.post(path, payload, format="json", **self.auth())
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.data, expected)
+
+    def test_reaction_flag_pin_and_action_shapes(self):
+        message = self.messages[0]
+        base = f"/api/messages/{message.id}"
+
+        reaction = self.client.post(
+            f"{base}/reactions/", {"type": "like"}, format="json", **self.auth()
+        )
+        self.assertEqual(reaction.status_code, 201)
+        self.assertTrue({"id", "type", "user_id", "created_at"}.issubset(reaction.data))
+        listed = self.client.get(f"{base}/reactions/", **self.auth())
+        self.assertEqual(listed.data[0]["type"], "like")
+
+        typed_url = f"{base}/reactions/wow/"
+        first = self.client.post(typed_url, **self.auth())
+        second = self.client.post(typed_url, **self.auth())
+        expected = {"status": "ok", "message_id": str(message.id), "type": "wow"}
+        self.assertEqual(first.data, expected)
+        self.assertEqual(second.data, expected)
+        self.assertEqual(
+            Reaction.objects.filter(message=message, user=self.member, type="wow").count(),
+            1,
+        )
+        self.assertEqual(self.client.delete(typed_url, **self.auth()).data, expected)
+
+        flagged = self.client.post(f"{base}/flag/", **self.auth())
+        pinned = self.client.post(f"{base}/pin/", **self.auth(self.agent))
+        action = self.client.post(
+            f"{base}/actions/",
+            {"name": "approve"},
+            format="json",
+            **self.auth(self.agent),
+        )
+        unpinned = self.client.delete(f"{base}/unpin/", **self.auth(self.agent))
+        self.assertTrue({"flag"}.issubset(flagged.data))
+        self.assertTrue({"pin"}.issubset(pinned.data))
+        self.assertEqual(action.data, {"action": {"name": "approve"}})
+        self.assertEqual(unpinned.status_code, 204)
+
+    def test_search_replies_threads_and_aliases_keep_paginated_envelopes(self):
+        secret_room = Room.objects.create(
+            uuid="secret-contract-room", client=self.outsider.username
+        )
+        secret_channel = Channel.objects.create(
+            uuid=secret_room.uuid, client=secret_room.client
+        )
+        secret = Message.objects.create(
+            channel=secret_channel,
+            body="exact forbidden contract phrase",
+            sent_by=self.outsider.username,
+        )
+        secret_room.messages.add(secret)
+
+        search = self.client.get(
+            "/search/messages/", {"q": "contract", "limit": 2}, **self.auth()
+        )
+        self.assertEqual(search.status_code, 200)
+        self.assertEqual(set(search.data), {"results", "next"})
+        self.assertEqual(len(search.data["results"]), 2)
+        self.assertTrue(
+            {"id", "text", "user_id", "created_at", "cid"}.issubset(
+                search.data["results"][0]
+            )
+        )
+        leaked = self.client.get(
+            "/search/messages/", {"q": "forbidden contract"}, **self.auth()
+        )
+        self.assertEqual(leaked.data, {"results": [], "next": None})
+
+        parent = self._message("thread parent")
+        self._message("thread reply", reply_to=parent)
+        api_replies = self.client.get(
+            f"/api/messages/{parent.id}/replies/", **self.auth()
+        )
+        alias_replies = self.client.get(
+            f"/messages/{parent.id}/replies/", **self.auth()
+        )
+        self.assertEqual(api_replies.status_code, 200)
+        self.assertEqual(api_replies.data, alias_replies.data)
+        self.assertEqual(set(api_replies.data), {"messages", "next"})
+        self.assertEqual(api_replies.data["messages"][0]["parent_id"], parent.id)
+
+        query = {"cid": f"messaging:{self.room.uuid}", "limit": 1}
+        api_threads = self.client.get("/api/threads/", query, **self.auth())
+        alias_threads = self.client.get("/threads/", query, **self.auth())
+        self.assertEqual(api_threads.status_code, 200)
+        self.assertEqual(api_threads.data, alias_threads.data)
+        self.assertEqual(set(api_threads.data), {"results", "next"})
+        self.assertTrue(
+            {"thread_id", "cid", "root_message", "reply_count"}.issubset(
+                api_threads.data["results"][0]
+            )
+        )
+
+    @override_settings(
+        CHAT_ATTACHMENTS_BUCKET="contract-bucket",
+        CHAT_ATTACHMENTS_ALLOWED_TYPES=["image/png"],
+        CHAT_ATTACHMENTS_MAX_SIZE=1024,
+        CHAT_ATTACHMENTS_PUBLIC_DOWNLOADS=False,
+        CHAT_ATTACHMENTS_PUBLIC_BASE_URL="https://public.invalid",
+    )
+    @patch("stream_server_django.chat.api_views._get_service_account", return_value=object())
+    @patch(
+        "stream_server_django.chat.api_views.generate_signed_url",
+        return_value="https://storage.example.test/signed",
+    )
+    def test_attachment_alias_sign_commit_serialization_and_private_download(
+        self, _signed_url, _account
+    ):
+        legacy_api = self.client.post(
+            "/api/attachments/", {"name": "legacy.txt"}, format="json", **self.auth()
+        )
+        legacy_alias = self.client.post(
+            "/attachments/", {"name": "legacy.txt"}, format="json", **self.auth()
+        )
+        for response in (legacy_api, legacy_alias):
+            self.assertEqual(response.status_code, 201)
+            attachment = response.data["attachment"]
+            self.assertTrue(
+                {"id", "name", "filename", "url", "uploaded_by", "legacy_placeholder", "scan_status"}.issubset(
+                    attachment
+                )
+            )
+            self.assertTrue(attachment["legacy_placeholder"])
+            self.assertIn("/api/attachments/", attachment["url"])
+
+        sign = self.client.post(
+            "/api/attachments/sign/",
+            {
+                "name": "contract.png",
+                "content_type": "image/png",
+                "size": 512,
+                "cid": f"messaging:{self.room.uuid}",
+                "message_id": str(self.messages[0].id),
+            },
+            format="json",
+            **self.auth(),
+        )
+        self.assertEqual(sign.status_code, 200, sign.data)
+        self.assertTrue(
+            {"upload_id", "method", "url", "headers", "constraints", "blob_name", "attachment_id"}.issubset(
+                sign.data
+            )
+        )
+
+        with patch(
+            "stream_server_django.chat.api_views.download_blob",
+            return_value=("a" * 64, 512),
+        ), patch("stream_server_django.chat.api_views.scan_attachment.delay"), patch(
+            "stream_server_django.chat.api_views._broadcast_to_cid"
+        ):
+            commit = self.client.post(
+                "/attachments/commit/",
+                {
+                    "upload_id": sign.data["upload_id"],
+                    "blob_name": sign.data["blob_name"],
+                    "sha256": "a" * 64,
+                    "size": 512,
+                    "cid": f"messaging:{self.room.uuid}",
+                    "message_id": str(self.messages[0].id),
+                },
+                format="json",
+                **self.auth(),
+            )
+        self.assertEqual(commit.status_code, 201, commit.data)
+        attachment = commit.data["attachment"]
+        self.assertTrue(
+            {"id", "url", "blob", "content_type", "size", "sha256", "uploaded_by", "message_id", "cid", "room_uuid", "integrity", "scan_status"}.issubset(
+                attachment
+            )
+        )
+        self.assertIn(f"/api/attachments/{attachment['id']}/download/", attachment["url"])
+        self.assertNotIn("public.invalid", attachment["url"])
+
+        message = self.messages[0]
+        message.refresh_from_db()
+        message.attachments[0]["scan_status"] = Message.ATTACHMENT_SCAN_CLEAN
+        message.save(update_fields=["attachments"])
+        download = self.client.get(
+            f"/api/attachments/{attachment['id']}/download/", **self.auth()
+        )
+        self.assertEqual(download.status_code, 302)
+        self.assertEqual(download["Location"], "https://storage.example.test/signed")
+        self.assertEqual(download["Cache-Control"], "private, no-store")

--- a/backend/stream_server_django/chat/tests/test_stream_contract_websocket.py
+++ b/backend/stream_server_django/chat/tests/test_stream_contract_websocket.py
@@ -1,0 +1,232 @@
+"""Authorized WebSocket contract coverage for the frontend Stream adapter."""
+
+import jwt
+import pytest
+from asgiref.sync import sync_to_async
+from channels.layers import get_channel_layer
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+
+from stream_server_django.chat.models import Channel, Message, Room
+from stream_server_django.chat.routing import websocket_urlpatterns
+from stream_server_django.chat.serializers import MessageSerializer
+from stream_server_django.chat.utils import group_name_for_cid
+
+
+User = get_user_model()
+application = URLRouter(websocket_urlpatterns)
+
+
+def make_token(sub):
+    return jwt.encode(
+        {"sub": sub, "email": f"{sub}@example.com"},
+        settings.SUPABASE_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+async def connect(room_key, sub):
+    communicator = WebsocketCommunicator(
+        application, f"/ws/{room_key}/?token={make_token(sub)}"
+    )
+    connected, code = await communicator.connect()
+    return communicator, connected, code
+
+
+@sync_to_async
+def create_contract_room(uuid, username, message_count=1):
+    user = User.objects.filter(username=username).first()
+    if user is None:
+        user = User.objects.create_user(
+            username=username,
+            email=f"{username}@example.com",
+            supabase_uid=username,
+            password="x",
+        )
+    room = Room.objects.create(uuid=uuid, client=username)
+    channel = Channel.objects.create(uuid=uuid, client=username)
+    messages = []
+    for index in range(message_count):
+        message = Message.objects.create(
+            channel=channel,
+            body=f"message {index}",
+            sent_by=username,
+        )
+        room.messages.add(message)
+        messages.append(message)
+    return user, room, messages
+
+
+@sync_to_async
+def serialized_message(message_id, *, text=None, attachment=None):
+    message = Message.objects.get(pk=message_id)
+    if text is not None:
+        message.body = text
+    if attachment is not None:
+        message.attachments = [attachment]
+    message.save()
+    return dict(MessageSerializer(message).data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_generic_socket_watch_message_and_typing_contract():
+    username = "ws-contract-generic"
+    _user, room, messages = await create_contract_room(
+        "ws-contract-generic-room", username, message_count=31
+    )
+    cid = f"messaging:{room.uuid}"
+    communicator, connected, _code = await connect("chat", username)
+    assert connected
+    assert await communicator.receive_json_from() == {
+        "type": "user.join",
+        "user": username,
+    }
+
+    await communicator.send_json_to({"type": "channel.watch", "cid": cid})
+    initialized = await communicator.receive_json_from()
+    assert set(initialized) == {
+        "type",
+        "cid",
+        "initialized",
+        "messages",
+        "next",
+        "members",
+    }
+    assert initialized["type"] == "initialized"
+    assert initialized["cid"] == cid
+    assert initialized["initialized"] is True
+    assert len(initialized["messages"]) == 30
+    assert initialized["next"] is not None
+    assert {
+        "id",
+        "text",
+        "body",
+        "sent_by",
+        "created_at",
+        "attachments",
+        "parent_id",
+        "pinned",
+    }.issubset(initialized["messages"][0])
+    assert isinstance(initialized["members"], list)
+
+    message_payload = await serialized_message(messages[-1].id, text="REST broadcast")
+    layer = get_channel_layer()
+    await layer.group_send(
+        group_name_for_cid(cid),
+        {
+            "type": "chat.message",
+            "payload": {"type": "message.new", "cid": cid, "message": message_payload},
+        },
+    )
+    event = await communicator.receive_json_from()
+    assert event["type"] == "message.new"
+    assert event["cid"] == cid
+    assert event["message"]["id"] == messages[-1].id
+    assert event["message"]["text"] == "REST broadcast"
+
+    await communicator.send_json_to({"type": "typing.start", "cid": cid})
+    assert await communicator.receive_json_from() == {
+        "type": "typing.start",
+        "cid": cid,
+        "user_id": username,
+    }
+    await communicator.send_json_to({"type": "typing.stop"})
+    assert await communicator.receive_json_from() == {
+        "type": "typing.stop",
+        "cid": cid,
+        "user_id": username,
+    }
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+async def test_room_specific_socket_cid_binding_and_update_event_contracts():
+    username = "ws-contract-bound"
+    _user, room, messages = await create_contract_room(
+        "ws-contract-bound-room", username
+    )
+    await create_contract_room("ws-contract-other-room", username)
+    cid = f"messaging:{room.uuid}"
+    communicator, connected, _code = await connect(cid, username)
+    assert connected
+    await communicator.receive_json_from()
+
+    await communicator.send_json_to(
+        {"type": "channel.watch", "cid": "messaging:ws-contract-other-room"}
+    )
+    assert await communicator.receive_json_from() == {
+        "type": "error",
+        "code": "cid_mismatch",
+        "cid": "messaging:ws-contract-other-room",
+    }
+
+    await communicator.send_json_to({"type": "channel.watch", "cid": cid})
+    assert (await communicator.receive_json_from())["type"] == "initialized"
+
+    attachment = {
+        "id": "att-contract",
+        "name": "contract.txt",
+        "filename": "contract.txt",
+        "url": "/api/attachments/att-contract/download/",
+        "uploaded_by": username,
+        "legacy_placeholder": True,
+        "scan_status": Message.ATTACHMENT_SCAN_PENDING,
+    }
+    updated_message = await serialized_message(
+        messages[0].id, text="updated text", attachment=attachment
+    )
+    layer = get_channel_layer()
+    update_payload = {
+        "type": "message.updated",
+        "cid": cid,
+        "message": updated_message,
+    }
+    await layer.group_send(
+        group_name_for_cid(cid),
+        {"type": "chat.message", "payload": update_payload},
+    )
+    assert await communicator.receive_json_from() == update_payload
+
+    read_payload = {
+        "type": "message.read",
+        "cid": cid,
+        "user": {
+            "id": username,
+            "channel_last_read_at": "2026-08-06T12:00:00Z",
+            "channel_unread_count": 0,
+            "unread_count": 0,
+            "unread_channels": 0,
+            "total_unread_count": 0,
+        },
+        "created_at": "2026-08-06T12:00:00Z",
+    }
+    await layer.group_send(
+        group_name_for_cid(cid),
+        {"type": "chat.message", "payload": read_payload},
+    )
+    assert await communicator.receive_json_from() == read_payload
+
+    deleted_payload = {
+        "type": "message.deleted",
+        "cid": cid,
+        "message_id": str(messages[0].id),
+        "deleted_by": username,
+        "ts": "2026-08-06T12:01:00Z",
+    }
+    await layer.group_send(
+        group_name_for_cid(cid),
+        {"type": "chat.message", "payload": deleted_payload},
+    )
+    assert await communicator.receive_json_from() == deleted_payload
+    await communicator.disconnect()

--- a/backend/stream_server_django/chat/urls.py
+++ b/backend/stream_server_django/chat/urls.py
@@ -159,6 +159,11 @@ urlpatterns = [
         RoomCooldownView.as_view(),
         name="room-cooldown",
     ),
+    re_path(
+        r"^api/rooms/(?P<cid>[^/]+:[^/]+)/members/$",
+        RoomMembersCIDView.as_view(),
+        name="room-members-cid",
+    ),
     path(
         "api/rooms/<str:room_uuid>/members/",
         RoomMembersView.as_view(),
@@ -167,7 +172,7 @@ urlpatterns = [
     path(
         "api/rooms/<path:cid>/members/",
         RoomMembersCIDView.as_view(),
-        name="room-members-cid",
+        name="room-members-cid-fallback",
     ),
     path(
         "api/rooms/<str:room_uuid>/pinned/",
@@ -235,6 +240,11 @@ urlpatterns = [
         MessageRepliesView.as_view(),
         name="message-replies",
     ),
+    path(
+        "api/messages/<str:message_id>/replies/",
+        MessageRepliesView.as_view(),
+        name="message-replies-api",
+    ),
     path("api/notifications/", NotificationListView.as_view(), name="notifications"),
     path("api/reminders/", ReminderListCreateView.as_view(), name="stream_server_django.reminders"),
     path(
@@ -248,6 +258,7 @@ urlpatterns = [
         name="room-reminders",
     ),
     path("threads/", ThreadListView.as_view(), name="threads"),
+    path("api/threads/", ThreadListView.as_view(), name="threads-api"),
     path("api/muted-channels/", MutedChannelListView.as_view(), name="muted-channels"),
     path(
         "api/messages/<str:message_id>/reactions/",

--- a/backend/stream_server_django/chat_addons/agent/tests/test_stream_agent_contract.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_stream_agent_contract.py
@@ -1,0 +1,131 @@
+"""Frontend-facing agent response contract tests."""
+
+from unittest.mock import Mock, patch
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat.models import Channel, Message, Room
+from stream_server_django.chat_addons.agent.models import RoomAgentFlag
+
+
+User = get_user_model()
+
+
+@override_settings(ROOT_URLCONF="jatte.urls")
+class StreamAgentContractTests(APITestCase):
+    def setUp(self):
+        self.member = User.objects.create_user(
+            username="agent-contract-member",
+            email="agent-contract-member@example.com",
+            supabase_uid="agent-contract-member",
+            password="x",
+        )
+        self.agent = User.objects.create_user(
+            username="agent-contract-agent",
+            email="agent-contract-agent@example.com",
+            supabase_uid="agent-contract-agent",
+            password="x",
+        )
+        self.room = Room.objects.create(
+            uuid="agent-contract-room",
+            client=self.member.username,
+            agent=self.agent,
+        )
+        channel = Channel.objects.create(
+            uuid=self.room.uuid, client=self.room.client
+        )
+        self.message = Message.objects.create(
+            channel=channel,
+            body="Please prepare the contract response",
+            sent_by=self.member.username,
+        )
+        self.room.messages.add(self.message)
+        self.flag = RoomAgentFlag.objects.create(
+            room=self.room, agent_enabled=True
+        )
+
+    def auth(self, user=None):
+        actor = user or self.member
+        token = jwt.encode(
+            {"sub": actor.supabase_uid, "email": actor.email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_status_contract_is_available_to_room_participant(self):
+        response = self.client.get(
+            f"/chat/agent/{self.room.cid}/", **self.auth()
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            set(response.data), {"cid", "agent_enabled", "updated_at"}
+        )
+        self.assertEqual(response.data["cid"], self.room.cid)
+        self.assertIs(response.data["agent_enabled"], True)
+
+    @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
+    def test_frontend_invoke_returns_stable_queued_shape(self, service_factory):
+        service = Mock()
+        service.enqueue_generate.return_value = "job-contract-1"
+        service_factory.return_value = service
+        response = self.client.post(
+            f"/api/chat/agent/{self.room.cid}/invoke/",
+            {
+                "room_uuid": self.room.uuid,
+                "last_human_message_id": self.message.id,
+                "trace_id": "trace-contract-1",
+            },
+            format="json",
+            **self.auth(),
+        )
+
+        self.assertEqual(response.status_code, 202, response.data)
+        self.assertEqual(
+            response.data,
+            {
+                "status": "queued",
+                "job_id": "job-contract-1",
+                "trace_id": "trace-contract-1",
+            },
+        )
+        service.enqueue_generate.assert_called_once()
+
+    @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
+    def test_disabled_agent_error_shape_stays_stable(self, service_factory):
+        self.flag.agent_enabled = False
+        self.flag.save(update_fields=["agent_enabled", "updated_at"])
+        response = self.client.post(
+            f"/api/chat/agent/{self.room.cid}/invoke/",
+            {
+                "room_uuid": self.room.uuid,
+                "last_human_message_id": self.message.id,
+            },
+            format="json",
+            **self.auth(),
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data, {"detail": "Agent is disabled for this room."}
+        )
+        service_factory.assert_not_called()
+
+    def test_room_mismatch_error_shape_stays_stable(self):
+        response = self.client.post(
+            f"/api/chat/agent/{self.room.cid}/invoke/",
+            {
+                "room_uuid": "different-room",
+                "last_human_message_id": self.message.id,
+            },
+            format="json",
+            **self.auth(),
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {"detail": "Room does not match invocation payload."},
+        )


### PR DESCRIPTION
## Summary

Implements PR6 of the JATTE-headless security hardening sequence: Stream compatibility and contract regression coverage.

This PR is stacked on PR #1192 / `security/pr5-admin-agent-notification-sms-auth` because it locks the frontend-facing Stream contract after the auth, WebSocket, REST, attachment, and privileged-route hardening stack.

## Changes

- Adds `backend/audit/pr6-stream-compatibility-contract.md` documenting the supported Stream-compatible subset.
- Maps frontend Stream adapter calls to backend routes, methods, auth policy, and successful response shapes.
- Adds authorized REST contract tests for bootstrap, rooms, messages, members, read state, drafts/config/composer, reactions, search, replies/threads, and attachments.
- Adds authorized WebSocket contract tests for generic `/ws/chat/`, room-specific `/ws/<cid>/`, watch initialization, message events, typing, read, update, delete, and CID mismatch behavior.
- Adds frontend-facing agent contract tests for status, queued invocation, disabled-agent error shape, and room-mismatch error shape.
- Exposes/locks production aliases for replies, threads, CID member routing, and canonical route order.
- Preserves PR1-PR5 security behavior while testing successful authorized payload contracts.

## Testing

- 14 PR6 contract tests passed.
- 76 PR1-PR5 security regressions passed.
- Django system check passed.
- Changed files compile successfully.
- `git diff --check` passed.

## Known deferred issue

Full `compileall backend` remains blocked by the pre-existing malformed quote in `test_reminders.py:59`. Additional broad legacy suites retain pre-existing import/collection defects unrelated to PR6.

## Out of scope

- New security policy
- New auth model
- New Stream features not already used by the frontend
- Broad UI or Stream adapter rewrite
- Performance optimization
- Agent orchestration changes beyond response-shape verification

## Review guidance

Review this as the compatibility-lock pass for the security stack. The key question is whether authorized frontend-facing REST and WebSocket payloads remain stable while PR1-PR5 security boundaries remain intact.