### PR TITLE
Security PR10: Enforce Supabase JWT authority and refresh semantics

### DIFF
--- a/backend/SECURITY.md
+++ b/backend/SECURITY.md
@@ -12,6 +12,8 @@ Production uses `jatte.settingsprod`. Startup requires all of the following:
 
 - `DJANGO_SECRET_KEY`
 - `SUPABASE_JWT_SECRET`
+- `SUPABASE_JWT_ISSUER` (or the trusted Supabase project URL used to derive it)
+- `SUPABASE_JWT_AUDIENCE` (defaults explicitly to `authenticated`)
 - `DJANGO_ALLOWED_HOSTS`
 - `DJANGO_CORS_ALLOWED_ORIGINS`
 - `DJANGO_WS_ALLOWED_ORIGINS`
@@ -20,6 +22,13 @@ The origin and host variables are comma-separated allowlists; wildcard values
 are rejected. Production TLS is expected to terminate at a proxy that sets
 `X-Forwarded-Proto: https`; this is used only because production settings
 explicitly configure Django to trust that proxy header.
+
+Supabase Auth is the sole issuer and refresher of browser user-session access
+tokens. JATTE requires signature validation plus `sub`, `exp`, `iat`, `iss`,
+and `aud` on both HTTP and WebSocket paths. `/api/token/` and the temporary
+refresh aliases relay the already-validated access token without minting,
+re-signing, or extending it. Actual refresh-token rotation stays inside the
+Supabase browser client; Supabase refresh tokens are never sent to JATTE.
 
 ## WebSocket boundary
 

--- a/backend/audit/pr10-jwt-authority-contract.md
+++ b/backend/audit/pr10-jwt-authority-contract.md
@@ -1,0 +1,44 @@
+# PR10 JWT authority and refresh contract
+
+## Production route and caller inventory
+
+| Route / operation | Effective implementation | Active caller | Before PR10 | PR10 contract |
+| --- | --- | --- | --- | --- |
+| `/refresh-token/` | `auth.views.RefreshTokenView`, inheriting `accounts_supabase.views.RefreshTokenView` | `ChatClient.refreshToken()` only | Locally minted indefinite HS256 token | Compatibility relay returning byte-for-byte `request.auth`, with `no-store`/`no-cache` |
+| `/api/refresh-token/` | `accounts_supabase.views.RefreshTokenView` because `accounts_supabase.urls` precedes `auth.urls` | No separate active caller found | Same local mint | Same non-minting relay |
+| `/api/token/` | `chat.views.TokenView` | `getChatCreds()` / `ChatProvider` bootstrap | Returned the validated incoming token as `userToken` | Unchanged pass-through bootstrap; never an issuer |
+| `/api/ws-auth/` | `chat.api.ws_auth` | Adapter connection handshake | Minted a separate five-minute exp-only HS256 token | Relays the exact validated Supabase token in the legacy URL; never an issuer |
+| `ChatClient.refreshToken()` | frontend Stream adapter | Stream-compatible client lifecycle | Called Django `/api/refresh-token/` through `apiFetch` | Calls Supabase JS 2.50.0 `auth.refreshSession()`, then validates/bootstrap-relays its access token through `/api/token/` |
+
+`TokenManager.refreshToken()` had no caller other than `ChatClient.refreshToken()`.
+No other active frontend component depends on Django minting a replacement JWT.
+`AuthBootstrap` calls `/api/token/` without a bearer token and cannot mint or
+refresh a credential.
+
+## Authority and propagation
+
+Supabase Auth is the sole issuer and refresher of browser user-session tokens.
+JATTE validates access tokens and may relay the exact validated token for
+Stream compatibility. A successful frontend refresh synchronizes
+`ChatClient.jwt`, `ChatClient.authToken`, `TokenManager.token`, the shared
+`authTokenStore`, and the stream-shim authorization token. REST, adapter,
+channel, and newly opened WebSocket operations therefore use the same access
+token.
+
+HTTP and the active `ChatConsumer` WebSocket path both call
+`decode_supabase_token`. HS256 accepts only the configured symmetric key;
+RS256 accepts only the configured JWKS key. Both require and validate `sub`,
+`exp`, `iat`, `iss`, and `aud` against `SUPABASE_JWT_ISSUER` and
+`SUPABASE_JWT_AUDIENCE`, with the existing 30-second leeway. Tokens using any
+other algorithm are rejected. User provisioning occurs only after this full
+validation.
+
+Production derives the issuer from an explicit `SUPABASE_JWT_ISSUER` or, as a
+compatibility fallback, the configured Supabase project URL. Startup fails
+closed if neither is available. The browser-user audience defaults explicitly
+to `authenticated` and can be set with `SUPABASE_JWT_AUDIENCE`.
+
+Old JATTE-minted tokens have no issuer, audience, issued-at, or expiry and are
+intentionally rejected. They are not grandfathered or exchanged. Normal
+browser bootstrap and refresh recover through the authenticated Supabase
+session.

--- a/backend/jatte/auth/supabase.py
+++ b/backend/jatte/auth/supabase.py
@@ -1,61 +1,8 @@
 # backend/jatte/auth/supabase.py
-import jwt
-from jwt import PyJWKClient
-from jwt.exceptions import PyJWTError
-
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from rest_framework import authentication, exceptions
+from stream_server_django.accounts_supabase.authentication import (
+    SupabaseJWTAuthentication,
+)
 
 
-class Old_Maybe_Delete_SupabaseJWTAuthentication(authentication.BaseAuthentication):
-    """Authenticate requests using Supabase-issued JWT tokens."""
-
-    def __init__(self):
-        jwks_url = settings.SUPABASE_JWKS_URL
-        if not jwks_url:
-            raise exceptions.AuthenticationFailed("Supabase JWKS URL not configured")
-        self.jwks_client = PyJWKClient(jwks_url)
-
-    def authenticate(self, request):
-        auth_header = request.headers.get("Authorization")
-        if not auth_header:
-            return None
-
-        try:
-            token_type, token = auth_header.split()
-            if token_type.lower() != "bearer":
-                return None
-        except ValueError:
-            return None
-
-        try:
-            signing_key = self.jwks_client.get_signing_key_from_jwt(token)
-            decoded = jwt.decode(
-                token,
-                signing_key.key,
-                algorithms=["RS256"],
-                options={"verify_aud": False},
-            )
-        except PyJWTError as e:
-            raise exceptions.AuthenticationFailed(f"Invalid token: {e}")
-
-        uid = decoded.get("sub")
-        if not uid:
-            raise exceptions.AuthenticationFailed("No 'sub' claim found")
-
-        email = decoded.get("email")
-        if not email:
-            raise exceptions.AuthenticationFailed("No 'email' claim found")
-
-        User = get_user_model()
-        user, created = User.objects.get_or_create(
-            username=uid,
-            defaults={"email": email, "supabase_uid": uid},
-        )
-        if not created and not getattr(user, "supabase_uid", None):
-            user.supabase_uid = uid
-            user.save(update_fields=["supabase_uid"])
-
-        # Return the token so downstream views can forward it
-        return (user, token)
+class Old_Maybe_Delete_SupabaseJWTAuthentication(SupabaseJWTAuthentication):
+    """Deprecated alias retaining the shared strict Supabase validation path."""

