### PR TITLE
Security PR9: Close state and reminder alias authorization gaps

### DIFF
--- a/backend/audit/pr9-state-reminder-alias-contract.md
+++ b/backend/audit/pr9-state-reminder-alias-contract.md
@@ -1,0 +1,34 @@
+# PR9 state and reminder alias contract
+
+## Effective production routes
+
+All results below use `ROOT_URLCONF="jatte.urls"`.
+
+| Route | Effective view | Caller/status | Successful shape | Authorization |
+| --- | --- | --- | --- | --- |
+| `/recover-state/` | `state.views.recover_state` | Root compatibility route; no active frontend caller found | `{stream_server_django.rooms: [{id, uuid, name, data}], notifications: [{type, payload, ts}]}` | Active rooms from `rooms_accessible_to_user`; notifications for the authenticated user |
+| `/api/recover-state/` | `chat.api_views.RecoverStateView` | Canonical frontend `ChatClient.recoverStateOnReconnect` call | `{stream_server_django.rooms: RoomSerializer[], notifications: NotificationSerializer[]}` | Active rooms from `rooms_accessible_to_user`; notifications for the authenticated user |
+| `/reminders/` | `reminders.views.ReminderListCreateView` | Root compatibility route; `API.REMINDERS` reaches `/api/reminders/` through `apiFetch` | GET list / POST `{reminder}` using compatibility fields | User-owned list; optional room target resolves an existing room and requires access before save/broadcast |
+| `/api/reminders/` | `chat.api_views.ReminderListCreateView` | Canonical frontend reminder endpoint | GET list / POST canonical reminder object | User-owned list; POST CID resolves an existing accessible room before save/broadcast |
+| `/api/rooms/<cid>/reminders/` | `chat.api_views.RoomReminderCreateView` | Canonical room-targeted shim call | canonical reminder object | Existing room and room access required before save/broadcast |
+
+The two recovery responses deliberately retain their existing serializer shapes;
+their effective authorized active-room set is now identical. With Django
+`APPEND_SLASH`, `/recover-state` and `/api/recover-state` redirect to their
+trailing-slash forms, which are the views above. Compatibility `/reminders`
+and `/reminders/` are both accepted explicitly.
+
+## Compatibility reminder CID consumers
+
+The compatibility `stream_server_django.reminders.models.Reminder.cid` is read
+only during the POST request that creates a row and emits `reminder.new`.
+Repository search found no scheduler, background job, notification delivery,
+read/list path, or later broadcaster consuming stored compatibility CIDs.
+Listing omits CID from `ReminderOut`, and deletion is user-scoped and emits no
+event.
+
+Historical compatibility CIDs therefore remain unchanged as untrusted inert
+data. They are never rebroadcast by reading/listing. Any new room-targeted
+creation resolves the existing room, proves owner access, saves the canonical
+room-derived CID, and broadcasts only to that canonical group. No migration or
+automatic historical adjudication is performed.

