### PR TITLE
Security PR8: Bind poll APIs to authorized rooms

### DIFF
--- a/backend/audit/pr8-poll-contract.md
+++ b/backend/audit/pr8-poll-contract.md
@@ -65,15 +65,30 @@ counts cannot be queried from this development environment. Migration
 `polls.0002_poll_room` handles the unknown inventory deterministically:
 
 1. normalize each existing canonical poll CID;
-2. bind it only when an already-existing `chat.Room.uuid` matches;
-3. canonicalize the stored CID from that room;
-4. preserve unmatched polls with `room = NULL`.
+2. find an already-existing `chat.Room.uuid` match;
+3. bind only when frozen-model evidence proves the creator was staff/superuser,
+   the room agent, matched `room.client` by username/Supabase UID/user ID, or
+   had previously sent a message attached to that room;
+4. canonicalize the stored CID from that room only after that proof;
+5. preserve unmatched or unauthorized polls with `room = NULL`.
 
 The migration never creates rooms and never deletes poll data. Preserved
 orphans are excluded from every externally reachable poll operation pending
 operator adjudication. Legacy `chat.Poll` rows are likewise preserved in their
 tables but retired from external request handling; no destructive data
 migration is performed.
+
+After deployment, operators can obtain a content-free adjudication inventory
+without mutating rows:
+
+```python
+from stream_server_django.polls.models import Poll
+print({
+    "total": Poll.objects.count(),
+    "bound": Poll.objects.filter(room__isnull=False).count(),
+    "unbound": Poll.objects.filter(room__isnull=True).count(),
+})
+```
 
 ## Event contract
 

--- a/backend/audit/pr8-poll-contract.md
+++ b/backend/audit/pr8-poll-contract.md
@@ -1,0 +1,84 @@
+# PR8 poll contract and room-authorization design
+
+## Production route inventory
+
+`jatte.urls` includes `stream_server_django.chat.urls` before
+`stream_server_django.polls.urls`, but the families do not collide because the
+former is under `/api/polls/` and the latter is under `/polls/`.
+
+| Route | Methods | Production view | Model after PR8 | Successful shape | Caller / status |
+| --- | --- | --- | --- | --- | --- |
+| `/polls/` | GET, POST | `polls.PollListCreateView` | `polls.Poll` | GET `{results, next}`; POST `{poll}` | Direct frontend composer and canonical API |
+| `/polls/<poll_id>/` | DELETE | `polls.PollDetailView` | `polls.Poll` | empty 204 | Direct frontend composer; canonical delete |
+| `/polls/<poll_id>/options/` | POST | `polls.PollOptionCreateView` | `polls.PollOption` | `{option}` | Canonical API |
+| `/polls/<poll_id>/answers/` | POST | `polls.PollAnswerCreateView` | `polls.PollAnswer` | `{answer}` | Poll answer contract |
+| `/polls/<poll_id>/options/<option_id>/votes/` | GET, POST, DELETE | `polls.PollVoteView` | `polls.PollVote` | GET `{results, count, next}`; mutations preserve the existing vote payload | Stream-compatible vote contract |
+| `/api/polls/` | GET, POST | `chat.PollListCreateView` compatibility adapter | `polls.Poll` | legacy GET list and POST `{poll}` | `apiFetch(API.POLLS)` frontend path |
+| `/api/polls/<poll_id>/` | DELETE | `chat.PollDetailView` compatibility adapter | `polls.Poll` | empty 204 | channel poll composer |
+| `/api/polls/<poll_id>/options/` | POST | `chat.PollOptionCreateView` compatibility adapter | `polls.PollOption` | `{poll_option}` | `createPollOption` shims |
+| `/api/polls/<poll_id>/options/<option_id>/votes/` | GET | `chat.PollOptionVotesListView` compatibility adapter | `polls.PollVote` | `{results, count, next?, prev?}` | `queryOptionVotes` shim |
+
+Trailing-slash redirects may be provided by Django's `APPEND_SLASH`; the
+effective views after redirect are the same room-authorized views above.
+There is no production `/api/polls/<id>/answers/` route. The shim's local
+answer fallback does not make an HTTP call unless a poll object supplies one.
+
+## Active contract decision
+
+The richer `stream_server_django.polls` implementation is canonical. Both
+route families are currently reachable and frontend code calls both. The
+legacy `stream_server_django.chat` poll tables may contain historical data,
+but their models cannot express a room boundary and are no longer used by any
+externally reachable poll view. `/api/polls/**` is therefore a response-shape
+compatibility adapter over the canonical room-bound implementation.
+
+Consolidation does not rename poll/option IDs, CID, question text, vote fields,
+`{results, next}`, counts, or poll event names. Poll creation now requires a
+CID because a room cannot be safely inferred from authentication or a global
+client. Channel frontend callers now include their existing canonical CID.
+
+## Room binding and authorization
+
+`polls.Poll.room` is the authoritative parent. The externally visible CID is
+derived from `poll.room.cid`; request data and stale database CID values are
+never used for event routing after a poll is resolved.
+
+- List/create resolves an existing room and applies the PR3 room-access policy.
+- Direct poll IDs load only non-orphan polls and return 404 to callers without
+  owning-room access.
+- Option, answer, vote, count, and cursor operations authorize the poll room
+  before accessing descendants.
+- Poll-list cursors carry the room scope. Vote cursors carry poll and option
+  scope. A cursor from another scope is rejected before any rows/counts are
+  returned.
+- Delete is allowed to staff/superusers, the room agent, or the poll creator
+  while the creator still has room access. Other participants receive 403;
+  non-members receive 404.
+- Vote events use `poll.room.cid`. Denied requests perform no writes or
+  broadcasts.
+
+## Existing data and migration treatment
+
+This repository contains no tracked SQLite database and provides no production
+database credential or operator connection in the checkout, so production row
+counts cannot be queried from this development environment. Migration
+`polls.0002_poll_room` handles the unknown inventory deterministically:
+
+1. normalize each existing canonical poll CID;
+2. bind it only when an already-existing `chat.Room.uuid` matches;
+3. canonicalize the stored CID from that room;
+4. preserve unmatched polls with `room = NULL`.
+
+The migration never creates rooms and never deletes poll data. Preserved
+orphans are excluded from every externally reachable poll operation pending
+operator adjudication. Legacy `chat.Poll` rows are likewise preserved in their
+tables but retired from external request handling; no destructive data
+migration is performed.
+
+## Event contract
+
+Existing `poll.vote_casted`, `poll.vote_changed`, and `poll.vote_removed`
+payload names and vote fields remain intact. The payload CID and channel-layer
+group are derived exclusively from the bound room. Poll creation, option
+creation, and answer creation currently emit no producer events, so their
+denied paths have no broadcast side effect to suppress.

--- a/backend/stream_server_django/chat/api_views.py
+++ b/backend/stream_server_django/chat/api_views.py
@@ -26,6 +26,20 @@ from rest_framework.views import APIView
 
 from stream_server_django.common.identity import ChatIdentity, get_chat_identity
 from stream_server_django.chatcore.services import should_gate_first_message