--- a/backend/jatte/settings.py
+++ b/backend/jatte/settings.py
@@ -46,6 +46,12 @@ SUPABASE_URL = os.environ.get('NEXT_PUBLIC_SUPABASE_URL')
 SUPABASE_JWKS_URL = (
     f"{SUPABASE_URL.rstrip('/')}/auth/v1/keys" if SUPABASE_URL else None
 )
+SUPABASE_JWT_ISSUER = os.environ.get("SUPABASE_JWT_ISSUER") or (
+    f"{SUPABASE_URL.rstrip('/')}/auth/v1"
+    if SUPABASE_URL
+    else "http://localhost:54321/auth/v1"
+)
+SUPABASE_JWT_AUDIENCE = os.environ.get("SUPABASE_JWT_AUDIENCE", "authenticated")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/backend/jatte/settingsprod.py
+++ b/backend/jatte/settingsprod.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 from pathlib import Path
 import os
 
-from .security_settings import required_csv, required_secret
+from .security_settings import ProductionConfigurationError, required_csv, required_secret
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -30,6 +30,14 @@ SUPABASE_URL = os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
 SUPABASE_JWKS_URL = (
     f"{SUPABASE_URL.rstrip('/')}/auth/v1/keys" if SUPABASE_URL else None
 )
+SUPABASE_JWT_ISSUER = os.environ.get("SUPABASE_JWT_ISSUER") or (
+    f"{SUPABASE_URL.rstrip('/')}/auth/v1" if SUPABASE_URL else None
+)
+if not SUPABASE_JWT_ISSUER:
+    raise ProductionConfigurationError(
+        "SUPABASE_JWT_ISSUER or NEXT_PUBLIC_SUPABASE_URL must be configured in production"
+    )
+SUPABASE_JWT_AUDIENCE = os.environ.get("SUPABASE_JWT_AUDIENCE", "authenticated")
 SMS_PROVIDER = os.environ.get("SMS_PROVIDER", "adapter_http")
 SMS_PROVIDER_BASE_URL = os.environ.get("SMS_PROVIDER_BASE_URL", "")
 SMS_PROVIDER_TOKEN = os.environ.get("SMS_PROVIDER_TOKEN", "")

--- a/backend/jatte/tests/jwt_factory.py
+++ b/backend/jatte/tests/jwt_factory.py
@@ -1,0 +1,32 @@
+import time
+
+import jwt
+from django.conf import settings
+
+
+def make_test_token(
+    sub="test-user",
+    *,
+    email=None,
+    claims=None,
+    remove=(),
+    algorithm="HS256",
+    key=None,
+    headers=None,
+):
+    """Mint a realistic Supabase access token for security and contract tests."""
+
+    now = int(time.time())
+    payload = {
+        "sub": sub,
+        "email": email or f"{sub}@example.com",
+        "iss": settings.SUPABASE_JWT_ISSUER,
+        "aud": settings.SUPABASE_JWT_AUDIENCE,
+        "iat": now,
+        "exp": now + 3600,
+    }
+    payload.update(claims or {})
+    for claim in remove:
+        payload.pop(claim, None)
+    signing_key = key if key is not None else settings.SUPABASE_JWT_SECRET
+    return jwt.encode(payload, signing_key, algorithm=algorithm, headers=headers)

--- a/backend/jatte/tests/test_security_boundary.py
+++ b/backend/jatte/tests/test_security_boundary.py
@@ -3,20 +3,21 @@ import os
 import sys
 from unittest.mock import patch
 
-import jwt
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
 from jatte.security_settings import ProductionConfigurationError, required_csv, required_secret