--- a/backend/stream_server_django/chat/tests/test_recover_state.py
+++ b/backend/stream_server_django/chat/tests/test_recover_state.py
@@ -14,7 +14,7 @@ class RecoverStateAPITests(APITestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
-        Room.objects.create(uuid="r1", client="c1", status=Room.ACTIVE)
+        Room.objects.create(uuid="r1", client=self.user.supabase_uid, status=Room.ACTIVE)
         Notification.objects.create(user=self.user, text="hi")
 
     def test_recover_state_returns_data(self):

--- a/backend/stream_server_django/reminders/views.py
+++ b/backend/stream_server_django/reminders/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from stream_server_django.common.identity import get_chat_identity
+from stream_server_django.rooms.utils import get_room_or_404, require_room_access
 
 from .models import Reminder
 from .serializers import ReminderIn, ReminderOut
@@ -50,14 +51,28 @@ class ReminderListCreateView(APIView):
     def post(self, request):
         identity = get_chat_identity(request)
         user = identity.as_user()
+        cid_supplied = "cid" in request.data
+        raw_cid = request.data.get("cid")
+        if cid_supplied and (not isinstance(raw_cid, str) or not raw_cid.strip()):
+            return Response(
+                {"cid": ["A non-blank string is required when cid is supplied."]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         serializer = ReminderIn(data=request.data, context={"user": user})
         serializer.is_valid(raise_exception=True)
+        room = None
+        if cid_supplied:
+            room = require_room_access(
+                user, get_room_or_404(serializer.validated_data["cid"])
+            )
+            serializer.validated_data["cid"] = room.cid
+
         reminder = serializer.save()
         payload = ReminderOut(reminder).data
 
-        cid = serializer.validated_data.get("cid")
-        if cid:
-            _broadcast_new_reminder(cid, payload)
+        if room is not None:
+            _broadcast_new_reminder(room.cid, payload)
 
         return Response({"reminder": payload}, status=status.HTTP_201_CREATED)
 

--- a/backend/stream_server_django/state/tests/test_pr9_alias_authorization.py
+++ b/backend/stream_server_django/state/tests/test_pr9_alias_authorization.py
@@ -1,0 +1,295 @@
+from datetime import timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from stream_server_django.chat.models import Notification, Reminder as CanonicalReminder, Room
+from stream_server_django.chat.utils import group_name_for_cid
+from stream_server_django.reminders.models import Reminder as CompatibilityReminder
+
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="jatte.urls",
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+class StateReminderAliasAuthorizationTests(APITestCase):
+    def setUp(self):
+        self.user_a = self._user("user-a")
+        self.user_b = self._user("user-b")
+        self.outsider = self._user("outsider")
+        self.staff = self._user("staff", is_staff=True)
+        self.room_a = Room.objects.create(
+            uuid="room-a",
+            client=self.user_a.supabase_uid,
+            data={"name": "Room A", "secret": "alpha"},
+        )
+        self.room_b = Room.objects.create(
+            uuid="room-b",
+            client=self.user_b.supabase_uid,
+            data={"name": "Room B", "secret": "bravo"},
+        )
+        Notification.objects.create(user=self.user_a, text="note-a")
+        Notification.objects.create(user=self.user_b, text="note-b")
+
+    def _user(self, username, **kwargs):
+        return User.objects.create_user(
+            username=username,
+            email=f"{username}@example.com",
+            password="pwd",
+            supabase_uid=username,
+            **kwargs,
+        )
+
+    def _headers(self, user):
+        token = jwt.encode(
+            {"sub": user.username, "email": user.email},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def _reminder_payload(self, **updates):
+        payload = {
+            "text": "Follow up",
+            "remind_at": (timezone.now() + timedelta(hours=1)).isoformat(),
+        }
+        payload.update(updates)
+        return payload
+
+    def _room_ids(self, response):
+        return {
+            room["uuid"] for room in response.data["stream_server_django.rooms"]
+        }
+
+    def test_recovery_aliases_share_authorized_room_set_and_notifications(self):
+        before = (Room.objects.count(), Notification.objects.count())
+        root = self.client.get("/recover-state/", **self._headers(self.user_a))
+        canonical = self.client.get(
+            "/api/recover-state/", **self._headers(self.user_a)
+        )
+        self.assertEqual((root.status_code, canonical.status_code), (200, 200))
+        self.assertEqual(self._room_ids(root), {self.room_a.uuid})
+        self.assertEqual(self._room_ids(canonical), {self.room_a.uuid})
+
+        root_payload = root.json()
+        serialized = str(root_payload)
+        self.assertNotIn(self.room_b.uuid, serialized)
+        self.assertNotIn("Room B", serialized)
+        self.assertNotIn("bravo", serialized)
+        self.assertEqual(len(root_payload["notifications"]), 1)
+        self.assertEqual(
+            root_payload["notifications"][0]["payload"], {"text": "note-a"}
+        )
+        self.assertEqual(
+            (Room.objects.count(), Notification.objects.count()), before
+        )
+
+    def test_recovery_outsider_staff_and_authentication_policy(self):
+        outsider_root = self.client.get(
+            "/recover-state/", **self._headers(self.outsider)
+        )
+        outsider_api = self.client.get(
+            "/api/recover-state/", **self._headers(self.outsider)
+        )
+        staff_root = self.client.get("/recover-state/", **self._headers(self.staff))
+        staff_api = self.client.get(
+            "/api/recover-state/", **self._headers(self.staff)
+        )
+        self.assertEqual(self._room_ids(outsider_root), set())
+        self.assertEqual(self._room_ids(outsider_api), set())
+        self.assertEqual(
+            self._room_ids(staff_root), {self.room_a.uuid, self.room_b.uuid}
+        )
+        self.assertEqual(self._room_ids(staff_api), self._room_ids(staff_root))
+        self.assertIn(self.client.get("/recover-state/").status_code, {401, 403})
+        self.assertIn(
+            self.client.get(
+                "/recover-state/", HTTP_AUTHORIZATION="Bearer invalid"
+            ).status_code,
+            {401, 403},
+        )
+
+    def test_recovery_no_slash_variants_redirect_to_secured_views(self):
+        for url, expected in (
+            ("/recover-state", "/recover-state/"),
+            ("/api/recover-state", "/api/recover-state/"),
+        ):
+            response = self.client.get(url, **self._headers(self.user_a))
+            self.assertEqual(response.status_code, 301)
+            self.assertEqual(response["Location"], expected)
+
+    @patch("stream_server_django.reminders.views.get_channel_layer")
+    def test_global_and_authorized_compatibility_reminders(self, get_channel_layer):
+        channel_layer = Mock()
+        channel_layer.group_send = AsyncMock()
+        get_channel_layer.return_value = channel_layer
+        global_response = self.client.post(
+            "/reminders/",
+            self._reminder_payload(),
+            format="json",
+            **self._headers(self.user_a),
+        )
+        self.assertEqual(global_response.status_code, 201)
+        global_reminder = CompatibilityReminder.objects.get(
+            pk=global_response.data["reminder"]["id"]
+        )
+        self.assertEqual(global_reminder.user, self.user_a)
+        self.assertIsNone(global_reminder.cid)
+        channel_layer.group_send.assert_not_awaited()
+
+        room_response = self.client.post(
+            "/reminders/",
+            self._reminder_payload(cid=self.room_a.uuid),
+            format="json",
+            **self._headers(self.user_a),
+        )
+        self.assertEqual(room_response.status_code, 201)
+        room_reminder = CompatibilityReminder.objects.get(
+            pk=room_response.data["reminder"]["id"]
+        )
+        self.assertEqual(room_reminder.cid, self.room_a.cid)
+        channel_layer.group_send.assert_awaited_once()
+        group, event = channel_layer.group_send.await_args.args
+        self.assertEqual(group, group_name_for_cid(self.room_a.cid))
+        self.assertEqual(event["payload"]["type"], "reminder.new")
+        self.assertEqual(event["payload"]["cid"], self.room_a.cid)
+
+    @patch("stream_server_django.reminders.views._broadcast_new_reminder")
+    def test_foreign_guessed_and_malformed_cids_have_zero_side_effects(self, broadcast):
+        before = (
+            CompatibilityReminder.objects.count(),
+            Room.objects.count(),
+            Notification.objects.count(),
+        )
+        for cid, expected_status in (
+            (self.room_b.cid, 403),
+            ("messaging:missing", 404),
+            ("", 400),
+            ("   ", 400),
+            (None, 400),
+            (17, 400),
+            ({"room": "a"}, 400),
+        ):
+            with self.subTest(cid=cid):
+                response = self.client.post(
+                    "/reminders/",
+                    self._reminder_payload(cid=cid),
+                    format="json",
+                    **self._headers(self.user_a),
+                )
+                self.assertEqual(response.status_code, expected_status)
+                self.assertEqual(
+                    (
+                        CompatibilityReminder.objects.count(),
+                        Room.objects.count(),
+                        Notification.objects.count(),
+                    ),
+                    before,
+                )
+        broadcast.assert_not_called()
+
+    def test_compatibility_reminder_ownership_is_unchanged(self):
+        own = CompatibilityReminder.objects.create(
+            user=self.user_a,
+            text="own",
+            remind_at=timezone.now(),
+            cid=self.room_b.cid,
+        )
+        other = CompatibilityReminder.objects.create(
+            user=self.user_b,
+            text="other",
+            remind_at=timezone.now(),
+            cid=self.room_a.cid,
+        )
+        listing = self.client.get("/reminders/", **self._headers(self.user_a))
+        self.assertEqual([item["id"] for item in listing.data], [str(own.id)])
+        denied = self.client.delete(
+            f"/reminders/{other.id}/", **self._headers(self.user_a)
+        )
+        self.assertEqual(denied.status_code, 404)
+        self.assertTrue(CompatibilityReminder.objects.filter(pk=other.pk).exists())
+
+    @patch("stream_server_django.chat.api_views._broadcast_reminder_created")
+    def test_canonical_reminder_routes_retain_authorized_creation(self, broadcast):
+        remind_at = self._reminder_payload()["remind_at"]
+        global_route = self.client.post(
+            "/api/reminders/",
+            {"cid": self.room_a.cid, "remind_at": remind_at, "note": "global"},
+            format="json",
+            **self._headers(self.user_a),
+        )
+        room_route = self.client.post(
+            f"/api/rooms/{self.room_a.cid}/reminders/",
+            {"remind_at": remind_at, "note": "room"},
+            format="json",
+            **self._headers(self.user_a),
+        )
+        self.assertEqual((global_route.status_code, room_route.status_code), (201, 201))
+        self.assertEqual(
+            CanonicalReminder.objects.filter(
+                room=self.room_a, created_by=self.user_a
+            ).count(),
+            2,
+        )
+        self.assertEqual(broadcast.call_count, 2)
+        self.assertEqual(
+            [call.args[0] for call in broadcast.call_args_list],
+            [self.room_a, self.room_a],
+        )
+
+    @patch("stream_server_django.chat.api_views._broadcast_reminder_created")
+    @patch("stream_server_django.reminders.views._broadcast_new_reminder")
+    def test_reminder_aliases_deny_inaccessible_rooms_before_side_effects(
+        self, compatibility_broadcast, canonical_broadcast
+    ):
+        before = (
+            CompatibilityReminder.objects.count(),
+            CanonicalReminder.objects.count(),
+            Room.objects.count(),
+            Notification.objects.count(),
+        )
+        compatibility = self.client.post(
+            "/reminders/",
+            self._reminder_payload(cid=self.room_b.cid),
+            format="json",
+            **self._headers(self.user_a),
+        )
+        canonical = self.client.post(
+            "/api/reminders/",
+            {
+                "cid": self.room_b.cid,
+                "remind_at": self._reminder_payload()["remind_at"],
+                "note": "no",
+            },
+            format="json",
+            **self._headers(self.user_a),
+        )
+        room_canonical = self.client.post(
+            f"/api/rooms/{self.room_b.cid}/reminders/",
+            {"remind_at": self._reminder_payload()["remind_at"], "note": "no"},
+            format="json",
+            **self._headers(self.user_a),
+        )
+        self.assertEqual(
+            (compatibility.status_code, canonical.status_code, room_canonical.status_code),
+            (403, 403, 403),
+        )
+        self.assertEqual(
+            (
+                CompatibilityReminder.objects.count(),
+                CanonicalReminder.objects.count(),
+                Room.objects.count(),
+                Notification.objects.count(),
+            ),
+            before,
+        )
+        compatibility_broadcast.assert_not_called()
+        canonical_broadcast.assert_not_called()

--- a/backend/stream_server_django/state/tests/test_state_recovery.py
+++ b/backend/stream_server_django/state/tests/test_state_recovery.py
@@ -10,7 +10,7 @@ import django
 import jwt
 from django.conf import settings
 from django.core.management import call_command
-from django.urls import reverse
+from django.test import override_settings
 
 # Configure Django manually because pytest-django is unavailable.
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -29,6 +29,7 @@ from stream_server_django.chat.models import Notification, Room  # noqa: E402
 User = get_user_model()
 
 
+@override_settings(ROOT_URLCONF="jatte.urls")
 class StateRecoveryEndpointsTests(APITestCase):
     """Validate recover-state helpers used during initialization."""
 
@@ -69,7 +70,7 @@ class StateRecoveryEndpointsTests(APITestCase):
         Notification.objects.create(user=self.other_user, text="ignore")
 
         token = self.make_token()
-        url = reverse("state:recover-state")
+        url = "/recover-state/"
 
         response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
 
@@ -98,14 +99,14 @@ class StateRecoveryEndpointsTests(APITestCase):
 
         token = self.make_token()
 
-        disconnected_url = reverse("state:disconnected")
+        disconnected_url = "/disconnected/"
         response = self.client.get(
             disconnected_url, HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"disconnected": False})
 
-        initialized_url = reverse("state:initialized")
+        initialized_url = "/initialized/"
         response = self.client.get(
             initialized_url, HTTP_AUTHORIZATION=f"Bearer {token}"
         )
@@ -116,7 +117,7 @@ class StateRecoveryEndpointsTests(APITestCase):
         """The audit diagnostic endpoint should echo integers back."""
 
         token = self.make_token()
-        url = reverse("state:editing-audit-state")
+        url = "/editing-audit-state/"
         payload = {"draft_update": 3, "state_update": 1}
 
         response = self.client.post(
@@ -133,12 +134,12 @@ class StateRecoveryEndpointsTests(APITestCase):
         """All state recovery endpoints should enforce authentication."""
 
         endpoints = [
-            ("get", reverse("state:recover-state"), None),
-            ("get", reverse("state:disconnected"), None),
-            ("get", reverse("state:initialized"), None),
+            ("get", "/recover-state/", None),
+            ("get", "/disconnected/", None),
+            ("get", "/initialized/", None),
             (
                 "post",
-                reverse("state:editing-audit-state"),
+                "/editing-audit-state/",
                 {"draft_update": 1, "state_update": 0},
             ),
         ]

--- a/backend/stream_server_django/state/views.py
+++ b/backend/stream_server_django/state/views.py
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 from stream_server_django.accounts_supabase.authentication import DevTokenOrJWTAuthentication
 from stream_server_django.common.identity import get_chat_identity
 from stream_server_django.chat.models import Notification, Room
+from stream_server_django.rooms.utils import rooms_accessible_to_user
 
 from .serializers import (
     EditingAuditStateSerializer,
@@ -39,7 +40,11 @@ def _coerce_room_data(value: Any) -> dict[str, Any]:
 def recover_state(request: Request) -> Response:
     """Return rooms and notifications required for a cold start."""
 
-    rooms = Room.objects.all().order_by("id")
+    identity = get_chat_identity(request)
+    user = identity.as_user()
+    rooms = rooms_accessible_to_user(
+        user, Room.objects.filter(status=Room.ACTIVE)
+    ).order_by("id")
     room_payload = []
     for room in rooms:
         data = _coerce_room_data(room.data)
@@ -54,8 +59,6 @@ def recover_state(request: Request) -> Response:
 
     rooms_serialized = RoomSnapshotSerializer(room_payload, many=True).data
 
-    identity = get_chat_identity(request)
-    user = identity.as_user()
     notifications = Notification.objects.filter(user=user).order_by(
         "-created_at"
     )


### PR DESCRIPTION
## Summary

- scope the root recover-state compatibility response with the shared PR3 room-access queryset
- preserve both recovery response shapes while enforcing the same active-room authorization set
- require compatibility reminder CIDs to resolve to an existing authorized room before persistence or broadcast
- derive stored and broadcast reminder CIDs from the resolved room
- preserve historical compatibility reminder rows as inert, user-owned data after confirming there are no later CID consumers
- add real jatte.urls alias-parity and zero-side-effect tests

## Verification

- 8 focused PR9 production-alias security tests passed
- 20 focused/current state and reminder tests passed
- 101 PR1-PR8 security and compatibility regression tests passed
- fresh-database migration passed
- Django system check passed
- changed-file Python compilation and Ruff passed
- git diff --check passed

The full migration drift check continues to report only the pre-existing, unrelated agent.0005_alter_documentchunk_id drift; PR9 adds no schema migration.