+from stream_server_django.polls.models import (
+    Poll as RoomPoll,
+    PollOption as RoomPollOption,
+    PollVote as RoomPollVote,
+)
+from stream_server_django.polls.serializers import (
+    PollCreateSerializer as RoomPollCreateSerializer,
+    PollOptionCreateSerializer as RoomPollOptionCreateSerializer,
+)
+from stream_server_django.polls.views import (
+    _authorized_poll,
+    _authorized_room,
+    _can_delete_poll,
+)
 from stream_server_django.rooms.utils import (
     can_admin_room,
     can_mutate_message,
@@ -67,9 +81,6 @@ from .models import (
     Message,
     Notification,
     Pin,
-    Poll,
-    PollOption,
-    PollVote,
     Reaction,
     ReadState,
     Reminder,
@@ -87,9 +98,6 @@ from .serializers import (
     MuteStatusSerializer,
     NotificationSerializer,
     PinSerializer,
-    PollOptionSerializer,
-    PollSerializer,
-    PollVoteSerializer,
     ReactionSerializer,
     RegisterSubscriptionsSerializer,
     ReminderCreateSerializer,
@@ -1149,7 +1157,7 @@ class MessageActionView(APIView):
 
 
 class PollOptionCreateView(APIView):
-    """Create a new poll option."""
+    """Compatibility adapter for canonical room-bound poll options."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
@@ -1157,64 +1165,85 @@ class PollOptionCreateView(APIView):
     def post(self, request, poll_id):
         identity = get_chat_identity(request)
         user = identity.as_user()
-        serializer = PollOptionSerializer(data=request.data)
+        poll = _authorized_poll(user, poll_id)
+        serializer = RoomPollOptionCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        option = PollOption.objects.create(
-            poll_id=poll_id,
+        option = RoomPollOption.objects.create(
+            poll=poll,
             text=serializer.validated_data["text"],
-            user=user,
+            created_by=user,
         )
-        return Response({"poll_option": PollOptionSerializer(option).data}, status=201)
+        return Response({"poll_option": _legacy_poll_option_data(option)}, status=201)
 
 
 class PollListCreateView(APIView):
-    """List or create polls."""
+    """Compatibility adapter over the canonical room-bound poll model."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        polls = Poll.objects.all()
-        if polls.count() == 0:
+        identity = get_chat_identity(request)
+        user = identity.as_user()
+        cid = request.query_params.get("cid")
+        if cid:
+            room = _authorized_room(user, cid)
+            polls = RoomPoll.objects.filter(room=room)
+        else:
+            rooms = rooms_accessible_to_user(user)
+            polls = RoomPoll.objects.filter(room__in=rooms, room__isnull=False)
+        polls = polls.select_related("created_by", "room").order_by(
+            "-created_at", "-id"
+        )
+        if not polls.exists():
             return Response(status=405)
-        serializer = PollSerializer(polls, many=True)
-        return Response(serializer.data)
+        return Response([_legacy_poll_data(poll) for poll in polls])
 
     def post(self, request):
         identity = get_chat_identity(request)
         user = identity.as_user()
-        serializer = PollSerializer(data=request.data)
+        serializer = RoomPollCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        poll = Poll.objects.create(
-            question=serializer.validated_data["question"],
-            user=user,
-        )
-        for text in request.data.get("options", []):
-            PollOption.objects.create(poll_id=str(poll.id), text=text, user=user)
-        return Response({"poll": PollSerializer(poll).data}, status=201)
+        room = _authorized_room(user, serializer.validated_data["cid"])
+        with transaction.atomic():
+            poll = RoomPoll.objects.create(
+                room=room,
+                cid=room.cid,
+                question=serializer.validated_data["question"],
+                created_by=user,
+            )
+            for text in serializer.validated_data["options"]:
+                RoomPollOption.objects.create(poll=poll, text=text, created_by=user)
+        return Response({"poll": _legacy_poll_data(poll)}, status=201)
 
 
 class PollDetailView(APIView):
-    """Delete a poll."""
+    """Delete a canonical poll through the legacy response contract."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def delete(self, request, poll_id):
-        poll = get_object_or_404(Poll, id=poll_id)
+        identity = get_chat_identity(request)
+        user = identity.as_user()
+        poll = _authorized_poll(user, poll_id)
+        if not _can_delete_poll(user, poll):
+            raise PermissionDenied()
         poll.delete()
         return Response(status=204)
 
 
 class PollOptionVotesListView(APIView):
-    """Return paginated votes for a poll option."""
+    """Return room-authorized canonical votes in the legacy shape."""
 
     authentication_classes = [DevTokenOrJWTAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, poll_id, option_id):
-        poll = get_object_or_404(Poll, id=poll_id)
-        option = get_object_or_404(PollOption, id=option_id, poll=poll)
+        identity = get_chat_identity(request)
+        user = identity.as_user()
+        poll = _authorized_poll(user, poll_id)
+        option = get_object_or_404(RoomPollOption, id=option_id, poll=poll)
 
         try:
             limit_param = request.query_params.get("limit")
@@ -1225,16 +1254,16 @@ class PollOptionVotesListView(APIView):
         limit = max(1, min(limit, 100))
         cursor = request.query_params.get("cursor")
 
-        votes_qs = PollVote.objects.filter(poll=poll, option=option).order_by(
+        votes_qs = RoomPollVote.objects.filter(poll=poll, option=option).order_by(
             "-created_at", "-id"
         )
 
         if cursor:
             try:
-                cursor_vote = PollVote.objects.get(
+                cursor_vote = RoomPollVote.objects.get(
                     id=cursor, poll=poll, option=option
                 )
-            except PollVote.DoesNotExist:
+            except (RoomPollVote.DoesNotExist, DjangoValidationError, ValueError):
                 return Response({"detail": "Invalid cursor"}, status=400)
 
             votes_qs = votes_qs.filter(
@@ -1245,7 +1274,7 @@ class PollOptionVotesListView(APIView):
                 )
             )
 
-        total = PollVote.objects.filter(poll=poll, option=option).count()
+        total = RoomPollVote.objects.filter(poll=poll, option=option).count()
         paginated = list(votes_qs[: limit + 1])
         has_next = len(paginated) > limit
         votes = paginated[:limit]
@@ -1254,9 +1283,8 @@ class PollOptionVotesListView(APIView):
         if has_next and votes:
             next_cursor = str(votes[-1].id)
 
-        serializer = PollVoteSerializer(votes, many=True)
         response_data = {
-            "results": serializer.data,
+            "results": [_legacy_poll_vote_data(vote) for vote in votes],
             "count": total,
         }
         if next_cursor:
@@ -1265,6 +1293,43 @@ class PollOptionVotesListView(APIView):
             response_data["prev"] = cursor
 
         return Response(response_data)
+
+
+def _legacy_poll_data(poll: RoomPoll) -> dict:
+    return {
+        "id": str(poll.id),
+        "question": poll.question,
+        "user_id": poll.created_by.get_username(),
+        "created_at": poll.created_at,
+    }
+
+
+def _legacy_poll_option_data(option: RoomPollOption) -> dict:
+    return {
+        "id": str(option.id),
+        "poll_id": str(option.poll_id),
+        "text": option.text,
+        "user_id": option.created_by.get_username(),
+        "created_at": option.created_at,
+    }
+
+
+def _legacy_poll_vote_data(vote: RoomPollVote) -> dict:
+    user = vote.user
+    profile = getattr(user, "profile", None)
+    return {
+        "id": str(vote.id),
+        "poll_id": str(vote.poll_id),
+        "option_id": str(vote.option_id),
+        "user_id": user.get_username(),
+        "user": {
+            "id": str(getattr(user, "supabase_uid", None) or user.id),
+            "name": getattr(profile, "display_name", None) or user.get_username(),
+            "image": getattr(profile, "image_url", None),
+        },
+        "created_at": vote.created_at,
+        "updated_at": vote.updated_at,
+    }
 
 
 class RoomConfigView(RoomFromCIDMixin, APIView):

--- a/backend/stream_server_django/chat/tests/test_create_poll.py
+++ b/backend/stream_server_django/chat/tests/test_create_poll.py
@@ -5,7 +5,8 @@ import jwt
 
 from django.contrib.auth import get_user_model
 
-from stream_server_django.chat.models import Poll, PollOption
+from stream_server_django.chat.models import Room
+from stream_server_django.polls.models import Poll, PollOption
 User = get_user_model()
 
 class PollAPITests(APITestCase):
@@ -14,11 +15,12 @@ class PollAPITests(APITestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
+        self.room = Room.objects.create(uuid="room-u1", client="u1")
 
     def test_create_poll(self):
         token = self.make_token()
         url = reverse("poll-create")
-        res = self.client.post(url, {"question": "q?", "options": ["a", "b"]}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
+        res = self.client.post(url, {"cid": self.room.cid, "question": "q?", "options": ["a", "b"]}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 201)
         pid = res.data["poll"]["id"]
         self.assertTrue(Poll.objects.filter(id=pid, question="q?").exists())
@@ -36,7 +38,7 @@ class PollAPITests(APITestCase):
         self.assertEqual(res.status_code, 405)
 
     def test_delete_poll(self):
-        poll = Poll.objects.create(question="bye", user=self.user)
+        poll = Poll.objects.create(room=self.room, cid=self.room.cid, question="bye", created_by=self.user)
         token = self.make_token()
         url = reverse("poll-detail", kwargs={"poll_id": poll.id})
         res = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
@@ -44,13 +46,13 @@ class PollAPITests(APITestCase):
         self.assertFalse(Poll.objects.filter(id=poll.id).exists())
 
     def test_delete_poll_requires_auth(self):
-        poll = Poll.objects.create(question="a", user=self.user)
+        poll = Poll.objects.create(room=self.room, cid=self.room.cid, question="a", created_by=self.user)
         url = reverse("poll-detail", kwargs={"poll_id": poll.id})
         res = self.client.delete(url)
         self.assertEqual(res.status_code, 403)
 
     def test_delete_poll_wrong_method(self):
-        poll = Poll.objects.create(question="a", user=self.user)
+        poll = Poll.objects.create(room=self.room, cid=self.room.cid, question="a", created_by=self.user)
         token = self.make_token()
         url = reverse("poll-detail", kwargs={"poll_id": poll.id})
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")

--- a/backend/stream_server_django/chat/tests/test_create_poll_option.py
+++ b/backend/stream_server_django/chat/tests/test_create_poll_option.py
@@ -2,30 +2,46 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 from django.conf import settings
 import jwt
+from django.contrib.auth import get_user_model
 
-from stream_server_django.chat.models import PollOption
+from stream_server_django.chat.models import Room
+from stream_server_django.polls.models import Poll, PollOption
+
+User = get_user_model()
 
 
 class CreatePollOptionAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
         return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
 
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="u1", email="u1@example.com", password="x", supabase_uid="u1"
+        )
+        self.room = Room.objects.create(uuid="room-u1", client="u1")
+        self.poll = Poll.objects.create(
+            room=self.room,
+            cid=self.room.cid,
+            question="q?",
+            created_by=self.user,
+        )
+
     def test_create_poll_option(self):
         token = self.make_token()
-        url = reverse("poll-option-create", kwargs={"poll_id": "p1"})
+        url = reverse("poll-option-create", kwargs={"poll_id": self.poll.id})
         res = self.client.post(url, {"text": "hello"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 201)
-        self.assertEqual(PollOption.objects.filter(poll_id="p1", text="hello").count(), 1)
-        option = PollOption.objects.get(poll_id="p1")
-        self.assertEqual(res.data["poll_option"]["id"], option.id)
+        self.assertEqual(PollOption.objects.filter(poll=self.poll, text="hello").count(), 1)
+        option = PollOption.objects.get(poll=self.poll)
+        self.assertEqual(res.data["poll_option"]["id"], str(option.id))
 
     def test_create_poll_option_requires_auth(self):
-        url = reverse("poll-option-create", kwargs={"poll_id": "p1"})
+        url = reverse("poll-option-create", kwargs={"poll_id": self.poll.id})
         res = self.client.post(url, {"text": "x"}, format="json")
         self.assertEqual(res.status_code, 403)
 
     def test_wrong_method(self):
         token = self.make_token()
-        url = reverse("poll-option-create", kwargs={"poll_id": "p1"})
+        url = reverse("poll-option-create", kwargs={"poll_id": self.poll.id})
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 405)

--- a/backend/stream_server_django/chat/tests/test_list_polls.py
+++ b/backend/stream_server_django/chat/tests/test_list_polls.py
@@ -5,7 +5,8 @@ import jwt
 
 from django.contrib.auth import get_user_model
 
-from stream_server_django.chat.models import Poll
+from stream_server_django.chat.models import Room
+from stream_server_django.polls.models import Poll
 User = get_user_model()
 
 class PollListAPITests(APITestCase):
@@ -14,8 +15,9 @@ class PollListAPITests(APITestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
-        Poll.objects.create(question="q1", user=self.user)
-        Poll.objects.create(question="q2", user=self.user)
+        self.room = Room.objects.create(uuid="room-u1", client="u1")
+        Poll.objects.create(room=self.room, cid=self.room.cid, question="q1", created_by=self.user)
+        Poll.objects.create(room=self.room, cid=self.room.cid, question="q2", created_by=self.user)
 
     def test_list_polls(self):
         token = self.make_token()

--- a/backend/stream_server_django/chat/tests/test_query_poll_option_votes.py
+++ b/backend/stream_server_django/chat/tests/test_query_poll_option_votes.py
@@ -6,11 +6,12 @@ import jwt
 
 from django.contrib.auth import get_user_model
 
-from stream_server_django.chat.models import Poll, PollOption, PollVote
+from stream_server_django.chat.models import Room
+from stream_server_django.polls.models import Poll, PollOption, PollVote
 User = get_user_model()
 
 
-@override_settings(ROOT_URLCONF="chat.urls")
+@override_settings(ROOT_URLCONF="jatte.urls")
 class QueryPollOptionVotesAPITests(APITestCase):
     def setUp(self):
         self.owner = User.objects.create_user(
@@ -26,11 +27,17 @@ class QueryPollOptionVotesAPITests(APITestCase):
             supabase_uid="voter",
         )
 
-        self.poll = Poll.objects.create(question="Best color?", user=self.owner)
+        self.room = Room.objects.create(uuid="owner-room", client="owner")
+        self.poll = Poll.objects.create(
+            room=self.room,
+            cid=self.room.cid,
+            question="Best color?",
+            created_by=self.owner,
+        )
         self.option = PollOption.objects.create(
             poll=self.poll,
             text="Blue",
-            user=self.owner,
+            created_by=self.owner,
         )
 
     def make_token(self, sub="owner", email="owner@example.com"):
@@ -49,8 +56,18 @@ class QueryPollOptionVotesAPITests(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_returns_paginated_votes(self):
-        for _ in range(3):
-            PollVote.objects.create(poll=self.poll, option=self.option, user=self.voter)
+        voters = [self.voter]
+        voters.extend(
+            User.objects.create_user(
+                username=f"voter-{index}",
+                email=f"voter-{index}@example.com",
+                password="x",
+                supabase_uid=f"voter-{index}",
+            )
+            for index in range(2)
+        )
+        for voter in voters:
+            PollVote.objects.create(poll=self.poll, option=self.option, user=voter)
 
         token = self.make_token()
         url = reverse(

--- a/backend/stream_server_django/polls/migrations/0002_poll_room.py
+++ b/backend/stream_server_django/polls/migrations/0002_poll_room.py
@@ -2,6 +2,34 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 
+def _creator_identifiers(creator):
+    return {
+        str(identifier)
+        for identifier in (
+            creator.username,
+            getattr(creator, "supabase_uid", None),
+            creator.pk,
+        )
+        if identifier not in (None, "")
+    }
+
+
+def _creator_had_room_access(creator, room):
+    """Reproduce the legacy-compatible PR3 policy using frozen models only."""
+
+    if creator.is_staff or creator.is_superuser:
+        return True
+    if room.agent_id == creator.pk:
+        return True
+
+    identifiers = _creator_identifiers(creator)
+    if room.client and room.client in identifiers:
+        return True
+    return bool(
+        identifiers and room.messages.filter(sent_by__in=identifiers).exists()
+    )
+
+
 def bind_existing_polls(apps, schema_editor):
     Poll = apps.get_model("polls", "Poll")
     Room = apps.get_model("chat", "Room")
@@ -13,6 +41,9 @@ def bind_existing_polls(apps, schema_editor):
             _room_type, identifier = identifier.split(":", 1)
         room = rooms.get(identifier)
         if room is None:
+            continue
+        creator = poll.created_by
+        if not _creator_had_room_access(creator, room):
             continue
         poll.room_id = room.pk
         poll.cid = f"messaging:{room.uuid}"

--- a/backend/stream_server_django/polls/migrations/0002_poll_room.py
+++ b/backend/stream_server_django/polls/migrations/0002_poll_room.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def bind_existing_polls(apps, schema_editor):
+    Poll = apps.get_model("polls", "Poll")
+    Room = apps.get_model("chat", "Room")
+
+    rooms = {room.uuid: room for room in Room.objects.all().iterator()}
+    for poll in Poll.objects.filter(room__isnull=True).iterator():
+        identifier = (poll.cid or "").strip()
+        if ":" in identifier:
+            _room_type, identifier = identifier.split(":", 1)
+        room = rooms.get(identifier)
+        if room is None:
+            continue
+        poll.room_id = room.pk
+        poll.cid = f"messaging:{room.uuid}"
+        poll.save(update_fields=["room", "cid"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0001_initial"),
+        ("polls", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="poll",
+            name="room",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="polls",
+                to="chat.room",
+            ),
+        ),
+        migrations.RunPython(bind_existing_polls, migrations.RunPython.noop),
+    ]

--- a/backend/stream_server_django/polls/models.py
+++ b/backend/stream_server_django/polls/models.py
@@ -20,6 +20,13 @@ class Poll(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     cid = models.CharField(max_length=255)
+    room = models.ForeignKey(
+        "chat.Room",
+        related_name="polls",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+    )
     question = models.CharField(max_length=255)
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -33,9 +40,17 @@ class Poll(models.Model):
         indexes = [models.Index(fields=["cid", "-created_at", "-id"])]
 
     def save(self, *args, **kwargs):  # pragma: no cover - normalized via create path
-        if self.cid:
+        if self.room_id:
+            self.cid = self.room.cid
+        elif self.cid:
             self.cid = normalize_cid(self.cid)
         super().save(*args, **kwargs)
+
+    @property
+    def canonical_cid(self) -> str:
+        if not self.room_id:
+            raise ValueError("poll is not bound to a room")
+        return self.room.cid
 
 
 class PollOption(models.Model):

--- a/backend/stream_server_django/polls/serializers.py
+++ b/backend/stream_server_django/polls/serializers.py
@@ -22,6 +22,7 @@ class PollOptionSerializer(serializers.ModelSerializer):
 
 class PollSerializer(serializers.ModelSerializer):
     poll_id = serializers.SerializerMethodField()
+    cid = serializers.SerializerMethodField()
     options = serializers.SerializerMethodField()
 
     class Meta:
@@ -31,6 +32,9 @@ class PollSerializer(serializers.ModelSerializer):
 
     def get_poll_id(self, obj: Poll) -> str:
         return str(obj.id)
+
+    def get_cid(self, obj: Poll) -> str:
+        return obj.canonical_cid
 
     def get_options(self, obj: Poll) -> Iterable[dict]:
         options = getattr(obj, "prefetched_options", None)

--- a/backend/stream_server_django/polls/tests/test_poll_room_authorization.py
+++ b/backend/stream_server_django/polls/tests/test_poll_room_authorization.py
@@ -302,22 +302,90 @@ class PollRoomAuthorizationTests(APITestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_data_migration_binds_only_existing_rooms_and_preserves_orphans(self):
+    def _run_room_binding_migration(self):
+        migration = importlib.import_module(
+            "stream_server_django.polls.migrations.0002_poll_room"
+        )
+        migration.bind_existing_polls(apps, None)
+
+    def test_data_migration_binds_authorized_creator_and_preserves_missing_room(self):
         matching = Poll.objects.create(
             cid=self.room_a.cid, question="matching", created_by=self.member_a
         )
         orphan = Poll.objects.create(
             cid="messaging:missing-room", question="orphan", created_by=self.member_a
         )
-        migration = importlib.import_module(
-            "stream_server_django.polls.migrations.0002_poll_room"
-        )
-        migration.bind_existing_polls(apps, None)
+        before = (Room.objects.count(), Poll.objects.count())
+        self._run_room_binding_migration()
         matching.refresh_from_db()
         orphan.refresh_from_db()
         self.assertEqual(matching.room, self.room_a)
         self.assertEqual(matching.cid, self.room_a.cid)
         self.assertIsNone(orphan.room)
+        self.assertEqual((Room.objects.count(), Poll.objects.count()), before)
+
+    def test_data_migration_rejects_historical_cross_room_cid_injection(self):
+        injected = Poll.objects.create(
+            cid=self.room_a.cid,
+            question="injected",
+            created_by=self.outsider,
+        )
+        before = (Room.objects.count(), Poll.objects.count())
+        self._run_room_binding_migration()
+        injected.refresh_from_db()
+
+        self.assertIsNone(injected.room)
+        self.assertEqual((Room.objects.count(), Poll.objects.count()), before)
+
+        canonical = self.client.get(
+            f"/polls/?cid={self.room_a.cid}", **self._headers(self.member_a)
+        )
+        legacy = self.client.get(
+            f"/api/polls/?cid={self.room_a.cid}", **self._headers(self.member_a)
+        )
+        direct = self.client.post(
+            f"/polls/{injected.id}/options/",
+            {"text": "hidden"},
+            format="json",
+            **self._headers(self.outsider),
+        )
+        self.assertNotIn(
+            str(injected.id), {poll["poll_id"] for poll in canonical.data["results"]}
+        )
+        self.assertNotIn(str(injected.id), {poll["id"] for poll in legacy.data})
+        self.assertEqual(direct.status_code, 404)
+
+    def test_data_migration_accepts_prior_message_membership(self):
+        historical = Poll.objects.create(
+            cid=self.room_a.cid,
+            question="prior message",
+            created_by=self.participant,
+        )
+        self._run_room_binding_migration()
+        historical.refresh_from_db()
+        self.assertEqual(historical.room, self.room_a)
+        self.assertEqual(historical.cid, self.room_a.cid)
+
+    def test_data_migration_accepts_agent_staff_and_superuser_evidence(self):
+        superuser = self._user("superuser", is_superuser=True)
+        cases = (
+            (self.agent, "agent"),
+            (self.staff, "staff"),
+            (superuser, "superuser"),
+        )
+        polls = [
+            Poll.objects.create(
+                cid=self.room_a.cid,
+                question=label,
+                created_by=creator,
+            )
+            for creator, label in cases
+        ]
+        self._run_room_binding_migration()
+        for poll in polls:
+            poll.refresh_from_db()
+            self.assertEqual(poll.room, self.room_a)
+            self.assertEqual(poll.cid, self.room_a.cid)
 
     def test_legacy_api_aliases_use_canonical_room_bound_models(self):
         created = self.client.post(

--- a/backend/stream_server_django/polls/tests/test_poll_room_authorization.py
+++ b/backend/stream_server_django/polls/tests/test_poll_room_authorization.py
@@ -1,0 +1,370 @@
+from urllib.parse import quote
+from unittest.mock import patch
+import importlib
+
+import jwt
+from django.conf import settings
+from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat.models import Channel, Message, Room
+from stream_server_django.polls.models import Poll, PollAnswer, PollOption, PollVote
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="jatte.urls",
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+class PollRoomAuthorizationTests(APITestCase):
+    def setUp(self):
+        self.member_a = self._user("member-a")
+        self.member_b = self._user("member-b")
+        self.outsider = self._user("outsider")
+        self.participant = self._user("participant")
+        self.agent = self._user("agent")
+        self.staff = self._user("staff", is_staff=True)
+
+        self.room_a = Room.objects.create(
+            uuid="room-a", client=self.member_a.supabase_uid, agent=self.agent
+        )
+        self.room_b = Room.objects.create(
+            uuid="room-b", client=self.member_b.supabase_uid
+        )
+        channel = Channel.objects.create(uuid="membership", client="membership")
+        membership = Message.objects.create(
+            channel=channel, body="joined", sent_by=self.participant.username
+        )
+        self.room_a.messages.add(membership)
+
+        self.poll_a = self._poll(self.room_a, self.member_a, "Poll A")
+        self.poll_b = self._poll(self.room_b, self.member_b, "Poll B")
+        self.option_a = PollOption.objects.create(
+            poll=self.poll_a, text="A", created_by=self.member_a
+        )
+        self.option_b = PollOption.objects.create(
+            poll=self.poll_b, text="B", created_by=self.member_b
+        )
+        PollAnswer.objects.create(poll=self.poll_a, text="answer", user=self.member_a)
+        PollVote.objects.create(
+            poll=self.poll_a, option=self.option_a, user=self.member_a
+        )
+        PollVote.objects.create(
+            poll=self.poll_b, option=self.option_b, user=self.member_b
+        )
+
+    def _user(self, username, **kwargs):
+        return User.objects.create_user(
+            username=username,
+            email=f"{username}@example.com",
+            password="pwd",
+            supabase_uid=username,
+            **kwargs,
+        )
+
+    def _poll(self, room, creator, question):
+        return Poll.objects.create(
+            room=room,
+            cid=room.cid,
+            question=question,
+            created_by=creator,
+        )
+
+    def _headers(self, user):
+        token = jwt.encode(
+            {"sub": user.username, "email": user.email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_anonymous_poll_list_is_denied(self):
+        response = self.client.get(f"/polls/?cid={self.room_a.cid}")
+        self.assertEqual(response.status_code, 403)
+
+    def test_list_is_room_scoped_and_inaccessible_counts_are_not_leaked(self):
+        allowed = self.client.get(
+            f"/polls/?cid={self.room_a.cid}", **self._headers(self.member_a)
+        )
+        self.assertEqual(allowed.status_code, 200)
+        self.assertEqual(
+            [item["poll_id"] for item in allowed.data["results"]],
+            [str(self.poll_a.id)],
+        )
+
+        cross_room = self.client.get(
+            f"/polls/?cid={self.room_b.cid}", **self._headers(self.member_a)
+        )
+        outsider = self.client.get(
+            f"/polls/?cid={self.room_a.cid}", **self._headers(self.outsider)
+        )
+        self.assertEqual(cross_room.status_code, 403)
+        self.assertEqual(outsider.status_code, 403)
+        self.assertNotIn("count", getattr(cross_room, "data", {}))
+        self.assertNotIn("count", getattr(outsider, "data", {}))
+
+    def test_create_requires_existing_authorized_room_before_side_effects(self):
+        payload = {"cid": self.room_a.cid, "question": "New?", "options": ["x"]}
+        allowed = self.client.post(
+            "/polls/", payload, format="json", **self._headers(self.member_a)
+        )
+        self.assertEqual(allowed.status_code, 201)
+        created = Poll.objects.get(pk=allowed.data["poll"]["poll_id"])
+        self.assertEqual(created.room, self.room_a)
+        self.assertEqual(created.cid, self.room_a.cid)
+
+        before = (Poll.objects.count(), PollOption.objects.count(), Room.objects.count())
+        with patch("stream_server_django.polls.views._broadcast_poll_event") as broadcast:
+            denied = self.client.post(
+                "/polls/", payload, format="json", **self._headers(self.outsider)
+            )
+            guessed = self.client.post(
+                "/polls/",
+                {"cid": "messaging:guessed", "question": "No", "options": ["x"]},
+                format="json",
+                **self._headers(self.member_a),
+            )
+        self.assertEqual(denied.status_code, 403)
+        self.assertEqual(guessed.status_code, 404)
+        self.assertEqual(
+            (Poll.objects.count(), PollOption.objects.count(), Room.objects.count()),
+            before,
+        )
+        broadcast.assert_not_called()
+
+    def test_option_and_answer_operations_authorize_through_poll_room(self):
+        option_url = f"/polls/{self.poll_a.id}/options/"
+        answer_url = f"/polls/{self.poll_a.id}/answers/"
+        option = self.client.post(
+            option_url,
+            {"text": "new option"},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        answer = self.client.post(
+            answer_url,
+            {"text": "new answer"},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(option.status_code, 200)
+        self.assertEqual(answer.status_code, 200)
+
+        before = (PollOption.objects.count(), PollAnswer.objects.count())
+        denied_option = self.client.post(
+            option_url,
+            {"text": "denied"},
+            format="json",
+            **self._headers(self.outsider),
+        )
+        denied_answer = self.client.post(
+            answer_url,
+            {"text": "denied"},
+            format="json",
+            **self._headers(self.outsider),
+        )
+        self.assertEqual(denied_option.status_code, 404)
+        self.assertEqual(denied_answer.status_code, 404)
+        self.assertEqual((PollOption.objects.count(), PollAnswer.objects.count()), before)
+
+    def test_poll_and_option_substitution_is_rejected(self):
+        response = self.client.post(
+            f"/polls/{self.poll_a.id}/options/{self.option_b.id}/votes/",
+            {},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(
+            PollVote.objects.filter(poll=self.poll_a, user=self.member_a, option=self.option_b).exists()
+        )
+
+    def test_vote_lifecycle_is_room_authorized_and_idempotent(self):
+        voter = self.participant
+        url = f"/polls/{self.poll_a.id}/options/{self.option_a.id}/votes/"
+        first = self.client.post(url, {}, format="json", **self._headers(voter))
+        second = self.client.post(url, {}, format="json", **self._headers(voter))
+        listing = self.client.get(url, **self._headers(voter))
+        removed = self.client.delete(url, **self._headers(voter))
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(PollVote.objects.filter(poll=self.poll_a, user=voter).count(), 0)
+        self.assertEqual(listing.status_code, 200)
+        self.assertEqual(removed.status_code, 200)
+
+    def test_vote_change_and_event_cid_derive_from_bound_room(self):
+        second_option = PollOption.objects.create(
+            poll=self.poll_a, text="A2", created_by=self.member_a
+        )
+        PollVote.objects.create(
+            poll=self.poll_a, option=self.option_a, user=self.participant
+        )
+        Poll.objects.filter(pk=self.poll_a.pk).update(cid=self.room_b.cid)
+        self.poll_a.refresh_from_db()
+        with patch("stream_server_django.polls.views._broadcast_poll_event") as broadcast:
+            response = self.client.post(
+                f"/polls/{self.poll_a.id}/options/{second_option.id}/votes/",
+                {},
+                format="json",
+                **self._headers(self.participant),
+            )
+        self.assertEqual(response.status_code, 200)
+        payload = broadcast.call_args.args[1]
+        self.assertEqual(payload["type"], "poll.vote_changed")
+        self.assertEqual(payload["cid"], self.room_a.cid)
+
+    def test_outsider_cannot_read_count_or_mutate_votes_and_emits_nothing(self):
+        url = f"/polls/{self.poll_a.id}/options/{self.option_a.id}/votes/"
+        before = PollVote.objects.count()
+        with patch("stream_server_django.polls.views._broadcast_poll_event") as broadcast:
+            listing = self.client.get(url, **self._headers(self.outsider))
+            create = self.client.post(url, {}, format="json", **self._headers(self.outsider))
+            remove = self.client.delete(url, **self._headers(self.outsider))
+        self.assertEqual([listing.status_code, create.status_code, remove.status_code], [404, 404, 404])
+        self.assertEqual(PollVote.objects.count(), before)
+        for response in (listing, create, remove):
+            self.assertNotIn("count", getattr(response, "data", {}))
+        broadcast.assert_not_called()
+
+    def test_poll_list_cursor_is_bound_to_room(self):
+        self._poll(self.room_b, self.member_b, "Poll B2")
+        room_b_page = self.client.get(
+            f"/polls/?cid={self.room_b.cid}&limit=1", **self._headers(self.member_b)
+        )
+        cursor = quote(room_b_page.data["next"], safe="")
+        cross = self.client.get(
+            f"/polls/?cid={self.room_a.cid}&cursor={cursor}",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(cross.status_code, 400)
+        self.assertNotIn("results", cross.data)
+
+    def test_vote_cursor_is_bound_to_poll_and_option(self):
+        second_b_voter = self._user("member-b-2")
+        PollVote.objects.create(
+            poll=self.poll_b, option=self.option_b, user=second_b_voter
+        )
+        page = self.client.get(
+            f"/polls/{self.poll_b.id}/options/{self.option_b.id}/votes/?limit=1",
+            **self._headers(self.member_b),
+        )
+        cursor = quote(page.data["next"], safe="")
+        cross = self.client.get(
+            f"/polls/{self.poll_a.id}/options/{self.option_a.id}/votes/?cursor={cursor}",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(cross.status_code, 400)
+        self.assertNotIn("results", cross.data)
+        self.assertNotIn("count", cross.data)
+
+    def test_delete_policy_creator_agent_staff_and_participant(self):
+        participant_poll = self._poll(self.room_a, self.member_a, "participant denied")
+        denied = self.client.delete(
+            f"/polls/{participant_poll.id}/", **self._headers(self.participant)
+        )
+        self.assertEqual(denied.status_code, 403)
+        self.assertTrue(Poll.objects.filter(pk=participant_poll.pk).exists())
+
+        creator_poll = self._poll(self.room_a, self.member_a, "creator")
+        creator = self.client.delete(
+            f"/polls/{creator_poll.id}/", **self._headers(self.member_a)
+        )
+        agent_poll = self._poll(self.room_a, self.member_a, "agent")
+        agent = self.client.delete(
+            f"/polls/{agent_poll.id}/", **self._headers(self.agent)
+        )
+        staff_poll = self._poll(self.room_a, self.member_a, "staff")
+        staff = self.client.delete(
+            f"/polls/{staff_poll.id}/", **self._headers(self.staff)
+        )
+        self.assertEqual([creator.status_code, agent.status_code, staff.status_code], [204, 204, 204])
+
+        outsider_poll = self._poll(self.room_a, self.member_a, "outsider")
+        outsider = self.client.delete(
+            f"/polls/{outsider_poll.id}/", **self._headers(self.outsider)
+        )
+        self.assertEqual(outsider.status_code, 404)
+        self.assertTrue(Poll.objects.filter(pk=outsider_poll.pk).exists())
+
+    def test_orphaned_historical_poll_is_not_api_reachable(self):
+        orphan = Poll.objects.create(
+            cid="messaging:missing", question="orphan", created_by=self.member_a
+        )
+        response = self.client.post(
+            f"/polls/{orphan.id}/options/",
+            {"text": "no"},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_data_migration_binds_only_existing_rooms_and_preserves_orphans(self):
+        matching = Poll.objects.create(
+            cid=self.room_a.cid, question="matching", created_by=self.member_a
+        )
+        orphan = Poll.objects.create(
+            cid="messaging:missing-room", question="orphan", created_by=self.member_a
+        )
+        migration = importlib.import_module(
+            "stream_server_django.polls.migrations.0002_poll_room"
+        )
+        migration.bind_existing_polls(apps, None)
+        matching.refresh_from_db()
+        orphan.refresh_from_db()
+        self.assertEqual(matching.room, self.room_a)
+        self.assertEqual(matching.cid, self.room_a.cid)
+        self.assertIsNone(orphan.room)
+
+    def test_legacy_api_aliases_use_canonical_room_bound_models(self):
+        created = self.client.post(
+            "/api/polls/",
+            {"cid": self.room_a.cid, "question": "legacy", "options": ["one"]},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(created.status_code, 201)
+        poll = Poll.objects.get(pk=created.data["poll"]["id"])
+        self.assertEqual(poll.room, self.room_a)
+
+        listed = self.client.get("/api/polls/", **self._headers(self.member_a))
+        self.assertEqual(listed.status_code, 200)
+        listed_ids = {item["id"] for item in listed.data}
+        self.assertIn(str(self.poll_a.id), listed_ids)
+        self.assertNotIn(str(self.poll_b.id), listed_ids)
+
+        option = self.client.post(
+            f"/api/polls/{poll.id}/options/",
+            {"text": "two"},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        self.assertEqual(option.status_code, 201)
+        self.assertTrue(
+            PollOption.objects.filter(
+                poll_id=poll.id, id=option.data["poll_option"]["id"]
+            ).exists()
+        )
+
+    def test_legacy_aliases_reject_cross_room_reads_mutations_and_delete(self):
+        list_b = self.client.get(
+            f"/api/polls/?cid={self.room_b.cid}", **self._headers(self.member_a)
+        )
+        option = self.client.post(
+            f"/api/polls/{self.poll_b.id}/options/",
+            {"text": "denied"},
+            format="json",
+            **self._headers(self.member_a),
+        )
+        votes = self.client.get(
+            f"/api/polls/{self.poll_b.id}/options/{self.option_b.id}/votes/",
+            **self._headers(self.member_a),
+        )
+        delete = self.client.delete(
+            f"/api/polls/{self.poll_b.id}/", **self._headers(self.member_a)
+        )
+        self.assertEqual([list_b.status_code, option.status_code, votes.status_code, delete.status_code], [403, 404, 404, 404])
+        self.assertTrue(Poll.objects.filter(pk=self.poll_b.pk).exists())

--- a/backend/stream_server_django/polls/tests/test_polls.py
+++ b/backend/stream_server_django/polls/tests/test_polls.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from rest_framework.test import APITestCase
 from stream_server_django.polls.models import Poll, PollOption
+from stream_server_django.chat.models import Room
 
 call_command("migrate", run_syncdb=True, verbosity=0)
 
@@ -26,6 +27,7 @@ class PollsAPITests(APITestCase):
             password="pwd",
             supabase_uid="alice",
         )
+        self.room = Room.objects.create(uuid="general", client="alice")
 
     def _auth_headers(self, sub: str | None = None) -> dict[str, str]:
         token = jwt.encode(
@@ -59,6 +61,7 @@ class PollsAPITests(APITestCase):
 
     def test_list_polls_returns_results(self):
         poll = Poll.objects.create(
+            room=self.room,
             cid="messaging:general",
             question="Favorite color?",
             created_by=self.user,

--- a/backend/stream_server_django/polls/tests/test_votes.py
+++ b/backend/stream_server_django/polls/tests/test_votes.py
@@ -9,17 +9,24 @@ django.setup()
 import jwt
 from asgiref.sync import async_to_sync, sync_to_async
 from channels.testing import WebsocketCommunicator
+from channels.routing import URLRouter
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TransactionTestCase, override_settings
+from django.urls import path
 from rest_framework.test import APIClient, APITestCase
 from urllib.parse import quote
 
 from django.contrib.auth import get_user_model
 
 from stream_server_django.polls.models import Poll, PollOption, PollVote
-from jatte.asgi import application
+from stream_server_django.chat.models import Room
+from stream_server_django.chat.consumers import ChatConsumer
 User = get_user_model()
+
+application = URLRouter(
+    [path("ws/<str:room_key>/", ChatConsumer.as_asgi())]
+)
 
 call_command("migrate", run_syncdb=True, verbosity=0)
 
@@ -37,7 +44,9 @@ class PollVoteWebsocketTests(TransactionTestCase):
             password="pwd",
             supabase_uid="bob",
         )
+        room = await sync_to_async(Room.objects.create)(uuid="general", client="bob")
         poll = await sync_to_async(Poll.objects.create)(
+            room=room,
             cid="messaging:general",
             question="Best snack?",
             created_by=user,
@@ -71,7 +80,7 @@ class PollVoteWebsocketTests(TransactionTestCase):
 
         communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
         connected, _ = await communicator.connect()
-        self.assertTrue(connected)
+        self.assertTrue(connected, f"websocket close detail: {_}")
         await communicator.receive_json_from()
         await communicator.send_json_to({"type": "channel.watch", "cid": poll.cid})
         await communicator.receive_json_from()
@@ -113,7 +122,7 @@ class PollVoteWebsocketTests(TransactionTestCase):
 
         communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
         connected, _ = await communicator.connect()
-        self.assertTrue(connected)
+        self.assertTrue(connected, f"websocket close detail: {_}")
         await communicator.receive_json_from()
         await communicator.send_json_to({"type": "channel.watch", "cid": poll.cid})
         await communicator.receive_json_from()
@@ -152,7 +161,7 @@ class PollVoteWebsocketTests(TransactionTestCase):
 
         communicator = WebsocketCommunicator(application, f"/ws/chat/?token={token}")
         connected, _ = await communicator.connect()
-        self.assertTrue(connected)
+        self.assertTrue(connected, f"websocket close detail: {_}")
         await communicator.receive_json_from()
         await communicator.send_json_to({"type": "channel.watch", "cid": poll.cid})
         await communicator.receive_json_from()
@@ -189,6 +198,7 @@ class PollVoteQueryTests(APITestCase):
             supabase_uid="dave",
         )
         self.poll = Poll.objects.create(
+            room=Room.objects.create(uuid="general", client="carol"),
             cid="messaging:general",
             question="Best day?",
             created_by=self.user,

--- a/backend/stream_server_django/polls/urls.py
+++ b/backend/stream_server_django/polls/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from .views import (
     PollAnswerCreateView,
+    PollDetailView,
     PollListCreateView,
     PollOptionCreateView,
     PollVoteView,
@@ -11,6 +12,7 @@ app_name = "stream_server_django.polls"
 
 urlpatterns = [
     path("polls/", PollListCreateView.as_view(), name="poll-list"),
+    path("polls/<uuid:poll_id>/", PollDetailView.as_view(), name="poll-detail"),
     path(
         "polls/<uuid:poll_id>/options/",
         PollOptionCreateView.as_view(),

--- a/backend/stream_server_django/polls/views.py
+++ b/backend/stream_server_django/polls/views.py
@@ -9,13 +9,21 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.db import transaction
 from django.db.models import Q
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.dateparse import parse_datetime
 from rest_framework import permissions, status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from stream_server_django.common.identity import get_chat_identity
+from stream_server_django.rooms.utils import (
+    can_admin_room,
+    get_room_or_404,
+    require_room_access,
+    user_has_room_access,
+)
 
 from .models import Poll, PollAnswer, PollOption, PollVote, normalize_cid
 from .serializers import (
@@ -47,17 +55,21 @@ def _parse_limit(raw: Optional[str]) -> int:
 
 @dataclass(frozen=True)
 class Cursor:
+    scope: str
     created_at: datetime
     identifier: uuid.UUID
 
     def encode(self) -> str:
-        return f"{self.created_at.isoformat()}|{self.identifier}"
+        return f"{self.scope}|{self.created_at.isoformat()}|{self.identifier}"
 
     @staticmethod
-    def decode(raw: str) -> "Cursor":
-        if "|" not in raw:
+    def decode(raw: str, *, expected_scope: str) -> "Cursor":
+        parts = raw.split("|", 2)
+        if len(parts) != 3:
             raise ValueError("Invalid cursor")
-        created_at, identifier = raw.split("|", 1)
+        scope, created_at, identifier = parts
+        if scope != expected_scope:
+            raise ValueError("Invalid cursor scope")
         dt = parse_datetime(created_at)
         if dt is None:
             raise ValueError("Invalid cursor timestamp")
@@ -65,7 +77,7 @@ class Cursor:
             option_uuid = uuid.UUID(identifier)
         except ValueError as exc:
             raise ValueError("Invalid cursor identifier") from exc
-        return Cursor(created_at=dt, identifier=option_uuid)
+        return Cursor(scope=scope, created_at=dt, identifier=option_uuid)
 
     def as_filters(self) -> Q:
         return Q(created_at__lt=self.created_at) | (
@@ -78,7 +90,7 @@ def _broadcast_poll_event(poll: Poll, payload: dict) -> None:
         channel_layer = get_channel_layer()
         if not channel_layer:
             return
-        cid = poll.cid
+        cid = poll.canonical_cid
         async_to_sync(channel_layer.group_send)(
             f"channel_{cid.replace(':', '_')}",
             {"type": "chat.message", "payload": payload},
@@ -87,20 +99,45 @@ def _broadcast_poll_event(poll: Poll, payload: dict) -> None:
         pass
 
 
+def _authorized_room(user, cid: str):
+    """Resolve an existing room and require access without creating state."""
+
+    return require_room_access(user, get_room_or_404(normalize_cid(cid)))
+
+
+def _authorized_poll(user, poll_id) -> Poll:
+    """Resolve a room-bound poll and hide it from unauthorized callers."""
+
+    poll = get_object_or_404(
+        Poll.objects.select_related("room", "created_by"),
+        pk=poll_id,
+        room__isnull=False,
+    )
+    if not user_has_room_access(user, poll.room):
+        raise Http404
+    return poll
+
+
+def _can_delete_poll(user, poll: Poll) -> bool:
+    return bool(
+        can_admin_room(user, poll.room)
+        or (poll.created_by_id == user.id and user_has_room_access(user, poll.room))
+    )
+
+
 class PollListCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
+        identity = get_chat_identity(request)
+        user = identity.as_user()
         cid_param = request.query_params.get("cid")
         if not cid_param:
             return Response(
                 {"detail": "cid query parameter is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        try:
-            cid = normalize_cid(cid_param)
-        except ValueError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        room = _authorized_room(user, cid_param)
 
         try:
             limit = _parse_limit(request.query_params.get("limit"))
@@ -108,10 +145,11 @@ class PollListCreateView(APIView):
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
         cursor_param = request.query_params.get("cursor")
-        filters = Q(cid=cid)
+        cursor_scope = f"room:{room.pk}"
+        filters = Q(room=room)
         if cursor_param:
             try:
-                cursor = Cursor.decode(cursor_param)
+                cursor = Cursor.decode(cursor_param, expected_scope=cursor_scope)
             except ValueError as exc:
                 return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
             filters &= cursor.as_filters()
@@ -129,6 +167,7 @@ class PollListCreateView(APIView):
         if has_next and page:
             last = page[-1]
             next_cursor = Cursor(
+                scope=cursor_scope,
                 created_at=last.created_at,
                 identifier=last.id,
             ).encode()
@@ -142,10 +181,12 @@ class PollListCreateView(APIView):
         serializer = PollCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
+        room = _authorized_room(user, data["cid"])
 
         with transaction.atomic():
             poll = Poll.objects.create(
-                cid=data["cid"],
+                room=room,
+                cid=room.cid,
                 question=data["question"],
                 created_by=user,
             )
@@ -163,13 +204,26 @@ class PollListCreateView(APIView):
         return Response({"poll": payload}, status=status.HTTP_201_CREATED)
 
 
+class PollDetailView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request, poll_id: str):
+        identity = get_chat_identity(request)
+        user = identity.as_user()
+        poll = _authorized_poll(user, poll_id)
+        if not _can_delete_poll(user, poll):
+            raise PermissionDenied()
+        poll.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 class PollOptionCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, poll_id: str):
         identity = get_chat_identity(request)
         user = identity.as_user()
-        poll = get_object_or_404(Poll, pk=poll_id)
+        poll = _authorized_poll(user, poll_id)
         serializer = PollOptionCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         option = PollOption.objects.create(
@@ -186,7 +240,7 @@ class PollAnswerCreateView(APIView):
     def post(self, request, poll_id: str):
         identity = get_chat_identity(request)
         user = identity.as_user()
-        poll = get_object_or_404(Poll, pk=poll_id)
+        poll = _authorized_poll(user, poll_id)
         serializer = PollAnswerCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         answer = PollAnswer.objects.create(
@@ -201,7 +255,9 @@ class PollVoteView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, poll_id: str, option_id: str):
-        poll = get_object_or_404(Poll, pk=poll_id)
+        identity = get_chat_identity(request)
+        user = identity.as_user()
+        poll = _authorized_poll(user, poll_id)
         option = get_object_or_404(PollOption, pk=option_id, poll=poll)
 
         try:
@@ -210,12 +266,13 @@ class PollVoteView(APIView):
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
         cursor_param = request.query_params.get("cursor")
+        cursor_scope = f"poll:{poll.id}:option:{option.id}"
         votes_qs = PollVote.objects.filter(poll=poll, option=option).order_by(
             "-created_at", "-id"
         )
         if cursor_param:
             try:
-                cursor = Cursor.decode(cursor_param)
+                cursor = Cursor.decode(cursor_param, expected_scope=cursor_scope)
             except ValueError as exc:
                 return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
             votes_qs = votes_qs.filter(cursor.as_filters())
@@ -228,6 +285,7 @@ class PollVoteView(APIView):
         if has_next and page:
             last = page[-1]
             next_cursor = Cursor(
+                scope=cursor_scope,
                 created_at=last.created_at,
                 identifier=last.id,
             ).encode()
@@ -242,7 +300,7 @@ class PollVoteView(APIView):
     def post(self, request, poll_id: str, option_id: str):
         identity = get_chat_identity(request)
         user = identity.as_user()
-        poll = get_object_or_404(Poll, pk=poll_id)
+        poll = _authorized_poll(user, poll_id)
         option = get_object_or_404(PollOption, pk=option_id, poll=poll)
 
         with transaction.atomic():
@@ -278,7 +336,7 @@ class PollVoteView(APIView):
     def delete(self, request, poll_id: str, option_id: str):
         identity = get_chat_identity(request)
         user = identity.as_user()
-        poll = get_object_or_404(Poll, pk=poll_id)
+        poll = _authorized_poll(user, poll_id)
         option = get_object_or_404(PollOption, pk=option_id, poll=poll)
 
         try:
@@ -346,7 +404,7 @@ def _broadcast_vote_event(
         "type": event_type,
         "event": event_type,
         "event_type": event_type,
-        "cid": poll.cid,
+        "cid": poll.canonical_cid,
         "poll_id": str(poll.id),
         "user_id": str(vote.user_id),
         "ts": current_timestamp(),

--- a/frontend/__tests__/adapter/pollComposer.test.ts
+++ b/frontend/__tests__/adapter/pollComposer.test.ts
@@ -27,7 +27,7 @@ test('create posts poll and stores result', async () => {
       'Content-Type': 'application/json',
       Authorization: 'Bearer jwt-test',
     },
-    body: JSON.stringify({ question: 'q1', options: ['a'] }),
+    body: JSON.stringify({ cid: 'messaging:r1', question: 'q1', options: ['a'] }),
   });
   expect(comp.state.getSnapshot().poll).toEqual({ id: 'p1', question: 'q1', options: ['a'] });
 });

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -186,7 +186,7 @@ export class Channel {
                             'Content-Type': 'application/json',
                             Authorization: `Bearer ${channelRef.client['jwt']}`,
                         },
-                        body: JSON.stringify({ question, options }),
+                        body: JSON.stringify({ cid: channelRef.cid, question, options }),
                     });
                     if (res.ok) {
                         const data = await res.json();

--- a/frontend/src/lib/stream-adapter/composer/index.ts
+++ b/frontend/src/lib/stream-adapter/composer/index.ts
@@ -11,7 +11,7 @@ export const buildMessageComposer = (channelRef:any) => {
   return {
     contextType:'message', tag:'root',
     attachmentManager: buildAttachmentManager({ jwt: channelRef.client['jwt'] }),
-    pollComposer     : buildPollComposer(channelRef.client),
+    pollComposer     : buildPollComposer(channelRef.client, channelRef.cid),
     customDataManager: {
       state:new MiniStore({ customData:{} as Record<string, unknown> }),
       set(k:string,v:unknown){

--- a/frontend/src/lib/stream-adapter/composer/polls.ts
+++ b/frontend/src/lib/stream-adapter/composer/polls.ts
@@ -2,7 +2,7 @@
 import { MiniStore } from '../MiniStore';
 import { API } from '../constants';
 
-export const buildPollComposer = (client: { jwt: string | null }) => ({
+export const buildPollComposer = (client: { jwt: string | null }, cid: string) => ({
   state: new MiniStore({ poll: undefined as any }),
   async create(question: string, options: string[] = []) {
     const res = await fetch(API.POLLS, {
@@ -11,7 +11,7 @@ export const buildPollComposer = (client: { jwt: string | null }) => ({
         'Content-Type': 'application/json',
         ...(client.jwt ? { Authorization: `Bearer ${client['jwt']}` } : {}),
       },
-      body: JSON.stringify({ question, options }),
+      body: JSON.stringify({ cid, question, options }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
Binds canonical polls to existing authorized rooms; converts reachable legacy poll APIs to secured compatibility adapters; scopes cursors and event routing to the owning room; and preserves unmatched historical rows as inaccessible orphans. Verification: 37 poll tests and 82 prior security/Stream contract tests passed; Django check, changed-file compilation, fresh migration, targeted migration drift check, and diff check passed. Frontend test provisioning was blocked by the pre-existing stale pnpm lockfile and only 40 MB free disk; no dependency metadata was changed.