+from jatte.tests.jwt_factory import make_test_token
 
 
 class ProductionSettingsHelperTests(TestCase):
     production_environ = {
         "DJANGO_SECRET_KEY": "real-django-secret",
         "SUPABASE_JWT_SECRET": "real-supabase-secret",
+        "SUPABASE_JWT_ISSUER": "https://project.supabase.co/auth/v1",
+        "SUPABASE_JWT_AUDIENCE": "authenticated",
         "DJANGO_ALLOWED_HOSTS": "chat.example,api.example",
         "DJANGO_CORS_ALLOWED_ORIGINS": "https://app.example",
         "DJANGO_WS_ALLOWED_ORIGINS": "https://app.example",
@@ -77,6 +78,17 @@ class ProductionSettingsHelperTests(TestCase):
         self.assertEqual(configured.CORS_ALLOWED_ORIGINS, ["https://app.example"])
         self.assertEqual(configured.DJANGO_WS_ALLOWED_ORIGINS, ["https://app.example"])
         self.assertFalse(configured.CORS_ALLOW_CREDENTIALS)
+        self.assertEqual(
+            configured.SUPABASE_JWT_ISSUER,
+            "https://project.supabase.co/auth/v1",
+        )
+        self.assertEqual(configured.SUPABASE_JWT_AUDIENCE, "authenticated")
+
+    def test_production_settings_require_trusted_supabase_issuer(self):
+        environ = dict(self.production_environ)
+        environ.pop("SUPABASE_JWT_ISSUER")
+        with self.assertRaises(ProductionConfigurationError):
+            self._load_production_settings(environ)
 
     def test_production_settings_require_service_and_webhook_secrets(self):
         for required_name in (
@@ -96,11 +108,7 @@ class AuthBoundaryRegressionTests(TestCase):
         self.client = APIClient()
 
     def _token(self, sub="auth-boundary-user"):
-        return jwt.encode(
-            {"sub": sub, "email": f"{sub}@example.com"},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        return make_test_token(sub)
 
     def test_x_user_id_does_not_authenticate_a_legacy_view(self):
         response = self.client.get("/api/ws-auth/", HTTP_X_USER_ID="impersonated-user")

--- a/backend/stream_server_django/accounts/middleware.py
+++ b/backend/stream_server_django/accounts/middleware.py
@@ -1,34 +1,19 @@
-import jwt
-from jwt.exceptions import PyJWTError
 from urllib.parse import parse_qs
 from channels.db import database_sync_to_async
 from channels.middleware import BaseMiddleware
 from django.contrib.auth.models import AnonymousUser
-from django.contrib.auth import get_user_model
-from django.conf import settings
+from rest_framework.exceptions import AuthenticationFailed
 
-User = get_user_model()
+from stream_server_django.accounts_supabase.authentication import (
+    authenticate_supabase_token,
+)
 
 @database_sync_to_async
 def get_user(token: str):
     try:
-        decoded = jwt.decode(
-            token,
-            settings.SUPABASE_JWT_SECRET,
-            algorithms=["HS256"],
-            options={"verify_aud": False},
-            leeway=30,
-        )
-        uid = decoded.get("sub")
-        email = decoded.get("email")
-        if uid:
-            user, _ = User.objects.get_or_create(
-                username=uid, defaults={"email": email, "supabase_uid": uid}
-            )
-            return user
-    except PyJWTError:
-        pass
-    return AnonymousUser()
+        return authenticate_supabase_token(token)
+    except AuthenticationFailed:
+        return AnonymousUser()
 
 
 class SupabaseJWTAuthMiddleware(BaseMiddleware):

--- a/backend/stream_server_django/accounts_supabase/authentication.py
+++ b/backend/stream_server_django/accounts_supabase/authentication.py
@@ -18,13 +18,20 @@ def decode_supabase_token(token: str) -> dict:
     """Validate a Supabase JWT using the same rules for HTTP and WebSockets."""
 
     try:
+        issuer = getattr(settings, "SUPABASE_JWT_ISSUER", None)
+        audience = getattr(settings, "SUPABASE_JWT_AUDIENCE", None)
+        if not issuer or not audience:
+            raise exceptions.AuthenticationFailed("Invalid token authority configuration")
+        decode_options = {"require": ["sub", "exp", "iat", "iss", "aud"]}
         algorithm = jwt.get_unverified_header(token).get("alg")
         if algorithm == "HS256":
             return jwt.decode(
                 token,
                 settings.SUPABASE_JWT_SECRET,
                 algorithms=["HS256"],
-                options={"verify_aud": False},
+                audience=audience,
+                issuer=issuer,
+                options=decode_options,
                 leeway=30,
             )
         if algorithm == "RS256":
@@ -36,14 +43,16 @@ def decode_supabase_token(token: str) -> dict:
                 token,
                 signing_key.key,
                 algorithms=["RS256"],
-                options={"verify_aud": False},
+                audience=audience,
+                issuer=issuer,
+                options=decode_options,
                 leeway=30,
             )
         raise exceptions.AuthenticationFailed("Invalid token algorithm")
     except ExpiredSignatureError:
         raise exceptions.AuthenticationFailed("Token expired")
     except PyJWTError as exc:
-        raise exceptions.AuthenticationFailed(f"Invalid token: {exc}") from exc
+        raise exceptions.AuthenticationFailed("Invalid token") from exc
 
 
 def resolve_supabase_user(decoded: dict):

--- a/backend/stream_server_django/accounts_supabase/tests.py
+++ b/backend/stream_server_django/accounts_supabase/tests.py
@@ -1,10 +1,9 @@
-import jwt
-from django.conf import settings
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from stream_server_django.accounts_supabase.models import UserProfile
+from jatte.tests.jwt_factory import make_test_token
 
 
 class SyncUserViewTests(TestCase):
@@ -13,8 +12,7 @@ class SyncUserViewTests(TestCase):
         self.auth_header = self._build_auth_header()
 
     def _build_auth_header(self, sub: str = "user-1", email: str | None = None) -> str:
-        payload = {"sub": sub, "email": email or f"{sub}@example.com"}
-        token = jwt.encode(payload, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        token = make_test_token(sub, email=email)
         return f"Bearer {token}"
 
     def test_sync_user_creates_profile_and_returns_current_user(self):

--- a/backend/stream_server_django/accounts_supabase/tests/test_jwt_authority.py
+++ b/backend/stream_server_django/accounts_supabase/tests/test_jwt_authority.py
@@ -1,0 +1,223 @@
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+from asgiref.sync import async_to_sync
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TransactionTestCase, override_settings
+from django.urls import path
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APITestCase
+
+from jatte.tests.jwt_factory import make_test_token
+from stream_server_django.accounts_supabase.authentication import (
+    decode_supabase_token,
+)
+from stream_server_django.chat.consumers import ChatConsumer
+
+
+User = get_user_model()
+websocket_application = URLRouter(
+    [path("ws/<str:room_key>/", ChatConsumer.as_asgi())]
+)
+
+
+@override_settings(ROOT_URLCONF="jatte.urls")
+class JWTAuthorityHTTPTests(APITestCase):
+    def test_valid_hs256_token_authenticates_and_api_token_relays_exactly(self):
+        token = make_test_token("valid-http")
+        with patch("jwt.encode") as encode:
+            response = self.client.get(
+                "/api/token/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["userToken"], token)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertEqual(response["Pragma"], "no-cache")
+        self.assertTrue(User.objects.filter(username="valid-http").exists())
+        encode.assert_not_called()
+
+    def test_ws_auth_compatibility_url_relays_without_minting(self):
+        token = make_test_token("ws-auth-relay")
+        with patch("jwt.encode") as encode:
+            response = self.client.get(
+                "/api/ws-auth/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            )
+        self.assertEqual(response.status_code, 200)
+        relayed = parse_qs(
+            urlparse(response.data["stream_server_django.auth"]).query
+        )["token"][0]
+        self.assertEqual(relayed, token)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        encode.assert_not_called()
+
+    def test_invalid_authority_and_lifetime_matrix_fails_before_provisioning(self):
+        now = int(time.time())
+        cases = {
+            "expired": make_test_token(
+                "expired", claims={"iat": now - 7200, "exp": now - 3600}
+            ),
+            "missing-exp": make_test_token("missing-exp", remove=("exp",)),
+            "missing-iat": make_test_token("missing-iat", remove=("iat",)),
+            "missing-issuer": make_test_token("missing-issuer", remove=("iss",)),
+            "wrong-issuer": make_test_token(
+                "wrong-issuer", claims={"iss": "https://attacker.invalid/auth/v1"}
+            ),
+            "missing-audience": make_test_token(
+                "missing-audience", remove=("aud",)
+            ),
+            "wrong-audience": make_test_token(
+                "wrong-audience", claims={"aud": "service_role"}
+            ),
+            "missing-subject": make_test_token("removed", remove=("sub",)),
+            "invalid-signature": make_test_token(
+                "invalid-signature", key="different-secret"
+            ),
+            "unexpected-algorithm": make_test_token(
+                "unexpected-algorithm", algorithm="HS384"
+            ),
+        }
+        for label, token in cases.items():
+            with self.subTest(label=label):
+                before = User.objects.count()
+                response = self.client.get(
+                    "/api/token/", HTTP_AUTHORIZATION=f"Bearer {token}"
+                )
+                self.assertIn(response.status_code, {401, 403})
+                self.assertEqual(User.objects.count(), before)
+
+    def test_old_locally_minted_token_cannot_authenticate_or_extend_itself(self):
+        old_token = jwt.encode(
+            {"sub": "old-local", "email": "old@example.com"},
+            settings.SUPABASE_JWT_SECRET,
+            algorithm="HS256",
+        )
+        for route in ("/refresh-token/", "/api/refresh-token/"):
+            with self.subTest(route=route):
+                response = self.client.get(
+                    route, HTTP_AUTHORIZATION=f"Bearer {old_token}"
+                )
+                self.assertIn(response.status_code, {401, 403})
+        self.assertFalse(User.objects.filter(username="old-local").exists())
+
+    def test_expired_token_cannot_use_refresh_relays(self):
+        now = int(time.time())
+        token = make_test_token(
+            "expired-refresh", claims={"iat": now - 7200, "exp": now - 3600}
+        )
+        for route in ("/refresh-token/", "/api/refresh-token/"):
+            response = self.client.get(
+                route, HTTP_AUTHORIZATION=f"Bearer {token}"
+            )
+            self.assertIn(response.status_code, {401, 403})
+
+    def test_both_refresh_aliases_are_exact_non_minting_no_store_relays(self):
+        token = make_test_token("relay-user")
+        with patch("jwt.encode") as encode:
+            responses = [
+                self.client.get(route, HTTP_AUTHORIZATION=f"Bearer {token}")
+                for route in ("/refresh-token/", "/api/refresh-token/")
+            ]
+        for response in responses:
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data, {"token": token})
+            self.assertEqual(response["Cache-Control"], "no-store")
+            self.assertEqual(response["Pragma"], "no-cache")
+        encode.assert_not_called()
+
+    def test_missing_trusted_authority_configuration_fails_closed(self):
+        token = make_test_token("config-user")
+        with override_settings(SUPABASE_JWT_ISSUER=None):
+            with self.assertRaises(AuthenticationFailed):
+                decode_supabase_token(token)
+        with override_settings(SUPABASE_JWT_AUDIENCE=None):
+            with self.assertRaises(AuthenticationFailed):
+                decode_supabase_token(token)
+
+    def test_rs256_uses_same_claim_and_authority_validation(self):
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        public_key = private_key.public_key()
+        valid = make_test_token(
+            "rs-valid",
+            algorithm="RS256",
+            key=private_key,
+            headers={"kid": "test-key"},
+        )
+        missing_exp = make_test_token(
+            "rs-missing-exp",
+            algorithm="RS256",
+            key=private_key,
+            headers={"kid": "test-key"},
+            remove=("exp",),
+        )
+        wrong_issuer = make_test_token(
+            "rs-wrong-issuer",
+            algorithm="RS256",
+            key=private_key,
+            headers={"kid": "test-key"},
+            claims={"iss": "https://attacker.invalid/auth/v1"},
+        )
+        with override_settings(SUPABASE_JWKS_URL="https://project.test/jwks"):
+            with patch(
+                "stream_server_django.accounts_supabase.authentication.PyJWKClient.get_signing_key_from_jwt",
+                return_value=SimpleNamespace(key=public_key),
+            ):
+                self.assertEqual(decode_supabase_token(valid)["sub"], "rs-valid")
+                for token in (missing_exp, wrong_issuer):
+                    with self.assertRaises(AuthenticationFailed):
+                        decode_supabase_token(token)
+
+
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+)
+class JWTAuthorityWebSocketTests(TransactionTestCase):
+    def _connect(self, token):
+        return async_to_sync(self._connect_async)(token)
+
+    async def _connect_async(self, token):
+        communicator = WebsocketCommunicator(
+            websocket_application, f"/ws/chat/?token={token}"
+        )
+        connected, code = await communicator.connect()
+        if connected:
+            await communicator.receive_json_from()
+            await communicator.disconnect()
+        else:
+            await communicator.wait()
+        return connected, code
+
+    def test_valid_token_authenticates_websocket(self):
+        connected, _code = self._connect(make_test_token("valid-websocket"))
+        self.assertTrue(connected)
+
+    def test_authority_lifetime_and_required_claim_failures_close_websocket(self):
+        now = int(time.time())
+        cases = (
+            make_test_token(
+                "ws-expired", claims={"iat": now - 7200, "exp": now - 3600}
+            ),
+            make_test_token("ws-missing-exp", remove=("exp",)),
+            make_test_token("ws-missing-iat", remove=("iat",)),
+            make_test_token("ws-missing-issuer", remove=("iss",)),
+            make_test_token(
+                "ws-wrong-issuer",
+                claims={"iss": "https://attacker.invalid/auth/v1"},
+            ),
+            make_test_token("ws-missing-audience", remove=("aud",)),
+            make_test_token(
+                "ws-wrong-audience", claims={"aud": "service_role"}
+            ),
+            make_test_token("ws-missing-subject", remove=("sub",)),
+        )
+        for token in cases:
+            connected, code = self._connect(token)
+            self.assertFalse(connected)
+            self.assertEqual(code, 4401)
+        self.assertEqual(User.objects.count(), 0)

--- a/backend/stream_server_django/accounts_supabase/tests/test_user_agent_auth.py
+++ b/backend/stream_server_django/accounts_supabase/tests/test_user_agent_auth.py
@@ -1,7 +1,6 @@
 """Tests for GET/POST /user-agent/ authentication requirements."""
 
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -17,8 +16,7 @@ class UserAgentAuthTests(APITestCase):
         self.url = reverse("user-agent")
 
     def _make_token(self, sub: str = "user-1", email: str | None = None) -> str:
-        payload = {"sub": sub, "email": email or f"{sub}@example.com"}
-        return jwt.encode(payload, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        return make_test_token(sub, email=email)
 
     def test_get_requires_authentication(self):
         response = self.client.get(self.url)

--- a/backend/stream_server_django/accounts_supabase/utils.py
+++ b/backend/stream_server_django/accounts_supabase/utils.py
@@ -2,16 +2,7 @@
 
 from __future__ import annotations
 
-import jwt
-from jwt import PyJWTError
 from rest_framework.request import Request
-
-
-def _decode_unverified(token: str) -> dict:
-    try:
-        return jwt.decode(token, options={"verify_signature": False, "verify_aud": False})
-    except PyJWTError:
-        return {}
 
 
 def is_at_least_guest_identity(request: Request) -> bool:
@@ -21,25 +12,6 @@ def is_at_least_guest_identity(request: Request) -> bool:
     user. False when there is no JWT / no authenticated identity on the request.
     """
 
-    token = getattr(request, "auth", None)
-    if not token:
-        return False
-
-    if not isinstance(token, str):
-        return True
-
-    claims = _decode_unverified(token)
-
-    app_metadata = claims.get("app_metadata")
-    if isinstance(app_metadata, dict) and app_metadata.get("provider") == "anonymous":
-        return True
-
-    for key in ("is_anonymous", "is_anonymous_session", "is_anonymous_user"):
-        if claims.get(key) is True:
-            return True
-
-    amr = claims.get("amr")
-    if isinstance(amr, (list, tuple)) and "anonymous" in amr:
-        return True
-
-    return True
+    # Authentication has already fully validated the token before assigning
+    # request.auth. Guest/anonymous Supabase sessions are still valid identities.
+    return bool(getattr(request, "auth", None))

--- a/backend/stream_server_django/accounts_supabase/views.py
+++ b/backend/stream_server_django/accounts_supabase/views.py
@@ -4,9 +4,7 @@ from typing import Any, Mapping
 import logging
 import uuid
 
-import jwt
 from django.apps import apps
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework import generics, serializers, status
 from rest_framework.permissions import IsAuthenticated
@@ -287,17 +285,16 @@ class CurrentUserView(APIView):
 
 
 class RefreshTokenView(APIView):
+    """Compatibility relay that never extends or replaces a Supabase token."""
+
     authentication_classes = get_chat_authentication_classes()
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        token = jwt.encode(
-            {"sub": _get_user_identifier(request.user) or str(getattr(request.user, "id", "")),
-            "email": getattr(request.user, "email", "") or ""},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
-        return Response({"token": token})
+        response = Response({"token": request.auth})
+        response["Cache-Control"] = "no-store"
+        response["Pragma"] = "no-cache"
+        return response
 
 
 class DisconnectedView(APIView):
@@ -320,4 +317,3 @@ class InitializedView(APIView):
     def get(self, request):
         val = request.session.get("initialized", False)
         return Response({"initialized": bool(val)})
-

--- a/backend/stream_server_django/auth/tests/test_auth_identity.py
+++ b/backend/stream_server_django/auth/tests/test_auth_identity.py
@@ -1,10 +1,10 @@
-import jwt
 from django.conf import settings
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from stream_server_django.accounts_supabase.models import UserProfile
+from jatte.tests.jwt_factory import make_test_token
 
 
 class AuthIdentityViewTests(TestCase):
@@ -14,8 +14,7 @@ class AuthIdentityViewTests(TestCase):
         settings.ALLOWED_HOSTS = ["testserver", "localhost"]
 
     def _build_auth_header(self, sub: str = "user-1", email: str | None = None) -> str:
-        payload = {"sub": sub, "email": email or f"{sub}@example.com"}
-        token = jwt.encode(payload, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        token = make_test_token(sub, email=email)
         return f"Bearer {token}"
 
     def test_sync_user_returns_minimal_payload(self):
@@ -67,8 +66,8 @@ class AuthIdentityViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertIn("token", data)
-        self.assertIsInstance(data["token"], str)
+        self.assertEqual(data, {"token": self.auth_header.removeprefix("Bearer ")})
+        self.assertEqual(response["Cache-Control"], "no-store")
 
     def test_refresh_token_requires_authentication(self):
         response = self.client.get("/refresh-token/")

--- a/backend/stream_server_django/auth/views.py
+++ b/backend/stream_server_django/auth/views.py
@@ -59,7 +59,7 @@ class SessionView(LegacySessionView):
 
 
 class RefreshTokenView(LegacyRefreshTokenView):
-    """Return a freshly minted JWT for the caller."""
+    """Relay the verified Supabase token without extending its lifetime."""
 
     authentication_classes = get_chat_authentication_classes()
     permission_classes = [permissions.IsAuthenticated]

--- a/backend/stream_server_django/chat/api.py
+++ b/backend/stream_server_django/chat/api.py
@@ -4,10 +4,12 @@ from rest_framework.decorators import api_view, authentication_classes, permissi
 from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.utils import timezone
-import jwt
+from datetime import datetime, timezone
 
-from stream_server_django.accounts_supabase.authentication import DevTokenOrJWTAuthentication
+from stream_server_django.accounts_supabase.authentication import (
+    DevTokenOrJWTAuthentication,
+    decode_supabase_token,
+)
 from stream_server_django.common.identity import get_chat_identity
 
 from .serializers import RegisterSubscriptionsSerializer
@@ -17,12 +19,17 @@ from .webpush import broadcast_subscriptions_registered
 @authentication_classes([DevTokenOrJWTAuthentication])
 @permission_classes([permissions.IsAuthenticated])
 def ws_auth(request):
-    """Return a short-lived legacy websocket URL for a JWT-authenticated user."""
-    exp = timezone.now() + timezone.timedelta(minutes=5)
-    ws_token = jwt.encode({"exp": int(exp.timestamp())}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+    """Return a legacy WebSocket URL carrying the verified Supabase token."""
+    decoded = decode_supabase_token(request.auth)
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
     scheme = "wss" if request.is_secure() else "ws"
-    ws_url = f"{scheme}://{request.get_host()}/ws/?token={ws_token}"
-    return Response({"stream_server_django.auth": ws_url, "expires": exp.isoformat()})
+    ws_url = f"{scheme}://{request.get_host()}/ws/?token={request.auth}"
+    response = Response(
+        {"stream_server_django.auth": ws_url, "expires": exp.isoformat()}
+    )
+    response["Cache-Control"] = "no-store"
+    response["Pragma"] = "no-cache"
+    return response
 
 @api_view(["GET"])
 @authentication_classes([DevTokenOrJWTAuthentication])

--- a/backend/stream_server_django/chat/tests/test_attachment_privacy.py
+++ b/backend/stream_server_django/chat/tests/test_attachment_privacy.py
@@ -1,10 +1,8 @@
 import json
 from unittest.mock import patch
 
-import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
 from django.test import override_settings
@@ -16,6 +14,7 @@ from stream_server_django.chat.api_views import (
 )
 from stream_server_django.chat.attachment_security import sign_attachment_metadata
 from stream_server_django.chat.models import Channel, Message, Room
+from jatte.tests.jwt_factory import make_test_token
 
 
 User = get_user_model()
@@ -83,11 +82,7 @@ class AttachmentPrivacyTests(APITestCase):
         super().tearDown()
 
     def token(self, user):
-        return jwt.encode(
-            {"sub": user.supabase_uid, "email": user.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        return make_test_token(user.supabase_uid, email=user.email)
 
     def auth(self, user):
         return {"HTTP_AUTHORIZATION": f"Bearer {self.token(user)}"}

--- a/backend/stream_server_django/chat/tests/test_refresh_token.py
+++ b/backend/stream_server_django/chat/tests/test_refresh_token.py
@@ -1,7 +1,6 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
-from django.conf import settings
-import jwt
+from jatte.tests.jwt_factory import make_test_token
 
 from django.contrib.auth import get_user_model
 
@@ -9,19 +8,18 @@ User = get_user_model()
 
 class RefreshTokenAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
-        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        return make_test_token(sub, email=email)
 
     def setUp(self):
         User.objects.create_user(username="u1", email="u1@example.com", password="x", supabase_uid="u1")
 
-    def test_refresh_token_returns_new_token(self):
+    def test_refresh_token_relays_existing_token(self):
         token = self.make_token()
         url = reverse("refresh-token")
         res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         self.assertEqual(res.status_code, 200)
-        new_token = res.data["token"]
-        decoded = jwt.decode(new_token, settings.SUPABASE_JWT_SECRET, algorithms=["HS256"], options={"verify_aud": False})
-        self.assertEqual(decoded["sub"], "u1")
+        self.assertEqual(res.data["token"], token)
+        self.assertEqual(res["Cache-Control"], "no-store")
 
     def test_refresh_token_requires_auth(self):
         url = reverse("refresh-token")

--- a/backend/stream_server_django/chat/tests/test_stream_contract_rest.py
+++ b/backend/stream_server_django/chat/tests/test_stream_contract_rest.py
@@ -2,14 +2,13 @@
 
 from unittest.mock import patch
 
-import jwt
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
 from django.test import override_settings
 from rest_framework.test import APITestCase
 
 from stream_server_django.chat.models import Channel, Message, Reaction, Room
+from jatte.tests.jwt_factory import make_test_token
 
 
 User = get_user_model()
@@ -76,11 +75,7 @@ class StreamRestContractTests(APITestCase):
 
     def token(self, user=None):
         actor = user or self.member
-        return jwt.encode(
-            {"sub": actor.supabase_uid, "email": actor.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        return make_test_token(actor.supabase_uid, email=actor.email)
 
     def auth(self, user=None):
         return {"HTTP_AUTHORIZATION": f"Bearer {self.token(user)}"}

--- a/backend/stream_server_django/chat/tests/test_stream_contract_websocket.py
+++ b/backend/stream_server_django/chat/tests/test_stream_contract_websocket.py
@@ -1,12 +1,10 @@
 """Authorized WebSocket contract coverage for the frontend Stream adapter."""
 
-import jwt
 import pytest
 from asgiref.sync import sync_to_async
 from channels.layers import get_channel_layer
 from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 
@@ -14,6 +12,7 @@ from stream_server_django.chat.models import Channel, Message, Room
 from stream_server_django.chat.routing import websocket_urlpatterns
 from stream_server_django.chat.serializers import MessageSerializer
 from stream_server_django.chat.utils import group_name_for_cid
+from jatte.tests.jwt_factory import make_test_token
 
 
 User = get_user_model()
@@ -21,11 +20,7 @@ application = URLRouter(websocket_urlpatterns)
 
 
 def make_token(sub):
-    return jwt.encode(
-        {"sub": sub, "email": f"{sub}@example.com"},
-        settings.SUPABASE_JWT_SECRET,
-        algorithm="HS256",
-    )
+    return make_test_token(sub)
 
 
 async def connect(room_key, sub):

--- a/backend/stream_server_django/chat/tests/test_supabase_auth.py
+++ b/backend/stream_server_django/chat/tests/test_supabase_auth.py
@@ -3,9 +3,8 @@ from django.test import override_settings
 from rest_framework.test import APITestCase
 from unittest.mock import patch
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
 from jwt.utils import base64url_encode
-import jwt
+from jatte.tests.jwt_factory import make_test_token
 
 
 def make_keys():
@@ -26,7 +25,9 @@ def make_keys():
 class SupabaseAuthAPITests(APITestCase):
     def test_rs256_jwt_via_jwks(self):
         priv, jwks = make_keys()
-        token = jwt.encode({"sub": "u1", "email": "u1@example.com"}, priv, algorithm="RS256", headers={"kid": "test"})
+        token = make_test_token(
+            "u1", algorithm="RS256", key=priv, headers={"kid": "test"}
+        )
         url = reverse("ws-auth")
         with patch("jwt.PyJWKClient.fetch_data", return_value=jwks):
             res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
@@ -36,7 +37,9 @@ class SupabaseAuthAPITests(APITestCase):
 
     def test_token_endpoint(self):
         priv, jwks = make_keys()
-        token = jwt.encode({"sub": "u1", "email": "u1@example.com"}, priv, algorithm="RS256", headers={"kid": "test"})
+        token = make_test_token(
+            "u1", algorithm="RS256", key=priv, headers={"kid": "test"}
+        )
         url = reverse("token-obtain")
         with patch("jwt.PyJWKClient.fetch_data", return_value=jwks):
             res = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")

--- a/backend/stream_server_django/chat/tests/test_token.py
+++ b/backend/stream_server_django/chat/tests/test_token.py
@@ -1,11 +1,10 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
-from django.conf import settings
-import jwt
+from jatte.tests.jwt_factory import make_test_token
 
 class TokenAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
-        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        return make_test_token(sub, email=email)
 
     def test_token_returns_passed_token(self):
         token = self.make_token()

--- a/backend/stream_server_django/chat/tests/test_ws_auth.py
+++ b/backend/stream_server_django/chat/tests/test_ws_auth.py
@@ -1,11 +1,10 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
-from django.conf import settings
-import jwt
+from jatte.tests.jwt_factory import make_test_token
 
 class WsAuthAPITests(APITestCase):
     def make_token(self, sub="u1", email="u1@example.com"):
-        return jwt.encode({"sub": sub, "email": email}, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+        return make_test_token(sub, email=email)
 
     def test_ws_auth_ok(self):
         token = self.make_token()

--- a/backend/stream_server_django/chat/tests/test_ws_security.py
+++ b/backend/stream_server_django/chat/tests/test_ws_security.py
@@ -1,25 +1,23 @@
 import time
 
-import jwt
 import pytest
 from asgiref.sync import sync_to_async
 from channels.layers import get_channel_layer
 from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
-from django.conf import settings
 from django.test import override_settings
 
 from stream_server_django.chat.models import Message, Room
 from stream_server_django.chat.routing import websocket_urlpatterns
 from stream_server_django.chat.utils import group_name_for_cid
+from jatte.tests.jwt_factory import make_test_token as make_authorized_test_token
 
 
 application = URLRouter(websocket_urlpatterns)
 
 
 def make_token(sub="member", **claims):
-    payload = {"sub": sub, "email": f"{sub}@example.com", **claims}
-    return jwt.encode(payload, settings.SUPABASE_JWT_SECRET, algorithm="HS256")
+    return make_authorized_test_token(sub, claims=claims)
 
 
 async def connect(room_key="chat", token=None):
@@ -44,13 +42,12 @@ async def create_room(uuid, client):
     [
         None,
         "not-a-jwt",
-        jwt.encode(
-            {"sub": "expired", "exp": int(time.time()) - 120},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
+        make_authorized_test_token(
+            "expired",
+            claims={"iat": int(time.time()) - 3600, "exp": int(time.time()) - 120},
         ),
-        jwt.encode({"sub": "wrong-signature"}, "different-secret", algorithm="HS256"),
-        jwt.encode({"email": "missing-sub@example.com"}, settings.SUPABASE_JWT_SECRET, algorithm="HS256"),
+        make_authorized_test_token("wrong-signature", key="different-secret"),
+        make_authorized_test_token("missing-sub", remove=("sub",)),
     ],
     ids=["missing", "malformed", "expired", "invalid-signature", "missing-sub"],
 )

--- a/backend/stream_server_django/chat/views.py
+++ b/backend/stream_server_django/chat/views.py
@@ -25,7 +25,7 @@ User = get_user_model()
 
 
 class TokenView(APIView):
-    """Return a signed chat token for the authenticated Supabase user."""
+    """Relay the authenticated Supabase token for Stream compatibility."""
 
     authentication_classes = get_chat_authentication_classes()
     permission_classes = [IsAuthenticated]
@@ -33,10 +33,13 @@ class TokenView(APIView):
     def get(self, request):
         """Return the current user's ID and their Supabase access token."""
 
-        return Response({
+        response = Response({
             "userID": request.user.id,
             "userToken": request.auth,
         })
+        response["Cache-Control"] = "no-store"
+        response["Pragma"] = "no-cache"
+        return response
 
 
 class RoomMembersCIDView(RoomFromCIDMixin, APIView):

--- a/backend/stream_server_django/chat_addons/admin_console/tests/test_admin_authorization.py
+++ b/backend/stream_server_django/chat_addons/admin_console/tests/test_admin_authorization.py
@@ -1,5 +1,4 @@
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -27,11 +26,7 @@ class AdminAuthorizationTests(APITestCase):
         self.url = reverse("list-admin-queue")
 
     def auth(self, user) -> dict[str, str]:
-        token = jwt.encode(
-            {"sub": user.supabase_uid},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        token = make_test_token(user.supabase_uid, email=user.email)
         return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
     def test_queue_is_staff_only_and_does_not_leak_to_other_actors(self):

--- a/backend/stream_server_django/chat_addons/agent/tests/test_agent_authorization.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_agent_authorization.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock, patch
 
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -48,11 +47,7 @@ class AgentAuthorizationTests(APITestCase):
         RoomAgentFlag.objects.create(room=self.room, agent_enabled=True)
 
     def token(self, user) -> str:
-        return jwt.encode(
-            {"sub": user.supabase_uid, "email": user.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        return make_test_token(user.supabase_uid, email=user.email)
 
     def auth(self, user) -> dict[str, str]:
         return {"HTTP_AUTHORIZATION": f"Bearer {self.token(user)}"}

--- a/backend/stream_server_django/chat_addons/agent/tests/test_stream_agent_contract.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_stream_agent_contract.py
@@ -2,8 +2,7 @@
 
 from unittest.mock import Mock, patch
 
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from rest_framework.test import APITestCase
@@ -50,11 +49,7 @@ class StreamAgentContractTests(APITestCase):
 
     def auth(self, user=None):
         actor = user or self.member
-        token = jwt.encode(
-            {"sub": actor.supabase_uid, "email": actor.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        token = make_test_token(actor.supabase_uid, email=actor.email)
         return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
     def test_status_contract_is_available_to_room_participant(self):

--- a/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_authorization.py
+++ b/backend/stream_server_django/chat_addons/sms_bridge/tests/test_sms_authorization.py
@@ -1,8 +1,6 @@
 import json
 from unittest.mock import patch
 
-import jwt
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -13,6 +11,7 @@ from stream_server_django.chat_addons.sms_bridge.models import SmsRelay
 from stream_server_django.chat_addons.sms_bridge.services.provider import (
     SmsProviderResponse,
 )
+from jatte.tests.jwt_factory import make_test_token
 
 
 User = get_user_model()
@@ -43,11 +42,7 @@ class SmsAuthorizationTests(APITestCase):
         }
 
     def jwt_auth(self, user) -> dict[str, str]:
-        token = jwt.encode(
-            {"sub": user.supabase_uid},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        token = make_test_token(user.supabase_uid, email=user.email)
         return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
     def signed_post(self, url, payload):

--- a/backend/stream_server_django/polls/tests/test_poll_room_authorization.py
+++ b/backend/stream_server_django/polls/tests/test_poll_room_authorization.py
@@ -2,8 +2,7 @@ from urllib.parse import quote
 from unittest.mock import patch
 import importlib
 
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.test import override_settings
@@ -75,11 +74,7 @@ class PollRoomAuthorizationTests(APITestCase):
         )
 
     def _headers(self, user):
-        token = jwt.encode(
-            {"sub": user.username, "email": user.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        token = make_test_token(user.username, email=user.email)
         return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
     def test_anonymous_poll_list_is_denied(self):

--- a/backend/stream_server_django/state/tests/test_pr9_alias_authorization.py
+++ b/backend/stream_server_django/state/tests/test_pr9_alias_authorization.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.utils import timezone
@@ -49,11 +48,7 @@ class StateReminderAliasAuthorizationTests(APITestCase):
         )
 
     def _headers(self, user):
-        token = jwt.encode(
-            {"sub": user.username, "email": user.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
-        )
+        token = make_test_token(user.username, email=user.email)
         return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
     def _reminder_payload(self, **updates):

--- a/frontend/__tests__/adapter/tokenManager.test.ts
+++ b/frontend/__tests__/adapter/tokenManager.test.ts
@@ -1,6 +1,25 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { ChatClient } from '../../src/lib/stream-adapter/ChatClient';
-import { API } from '../../src/lib/stream-adapter/constants';
+import { getChatCreds } from '../../src/lib/getChatCreds';
+import { getAccessToken, setAccessToken } from '../../src/lib/authTokenStore';
+import { setAuthToken } from '@iliad/stream-chat-shim';
+
+vi.mock('../../src/lib/getChatCreds', () => ({ getChatCreds: vi.fn() }));
+vi.mock('mitt', () => ({
+  default: () => ({ on: vi.fn(), off: vi.fn(), emit: vi.fn() }),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@iliad/stream-chat-shim', () => ({
+  AIStates: {
+    Thinking: 'thinking',
+    Generating: 'generating',
+    Error: 'error',
+    ExternalSources: 'external_sources',
+    Idle: 'idle',
+  },
+  WS_BASE: 'ws://testserver',
+  setAuthToken: vi.fn(),
+}));
 
 const originalFetch = global.fetch;
 
@@ -13,18 +32,37 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test('tokenManager stores and refreshes token', async () => {
+test('refresh uses Supabase credentials and synchronizes every active token store', async () => {
   (global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
   const client = new ChatClient();
   await client.connectUser({ id: 'u1' }, 't1');
+  setAccessToken('t1');
+  setAuthToken('t1');
   expect(client.tokenManager.getToken()).toBe('t1');
 
-  (global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ token: 't2' }) });
+  vi.mocked(getChatCreds).mockResolvedValueOnce({ userID: 1, userToken: 't2' });
   await client.refreshToken();
 
-  expect(global.fetch).toHaveBeenLastCalledWith(API.REFRESH_TOKEN, { headers: { Authorization: 'Bearer t1' } });
+  expect(getChatCreds).toHaveBeenCalledWith({ forceRefresh: true });
   expect(client.userToken).toBe('t2');
   expect(client.tokenManager.getToken()).toBe('t2');
+  expect(getAccessToken()).toBe('t2');
+
+  expect(setAuthToken).toHaveBeenLastCalledWith('t2');
+});
+
+test('failed Supabase refresh invents no token and preserves current credentials', async () => {
+  (global.fetch as any).mockResolvedValue({ ok: true, json: async () => ({}) });
+  const client = new ChatClient();
+  await client.connectUser({ id: 'u1' }, 't1');
+  setAccessToken('t1');
+  setAuthToken('t1');
+  vi.mocked(getChatCreds).mockRejectedValueOnce(new Error('Supabase refresh failed'));
+
+  await expect(client.refreshToken()).rejects.toThrow('Supabase refresh failed');
+  expect(client.userToken).toBe('t1');
+  expect(client.tokenManager.getToken()).toBe('t1');
+  expect(getAccessToken()).toBe('t1');
 });
 
 test('disconnectUser resets tokenManager', () => {

--- a/frontend/__tests__/getChatCreds.test.ts
+++ b/frontend/__tests__/getChatCreds.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { getAccessToken, setAccessToken } from '../src/lib/authTokenStore';
+import { getChatCreds } from '../src/lib/getChatCreds';
+import { getSupabaseClient } from '../src/lib/supabaseClient';
+
+
+vi.mock('../src/lib/supabaseClient', () => ({ getSupabaseClient: vi.fn() }));
+vi.mock('@iliad/stream-chat-shim', () => ({ setAuthToken: vi.fn() }));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  setAccessToken(null);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function configureSupabase(accessToken: string) {
+  const getSession = vi.fn().mockResolvedValue({
+    data: { session: { access_token: accessToken } },
+    error: null,
+  });
+  const refreshSession = vi.fn().mockResolvedValue({
+    data: { session: { access_token: accessToken } },
+    error: null,
+  });
+  vi.mocked(getSupabaseClient).mockReturnValue({
+    auth: { getSession, refreshSession },
+  } as any);
+  (global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: async () => ({ userID: 7, userToken: accessToken }),
+  });
+  return { getSession, refreshSession };
+}
+
+test('bootstrap validates the current Supabase access token through api/token', async () => {
+  const auth = configureSupabase('current-supabase-token');
+  const result = await getChatCreds();
+
+  expect(auth.getSession).toHaveBeenCalledOnce();
+  expect(auth.refreshSession).not.toHaveBeenCalled();
+  expect(global.fetch).toHaveBeenCalledWith('/api/token/', {
+    headers: { Authorization: 'Bearer current-supabase-token' },
+  });
+  expect(result).toEqual({ userID: 7, userToken: 'current-supabase-token' });
+  expect(getAccessToken()).toBe('current-supabase-token');
+});
+
+test('forced refresh uses Supabase refreshSession and relays its access token', async () => {
+  const auth = configureSupabase('refreshed-supabase-token');
+  const result = await getChatCreds({ forceRefresh: true });
+
+  expect(auth.refreshSession).toHaveBeenCalledOnce();
+  expect(auth.getSession).not.toHaveBeenCalled();
+  expect(result.userToken).toBe('refreshed-supabase-token');
+  expect(getAccessToken()).toBe('refreshed-supabase-token');
+});
+
+test('Supabase refresh failure is propagated without calling Django', async () => {
+  const refreshError = new Error('refresh rejected');
+  vi.mocked(getSupabaseClient).mockReturnValue({
+    auth: {
+      getSession: vi.fn(),
+      refreshSession: vi.fn().mockResolvedValue({ data: { session: null }, error: refreshError }),
+    },
+  } as any);
+  setAccessToken('existing-token');
+
+  await expect(getChatCreds({ forceRefresh: true })).rejects.toBe(refreshError);
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(getAccessToken()).toBe('existing-token');
+});
+
+test('bootstrap rejects a backend token substitution', async () => {
+  configureSupabase('supabase-token');
+  (global.fetch as any).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ userID: 7, userToken: 'different-token' }),
+  });
+
+  await expect(getChatCreds()).rejects.toThrow(
+    'token endpoint did not relay the Supabase access token',
+  );
+  expect(getAccessToken()).toBeNull();
+});

--- a/frontend/src/lib/getChatCreds.ts
+++ b/frontend/src/lib/getChatCreds.ts
@@ -1,10 +1,14 @@
 import { setAuthToken } from '@iliad/stream-chat-shim';
 
+import { setAccessToken } from './authTokenStore';
 import { getSupabaseClient } from './supabaseClient';
 
-export async function getChatCreds() {
+export async function getChatCreds(options: { forceRefresh?: boolean } = {}) {
   const supabase = getSupabaseClient();
-  const { data } = await supabase.auth.getSession();
+  const { data, error } = options.forceRefresh
+    ? await supabase.auth.refreshSession()
+    : await supabase.auth.getSession();
+  if (error) throw error;
   const accessToken = data.session?.access_token;
   if (!accessToken) throw new Error('No Supabase session');
 
@@ -14,6 +18,11 @@ export async function getChatCreds() {
   if (!res.ok) throw new Error('token endpoint failed');
 
   const creds = (await res.json()) as { userID: number; userToken: string };
-  setAuthToken(creds?.userToken ?? null);
+  if (!creds?.userToken) throw new Error('token endpoint returned no userToken');
+  if (creds.userToken !== accessToken) {
+    throw new Error('token endpoint did not relay the Supabase access token');
+  }
+  setAuthToken(creds.userToken);
+  setAccessToken(creds.userToken);
   return creds;
 }

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -1154,7 +1154,7 @@ export class Channel {
             console.log('[agent/ws] opening socket', {
                 cid: this.cid,
                 uuid: this.uuid,
-                url: wsUrl,
+                endpoint: `${WS_BASE}/ws/${this.cid}/`,
             });
         }
 

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -3,12 +3,14 @@ import { MiniStore } from './MiniStore';
 import { Channel } from './Channel';
 import { API, EVENTS } from './constants';
 import { apiFetch } from '../api';
+import { getChatCreds } from '../getChatCreds';
+import { setAccessToken } from '../authTokenStore';
 import { TokenManager } from './tokenManager';
 
 const randomId = () => Math.random().toString(36).slice(2);
 import type { Room, ChatEvents, AppSettings, User, Message } from './types';
 import type { AIState } from '@iliad/stream-chat-shim';
-import { AIStates } from '@iliad/stream-chat-shim';
+import { AIStates, setAuthToken } from '@iliad/stream-chat-shim';
 
 /* ------------------------------------------------------------------ */
 /* High-level client wrapper that Stream-UI talks to                  */
@@ -317,8 +319,12 @@ export class ChatClient {
     }
 
     async refreshToken() {
-        const newToken = await this.tokenManager.refreshToken(API.REFRESH_TOKEN);
+        const { userToken: newToken } = await getChatCreds({ forceRefresh: true });
         this.jwt = newToken;
+        this.authToken = newToken;
+        await this.tokenManager.setTokenOrProvider(newToken);
+        setAccessToken(newToken);
+        setAuthToken(newToken);
         return newToken;
     }
 

--- a/frontend/src/lib/stream-adapter/constants.ts
+++ b/frontend/src/lib/stream-adapter/constants.ts
@@ -23,7 +23,6 @@ export const API = {
   MUTE_USER: '/mute/',
   UNMUTE_USER: '/user-mutes/unmute/',
   RECOVER_STATE: '/recover-state/',
-  REFRESH_TOKEN: '/refresh-token/',
   SUBARRAY: '/subarray/',
   EDITING_AUDIT_STATE: '/editing-audit-state/',
   WS_AUTH: '/ws-auth/',
@@ -40,4 +39,3 @@ export const EVENTS = {
   MESSAGE_NEW: 'message.new',
   SETTINGS_UPDATED: 'settings.updated',
 } as const;
-

--- a/frontend/src/lib/stream-adapter/tokenManager.ts
+++ b/frontend/src/lib/stream-adapter/tokenManager.ts
@@ -58,14 +58,4 @@ export class TokenManager {
     return this.type === 'static';
   }
 
-  async refreshToken(apiUrl: string): Promise<string> {
-    if (!this.token) throw new Error('token not set');
-    const res = await fetch(apiUrl, {
-      headers: { Authorization: `Bearer ${this.token}` },
-    });
-    if (!res.ok) throw new Error('refreshToken failed');
-    const data = await res.json();
-    this.token = data.token;
-    return this.token!;
-  }
 }


### PR DESCRIPTION
## Summary

- eliminate locally minted refresh and WebSocket compatibility JWTs
- retain both refresh aliases as exact no-store relays of the validated incoming Supabase token
- preserve /api/token/ as an exact no-store Stream bootstrap relay
- require signature, explicit HS256/RS256 algorithm, issuer, audience, subject, issued-at, and expiry validation on shared HTTP/WebSocket authentication
- fail production startup when the intended Supabase issuer cannot be determined
- refresh through Supabase JS refreshSession() and synchronize every active frontend token store
- reject old indefinite JATTE tokens before user provisioning
- remove full bearer tokens from WebSocket URL logging

## Verification

- 10 focused backend JWT-authority tests passed
- 41 applicable backend auth/identity tests passed
- 7 focused frontend refresh/bootstrap tests passed
- 110 PR1-PR9 security and compatibility regression tests passed
- fresh-database migration passed
- Django system check and changed-file compilation passed
- Ruff and git diff --check passed

The full migration drift check continues to report only the pre-existing unrelated agent.0005_alter_documentchunk_id drift; PR10 adds no schema migration.