### PR TITLE
Security PR12: Bind agent background work to authorized idempotent runs

### DIFF
--- a/backend/audit/pr12-agent-background-trust-contract.md
+++ b/backend/audit/pr12-agent-background-trust-contract.md
@@ -1,0 +1,74 @@
+# PR12 agent background trust contract
+
+## Entry-point inventory
+
+| Path | Caller and authorization | Pre-PR12 background authority | Executor / reachability | PR12 contract |
+|---|---|---|---|---|
+| `AgentLLMInvokeView` | Authenticated room participant; existing room access and enabled-agent checks | Canonical CID, requester ID, source text, metadata, and trace ID crossed into a daemon thread | `AgentService.enqueue_generate()` → thread → `generate()`; active frontend path | HTTP creates the authorized `AgentRun`; thread receives only `run_id` |
+| Admin intake approval | Staff/internal admin approval of an existing `MessageIntake` | `run_id`, CID, prompt, and metadata passed to `run_agent_invocation.delay()` | Reachable from `approve_intake()` when the room agent flag is enabled | Approval resolves the room from the persisted message/channel relationship and queues the same persisted work order |
+| `run_agent_invocation` | Broker/Celery-compatible task; no request principal at execution time | Raw task arguments were sufficient to generate messages and create Channel/Room rows | Actively referenced by admin intake before PR12; retained as compatibility entry point | Signature is `run_agent_invocation(run_id)` and delegates to the canonical executor |
+| `AgentService` daemon thread | Internal scheduler after an authorized request commits | Separate random job ID plus raw CID/user/text/meta | Active executor retained | Thread target is `execute_agent_run(run_id)` only |
+| `AgentRagView` | Authenticated, room-authorized synchronous compatibility request | No asynchronous boundary | Synchronous and active | Unchanged; it is not a background entry point |
+| Simulation/eval/admin simulation | Staff/test/operator-controlled synchronous execution | Explicit simulation input | Synchronous and non-persisting where designed | Unchanged; it cannot be delivered by a broker/thread |
+
+Frontend `invokeAgent` sends the persisted source message ID, room UUID,
+`client_generated_id`, and trace ID to the authenticated HTTP boundary. The
+HTTP response remains `{status: "queued", job_id, trace_id}`, but `job_id` is
+now the durable `AgentRun.run_id`.
+
+## Persisted authority
+
+New runs persist the existing `Room`, authenticated requester, existing source
+human `Message`, canonical room CID snapshot, input snapshot, sanitized
+server-built request metadata, idempotency key, lifecycle timestamps/attempts,
+and the unique result `Message`. No bearer/session credential is stored.
+
+Historical `AgentRun` rows are retained unchanged. New relationship and work
+order fields are nullable so migrations do not infer authority from historical
+CID strings. There is no CID-based backfill, no room creation, and no run
+deletion. Production row counts were unavailable from this checkout; operators
+may report the non-sensitive inventory after deployment with:
+
+```python
+from stream_server_django.chat_addons.agent.models import AgentRun
+print({
+    "total": AgentRun.objects.count(),
+    "authoritative": AgentRun.objects.filter(room__isnull=False, source_message__isnull=False).count(),
+    "legacy": AgentRun.objects.filter(room__isnull=True).count(),
+})
+```
+
+## Idempotency and state machine
+
+The key is `agent:<room-pk>:message:<message-pk>`. A nonblank
+`client_generated_id` extends the key only when it equals the identifier stored
+on the already-authorized source message. Otherwise the stable room/message
+fallback is used. A duplicate request returns the same run before the room-busy
+check; a distinct message is eligible after the prior run terminates.
+
+Inside one transaction the Room row is locked, the idempotent run is found or
+created as `queued`, and `agent_busy`/`active_agent_run_id` are set to that run.
+Scheduling occurs through `transaction.on_commit`. Scheduler failure marks the
+queued run `error` and clears the matching room state.
+
+The worker locks the run and claims only `queued → running`, increments
+`attempt_count`, and validates all persisted relationships before orchestration.
+Missing, terminal, cancelled, or already-running delivery is a no-op. A stale
+running redelivery (15 minutes by default, configurable with
+`AGENT_STALE_RUN_SECONDS`) is marked `error` and its room state is cleared; it
+is never replayed automatically because tool side effects may be uncertain.
+
+## Result, cancellation, and cleanup
+
+After a successful claim, placeholder creation uses the persisted source
+message's existing Channel and Room. It performs no `get_or_create()` and
+stores the placeholder in the run's one-to-one `result_message`. The run ID is
+included in message agent metadata. Duplicate delivery cannot create another
+placeholder because it cannot claim the run.
+
+Queued cancellation marks the authoritative active run cancelled, clears room
+busy/active state, and makes later delivery a no-op. Running cancellation uses
+the same run ID and result placeholder; streaming cancellation checks that run
+status. Success, capped, handoff, error, cancellation, scheduler failure, and
+executor exceptions all use conditional cleanup that clears the room only when
+the run still owns `active_agent_run_id`.

--- a/backend/audit/pr12-agent-background-trust-contract.md
+++ b/backend/audit/pr12-agent-background-trust-contract.md
@@ -40,11 +40,13 @@ print({
 
 ## Idempotency and state machine
 
-The key is `agent:<room-pk>:message:<message-pk>`. A nonblank
-`client_generated_id` extends the key only when it equals the identifier stored
-on the already-authorized source message. Otherwise the stable room/message
-fallback is used. A duplicate request returns the same run before the room-busy
-check; a distinct message is eligible after the prior run terminates.
+The canonical work-order identity is `(room, source_message)`, represented by
+`agent:<room-pk>:message:<message-pk>` and enforced by a conditional database
+uniqueness constraint. A validated `client_generated_id` is retained only as
+request metadata and does not alter work-order identity. Retries with or without
+the client ID therefore resolve to the same persisted run. A duplicate request
+returns that run before the room-busy check; a distinct message is eligible
+after the prior run terminates.
 
 Inside one transaction the Room row is locked, the idempotent run is found or
 created as `queued`, and `agent_busy`/`active_agent_run_id` are set to that run.

--- a/backend/stream_server_django/chat_addons/admin_console/services/gating.py
+++ b/backend/stream_server_django/chat_addons/admin_console/services/gating.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import binascii
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Iterable, Literal
@@ -14,7 +15,7 @@ from django.db import models, transaction
 from django.utils import timezone
 
 from stream_server_django.chat.consumers import broadcast_message_update
-from stream_server_django.chat.models import Message, RoomMemberMute
+from stream_server_django.chat.models import Message, Room, RoomMemberMute
 from stream_server_django.chat.serializers import MessageSerializer
 from stream_server_django.chat.utils import canonical_cid, group_name_for_cid
 
@@ -35,6 +36,7 @@ _DEFAULT_PAGE_SIZE = 25
 
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -245,7 +247,7 @@ def approve_intake(*, message_id: str, actor) -> IntakeActionResult:
     else:
         _broadcast_message_new(cid, message)
 
-    _schedule_agent_if_enabled(cid=cid, room_uuid=_room_uuid_from_cid(cid), message=message)
+    _schedule_agent_if_enabled(message=message, actor=actor)
 
     return IntakeActionResult(
         message_id=str(message_pk),
@@ -370,19 +372,35 @@ def _decode_cursor(cursor: str) -> tuple[datetime, int] | None:
     return created_at, int(message_id)
 
 
-def _schedule_agent_if_enabled(*, cid: str, room_uuid: str, message: Message) -> None:
+def _schedule_agent_if_enabled(*, message: Message, actor) -> None:
     from stream_server_django.chat_addons.agent.models import RoomAgentFlag
-    from stream_server_django.chat_addons.agent.tasks import run_agent_invocation
+    from stream_server_django.chat_addons.agent.services.agent_service import (
+        AgentRoomBusyError,
+        get_agent_service,
+    )
 
-    flag = RoomAgentFlag.objects.filter(room__uuid=room_uuid).first()
+    room = Room.objects.filter(
+        uuid=message.channel.uuid,
+        messages=message,
+    ).first()
+    if room is None:
+        return
+    flag = RoomAgentFlag.objects.filter(room=room).first()
     if not flag or not flag.agent_enabled:
         return
-    run_agent_invocation.delay(
-        run_id=f"intake-{message.id}",
-        cid=cid,
-        prompt=message.body,
-        meta={"source": "intake_approval"},
-    )
+    try:
+        get_agent_service().queue_authorized_run(
+            room=room,
+            requested_by=actor,
+            source_message=message,
+            input_text=message.body or "",
+            request_meta={"source": "intake_approval"},
+        )
+    except AgentRoomBusyError:
+        logger.info(
+            "agent.intake.busy_noop",
+            extra={"room_id": room.pk, "message_id": message.pk},
+        )
 
 
 def _mute_user(*, intake: MessageIntake, actor) -> bool:

--- a/backend/stream_server_django/chat_addons/agent/models.py
+++ b/backend/stream_server_django/chat_addons/agent/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from django.conf import settings
 from django.db import models
 
 try:
@@ -87,6 +88,7 @@ class AgentRoomPolicy(models.Model):
 class AgentRun(models.Model):
     """Audit record for an agent invocation."""
 
+    STATUS_QUEUED = "queued"
     STATUS_RUNNING = "running"
     STATUS_OK = "ok"
     STATUS_CAPPED = "capped"
@@ -94,6 +96,7 @@ class AgentRun(models.Model):
     STATUS_ERROR = "error"
     STATUS_CANCELLED = "cancelled"
     STATUS_CHOICES = [
+        (STATUS_QUEUED, "Queued"),
         (STATUS_RUNNING, "Running"),
         (STATUS_OK, "Ok"),
         (STATUS_CAPPED, "Capped"),
@@ -105,6 +108,42 @@ class AgentRun(models.Model):
     run_id = models.CharField(max_length=255, unique=True)
     cid = models.CharField(max_length=255)
     user_id = models.CharField(max_length=255, blank=True)
+    room = models.ForeignKey(
+        "chat.Room",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="agent_runs",
+    )
+    requested_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="requested_agent_runs",
+    )
+    source_message = models.ForeignKey(
+        "chat.Message",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="source_agent_runs",
+    )
+    result_message = models.OneToOneField(
+        "chat.Message",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="result_agent_run",
+    )
+    input_text = models.TextField(blank=True, default="")
+    request_meta = models.JSONField(default=dict, blank=True)
+    idempotency_key = models.CharField(
+        max_length=512,
+        null=True,
+        blank=True,
+        unique=True,
+    )
     tools_used = models.JSONField(default=list)
     status = models.CharField(max_length=16, choices=STATUS_CHOICES)
     latency_ms = models.PositiveIntegerField(default=0)
@@ -117,6 +156,10 @@ class AgentRun(models.Model):
     last_tool_name = models.CharField(max_length=128, blank=True, default="")
     last_tool_call_id = models.CharField(max_length=128, blank=True, default="")
     last_tool_args_preview = models.TextField(blank=True, default="")
+    queued_at = models.DateTimeField(null=True, blank=True)
+    started_at = models.DateTimeField(null=True, blank=True)
+    finished_at = models.DateTimeField(null=True, blank=True)
+    attempt_count = models.PositiveIntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/stream_server_django/chat_addons/agent/models.py
+++ b/backend/stream_server_django/chat_addons/agent/models.py
@@ -166,6 +166,13 @@ class AgentRun(models.Model):
     class Meta:
         app_label = "chat_addons"
         ordering = ("-created_at", "-id")
+        constraints = [
+            models.UniqueConstraint(
+                fields=("room", "source_message"),
+                condition=models.Q(room__isnull=False, source_message__isnull=False),
+                name="unique_authoritative_agent_run_source",
+            )
+        ]
 
     def __str__(self) -> str:  # pragma: no cover - debug helper
         return f"{self.run_id}:{self.status}"

--- a/backend/stream_server_django/chat_addons/agent/serializers.py
+++ b/backend/stream_server_django/chat_addons/agent/serializers.py
@@ -100,5 +100,7 @@ class AgentSimulateRequestSerializer(serializers.Serializer):
 class AgentInvocationSerializer(serializers.Serializer):
     room_uuid = serializers.CharField()
     last_human_message_id = serializers.IntegerField()
-    client_generated_id = serializers.CharField(required=False, allow_blank=True)
+    client_generated_id = serializers.CharField(
+        required=False, allow_blank=True, max_length=255
+    )
     trace_id = serializers.CharField(required=False, allow_blank=True)

--- a/backend/stream_server_django/chat_addons/agent/services/agent_service.py
+++ b/backend/stream_server_django/chat_addons/agent/services/agent_service.py
@@ -1,4 +1,5 @@
 """Agent service orchestration for automated chat replies."""
+# ruff: noqa: F821
 from __future__ import annotations
 
 import json
@@ -82,6 +83,10 @@ class CancelledError(Exception):
     """Raised when an in-flight agent run has been cancelled."""
 
 
+class AgentRoomBusyError(Exception):
+    """Raised when a different persisted run already owns a room."""
+
+
 class ToolCallProtocolError(Exception):
     """Raised when tool call sequencing breaks expected protocol."""
 
@@ -93,6 +98,7 @@ def mark_agent_state(
     ai_message: Message | None = None,
     agent_run: AgentRun | None = None,
     error_reason: str | None = None,
+    preserve_active_run: bool = False,
 ) -> None:
     """
     Canonical place to keep AI message metadata, room busy flags, and run status in sync.
@@ -101,7 +107,15 @@ def mark_agent_state(
     room_update_fields: list[str] = []
     agent_run_update_fields: list[str] = []
 
-    if ai_state in ("AI_STATE_THINKING", "AI_STATE_GENERATING"):
+    if preserve_active_run and agent_run is not None:
+        room.refresh_from_db(fields=["agent_busy", "active_agent_run_id"])
+        still_active = (
+            room.agent_busy
+            and str(room.active_agent_run_id) == agent_run.run_id
+        )
+        desired_busy = bool(still_active)
+        desired_run_id = agent_run.run_id if still_active else None
+    elif ai_state in ("AI_STATE_THINKING", "AI_STATE_GENERATING"):
         desired_busy = True
         desired_run_id = agent_run.run_id if agent_run is not None else room.active_agent_run_id
     else:
@@ -241,6 +255,11 @@ class AgentOrchestrationResult:
     cost_usd: Decimal
     reason: str
     handoff_triggered: bool
+    handoff_reason: str | None = None
+    handoff_detail: str | None = None
+    last_tool_name: str | None = None
+    last_tool_call_id: str | None = None
+    last_tool_args_preview: str | None = None
     message: Message | None = None
 
 
@@ -392,100 +411,292 @@ class AgentService:
 
         return reply
 
-    def enqueue_generate(
+    def queue_authorized_run(
         self,
         *,
-        cid: str,
-        user_id: str | None = None,
-        text: str | None = None,
-        meta: dict[str, Any] | None = None,
-        request_id: str | None = None,
-    ) -> str:
-        """Fire-and-forget scheduling of :py:meth:`generate` in a background thread."""
+        room: Room,
+        requested_by,
+        source_message: Message,
+        input_text: str,
+        request_meta: dict[str, Any],
+        client_generated_id: str | None = None,
+    ) -> tuple[AgentRun, bool]:
+        """Persist and schedule one authorized work order transactionally."""
 
-        job_id = str(uuid.uuid4())
-        meta_payload = dict(meta or {})
-        meta_payload.setdefault("cid", cid)
-        meta_payload["job_id"] = job_id
+        requested_client_key = (client_generated_id or "").strip()
+        persisted_client_key = str(
+            (source_message.custom_data or {}).get("client_generated_id") or ""
+        ).strip()
+        client_key = (
+            requested_client_key
+            if requested_client_key and requested_client_key == persisted_client_key
+            else ""
+        )
+        idempotency_key = f"agent:{room.pk}:message:{source_message.pk}"
+        if client_key:
+            idempotency_key = f"{idempotency_key}:client:{client_key}"
+
+        with transaction.atomic():
+            locked_room = Room.objects.select_for_update().get(pk=room.pk)
+            existing = AgentRun.objects.filter(
+                idempotency_key=idempotency_key
+            ).first()
+            if existing is not None:
+                logger.info(
+                    "agent.run.enqueue_duplicate",
+                    extra={"run_id": existing.run_id, "room_id": locked_room.pk},
+                )
+                return existing, False
+
+            if locked_room.agent_busy:
+                raise AgentRoomBusyError("Agent is already processing a request")
+
+            if (
+                source_message.channel.uuid != locked_room.uuid
+                or not locked_room.messages.filter(pk=source_message.pk).exists()
+            ):
+                raise ValueError("Source message does not belong to the authorized room")
+            if input_text != (source_message.body or ""):
+                raise ValueError("Input snapshot must match the authorized source message")
+
+            run_id = str(uuid.uuid4())
+            now = timezone.now()
+            run = AgentRun.objects.create(
+                run_id=run_id,
+                cid=locked_room.cid,
+                user_id=str(requested_by.pk),
+                room=locked_room,
+                requested_by=requested_by,
+                source_message=source_message,
+                input_text=input_text,
+                request_meta=dict(request_meta),
+                idempotency_key=idempotency_key,
+                status=AgentRun.STATUS_QUEUED,
+                queued_at=now,
+            )
+            locked_room.agent_busy = True
+            locked_room.active_agent_run_id = run_id
+            locked_room.save(update_fields=["agent_busy", "active_agent_run_id"])
+            transaction.on_commit(lambda: self._schedule_committed_run(run.run_id))
+
+        return run, True
+
+    def _schedule_committed_run(self, run_id: str) -> None:
+        try:
+            self.enqueue_generate(run_id)
+        except Exception:
+            with transaction.atomic():
+                run = (
+                    AgentRun.objects.select_for_update()
+                    .filter(run_id=run_id, status=AgentRun.STATUS_QUEUED)
+                    .first()
+                )
+                if run is not None:
+                    self._fail_locked_run(run, "scheduler_failure")
+            raise
+
+    def enqueue_generate(self, run_id: str) -> str:
+        """Schedule the canonical persisted-run executor in a daemon thread."""
 
         logger.info(
             "agent.generate.job.enqueued",
-            extra={"cid": cid, "job_id": job_id, "trace_id": request_id},
+            extra={"run_id": run_id},
         )
 
         thread = threading.Thread(
-            target=self._run_generate_job,
-            kwargs={
-                "job_id": job_id,
-                "cid": cid,
-                "user_id": user_id,
-                "text": text,
-                "meta": meta_payload,
-                "request_id": request_id,
-            },
+            target=self.execute_agent_run,
+            args=(run_id,),
             daemon=True,
         )
         thread.start()
 
-        return job_id
+        return run_id
 
-    def _run_generate_job(
-        self,
-        *,
-        job_id: str,
-        cid: str,
-        user_id: str | None,
-        text: str | None,
-        meta: dict[str, Any],
-        request_id: str | None,
-    ) -> None:
+    def execute_agent_run(self, run_id: str) -> bool:
+        """Atomically claim and execute a persisted work order at most once."""
+
         close_old_connections()
-        job_status = "ok"
-        job_reason = "ok"
         start = time.perf_counter()
 
-        logger.info(
-            "agent.generate.job.start",
-            extra={"cid": cid, "job_id": job_id, "trace_id": request_id},
-        )
-
         try:
-            reply = self.generate(
-                cid=cid,
-                user_id=user_id,
-                text=text,
-                meta=meta,
-                request_id=request_id,
-            )
-            job_reason = reply.reason
-            self._finalize_generated_messages(reply, meta)
-        except CancelledError:
-            job_status = AgentRun.STATUS_CANCELLED
-            job_reason = "cancelled"
+            with transaction.atomic():
+                run = (
+                    AgentRun.objects.select_for_update()
+                    .select_related(
+                        "room",
+                        "requested_by",
+                        "source_message",
+                        "source_message__channel",
+                        "result_message",
+                    )
+                    .filter(run_id=run_id)
+                    .first()
+                )
+                if run is None:
+                    logger.warning(
+                        "agent.run.missing_noop", extra={"run_id": run_id}
+                    )
+                    return False
+                if run.status == AgentRun.STATUS_RUNNING:
+                    stale_after = timedelta(
+                        seconds=int(
+                            getattr(settings, "AGENT_STALE_RUN_SECONDS", 900)
+                        )
+                    )
+                    if run.started_at and run.started_at < timezone.now() - stale_after:
+                        self._fail_locked_run(run, "stale_running_redelivery")
+                    else:
+                        logger.info(
+                            "agent.run.running_noop", extra={"run_id": run_id}
+                        )
+                    return False
+                if run.status != AgentRun.STATUS_QUEUED:
+                    logger.info(
+                        "agent.run.terminal_noop",
+                        extra={"run_id": run_id, "status": run.status},
+                    )
+                    return False
+                if not self._persisted_run_is_consistent(run):
+                    self._fail_locked_run(run, "invalid_persisted_relationships")
+                    return False
+                run.status = AgentRun.STATUS_RUNNING
+                run.started_at = timezone.now()
+                run.attempt_count += 1
+                run.save(
+                    update_fields=[
+                        "status",
+                        "started_at",
+                        "attempt_count",
+                        "updated_at",
+                    ]
+                )
+
             logger.info(
-                "agent.generate.job.cancelled",
-                extra={"cid": cid, "job_id": job_id, "trace_id": request_id},
+                "agent.run.claimed",
+                extra={
+                    "run_id": run.run_id,
+                    "room_id": run.room_id,
+                    "attempt": run.attempt_count,
+                },
             )
+            result = self._orchestrate(
+                cid=run.cid,
+                user_id=run.user_id,
+                message_text=run.input_text,
+                meta=dict(run.request_meta or {}),
+                request_id=run.run_id,
+                persist=True,
+                record_run=False,
+                authoritative_run=run,
+            )
+            self._complete_persisted_run(run.run_id, result)
+            return True
         except Exception:
-            job_status = "error"
-            job_reason = "exception"
             logger.exception(
-                "agent.generate.job.failure",
-                extra={"cid": cid, "job_id": job_id, "trace_id": request_id},
+                "agent.run.failure", extra={"run_id": run_id}
             )
+            self._mark_run_error(run_id, "executor_exception")
+            return False
         finally:
             logger.info(
-                "agent.generate.job.complete",
+                "agent.run.delivery_complete",
                 extra={
-                    "cid": cid,
-                    "job_id": job_id,
-                    "trace_id": request_id,
-                    "status": job_status,
-                    "reason": job_reason,
+                    "run_id": run_id,
                     "latency_ms": int((time.perf_counter() - start) * 1000),
                 },
             )
             close_old_connections()
+
+    def _persisted_run_is_consistent(self, run: AgentRun) -> bool:
+        return bool(
+            run.room_id
+            and run.requested_by_id
+            and run.source_message_id
+            and run.cid == run.room.cid
+            and run.source_message.channel.uuid == run.room.uuid
+            and run.room.messages.filter(pk=run.source_message_id).exists()
+            and str(run.room.active_agent_run_id) == run.run_id
+            and run.room.agent_busy
+            and AgentRoomPolicy.objects.filter(
+                cid=run.cid, agent_enabled=True
+            ).exists()
+        )
+
+    def _clear_locked_room_for_run(self, run: AgentRun) -> None:
+        if run.room_id is None:
+            return
+        room = Room.objects.select_for_update().get(pk=run.room_id)
+        if str(room.active_agent_run_id) == run.run_id:
+            room.agent_busy = False
+            room.active_agent_run_id = None
+            room.save(update_fields=["agent_busy", "active_agent_run_id"])
+
+    def _fail_locked_run(self, run: AgentRun, reason: str) -> None:
+        run.status = AgentRun.STATUS_ERROR
+        run.finished_at = timezone.now()
+        run.handoff_detail = reason
+        run.save(
+            update_fields=["status", "finished_at", "handoff_detail", "updated_at"]
+        )
+        self._clear_locked_room_for_run(run)
+
+    def _mark_run_error(self, run_id: str, reason: str) -> None:
+        with transaction.atomic():
+            run = AgentRun.objects.select_for_update().filter(run_id=run_id).first()
+            if run is None or run.status != AgentRun.STATUS_RUNNING:
+                return
+            self._fail_locked_run(run, reason)
+
+    def _complete_persisted_run(
+        self, run_id: str, result: AgentOrchestrationResult
+    ) -> None:
+        with transaction.atomic():
+            run = (
+                AgentRun.objects.select_for_update()
+                .select_related("room")
+                .get(run_id=run_id)
+            )
+            if run.status not in {
+                AgentRun.STATUS_RUNNING,
+                AgentRun.STATUS_CANCELLED,
+            }:
+                return
+            if run.status != AgentRun.STATUS_CANCELLED:
+                run.status = result.status
+            run.tools_used = list(result.tools_used)
+            run.latency_ms = max(result.latency_ms, 0)
+            run.tokens_in = max(result.tokens_in, 0)
+            run.tokens_out = max(result.tokens_out, 0)
+            run.cost_usd = result.cost_usd
+            run.handoff = result.handoff_triggered
+            run.handoff_reason = result.handoff_reason or ""
+            run.handoff_detail = result.handoff_detail or ""
+            run.last_tool_name = result.last_tool_name or ""
+            run.last_tool_call_id = result.last_tool_call_id or ""
+            run.last_tool_args_preview = result.last_tool_args_preview or ""
+            run.finished_at = timezone.now()
+            if result.message is not None and run.result_message_id is None:
+                run.result_message = result.message
+            run.save(
+                update_fields=[
+                    "status",
+                    "tools_used",
+                    "latency_ms",
+                    "tokens_in",
+                    "tokens_out",
+                    "cost_usd",
+                    "handoff",
+                    "handoff_reason",
+                    "handoff_detail",
+                    "last_tool_name",
+                    "last_tool_call_id",
+                    "last_tool_args_preview",
+                    "finished_at",
+                    "result_message",
+                    "updated_at",
+                ]
+            )
+            self._clear_locked_room_for_run(run)
 
     def simulate(
         self,
@@ -548,8 +759,13 @@ class AgentService:
         request_id: str | None,
         persist: bool,
         record_run: bool,
+        authoritative_run: AgentRun | None = None,
     ) -> AgentOrchestrationResult:
-        effective_request_id = request_id or meta.get("request_id") or str(uuid.uuid4())
+        effective_request_id = (
+            authoritative_run.run_id
+            if authoritative_run is not None
+            else request_id or meta.get("request_id") or str(uuid.uuid4())
+        )
         start = time.perf_counter()
         run_status = AgentRun.STATUS_OK
         tools_used: list[str] = []
@@ -565,7 +781,11 @@ class AgentService:
         last_tool_args_preview: str | None = None
         agent_run: AgentRun | None = None
 
-        room = self._get_room_for_cid(cid)
+        room = (
+            authoritative_run.room
+            if authoritative_run is not None
+            else self._get_room_for_cid(cid)
+        )
         room_uuid = getattr(room, "uuid", None)
 
         policy = self._get_policy(cid)
@@ -762,21 +982,26 @@ class AgentService:
         ai_message: Message | None = None
 
         if persist and policy.agent_enabled:
-            if room is not None:
+            if authoritative_run is not None:
+                agent_run = authoritative_run
+            elif room is not None:
                 agent_run = self._start_agent_run(
                     room=room,
                     cid=cid,
                     run_id=effective_request_id,
                     user_id=user_id,
                 )
-            ai_message = self._persist_message(
-                cid=cid,
-                text="",
-                custom_data={
-                    "ai_generated": True,
-                    "ai_state": "AI_STATE_THINKING",
-                },
-            )
+            if authoritative_run is not None:
+                ai_message = self._persist_run_placeholder(authoritative_run)
+            else:
+                ai_message = self._persist_message(
+                    cid=cid,
+                    text="",
+                    custom_data={
+                        "ai_generated": True,
+                        "ai_state": "AI_STATE_THINKING",
+                    },
+                )
             if room is not None:
                 mark_agent_state(
                     room=room,
@@ -1132,10 +1357,12 @@ class AgentService:
                         room=room,
                         ai_state=final_state,
                         ai_message=ai_message,
+                        agent_run=agent_run,
                         error_reason=error_reason,
+                        preserve_active_run=authoritative_run is not None,
                     )
                 message = ai_message
-            else:
+            elif authoritative_run is None:
                 message = self._persist_reply(
                     cid=cid, text=reply_text, handoff=handoff_triggered
                 )
@@ -1167,8 +1394,12 @@ class AgentService:
                 if custom_data_for_message != message.custom_data:
                     self._update_message(message, custom_data=custom_data_for_message)
 
-            self._mark_provenance(message)
-            if handoff_triggered:
+            else:
+                message = None
+
+            if message is not None:
+                self._mark_provenance(message)
+            if handoff_triggered and message is not None:
                 self._notify_handoff(cid)
         else:
             message = None
@@ -1203,6 +1434,11 @@ class AgentService:
             cost_usd=total_cost,
             reason=reason,
             handoff_triggered=handoff_triggered,
+            handoff_reason=handoff_reason,
+            handoff_detail=handoff_detail,
+            last_tool_name=last_tool_name,
+            last_tool_call_id=last_tool_call_id,
+            last_tool_args_preview=last_tool_args_preview,
             message=message,
         )
 
@@ -1766,6 +2002,48 @@ class AgentService:
                 "last_tool_args_preview": last_tool_args_preview,
             },
         )
+
+    def _persist_run_placeholder(self, agent_run: AgentRun) -> Message:
+        """Create the one result message using only persisted relationships."""
+
+        with transaction.atomic():
+            locked_run = (
+                AgentRun.objects.select_for_update()
+                .select_related("room", "source_message", "source_message__channel")
+                .get(pk=agent_run.pk)
+            )
+            if locked_run.result_message_id is not None:
+                return locked_run.result_message
+            if (
+                locked_run.status != AgentRun.STATUS_RUNNING
+                or not self._persisted_run_is_consistent(locked_run)
+            ):
+                raise ValueError("Agent run relationships are no longer authoritative")
+
+            channel = locked_run.source_message.channel
+            custom_data = {
+                "ai_generated": True,
+                "ai_state": "AI_STATE_THINKING",
+                "agent": {"run_id": locked_run.run_id},
+            }
+            message = Message.objects.create(
+                channel=channel,
+                body="",
+                sent_by=agent_user_id_for_room(locked_run.room.uuid),
+                custom_data=custom_data,
+            )
+            locked_run.room.messages.add(message)
+            locked_run.result_message = message
+            locked_run.save(update_fields=["result_message", "updated_at"])
+
+        payload = MessageSerializer(message).data
+        payload["user_id"] = message.sent_by
+        payload["user"] = {"id": message.sent_by, "name": "Assistant"}
+        _broadcast_to_cid(
+            locked_run.room.cid,
+            {"type": "message.new", "message": payload},
+        )
+        return message
 
     def _persist_message(
         self, *, cid: str, text: str, custom_data: dict[str, Any] | None = None

--- a/backend/stream_server_django/chat_addons/agent/services/agent_service.py
+++ b/backend/stream_server_django/chat_addons/agent/services/agent_service.py
@@ -1,5 +1,4 @@
 """Agent service orchestration for automated chat replies."""
-# ruff: noqa: F821
 from __future__ import annotations
 
 import json
@@ -433,13 +432,14 @@ class AgentService:
             else ""
         )
         idempotency_key = f"agent:{room.pk}:message:{source_message.pk}"
+        authoritative_meta = dict(request_meta)
         if client_key:
-            idempotency_key = f"{idempotency_key}:client:{client_key}"
+            authoritative_meta["client_generated_id"] = client_key
 
         with transaction.atomic():
             locked_room = Room.objects.select_for_update().get(pk=room.pk)
             existing = AgentRun.objects.filter(
-                idempotency_key=idempotency_key
+                room=locked_room, source_message=source_message
             ).first()
             if existing is not None:
                 logger.info(
@@ -469,7 +469,7 @@ class AgentService:
                 requested_by=requested_by,
                 source_message=source_message,
                 input_text=input_text,
-                request_meta=dict(request_meta),
+                request_meta=authoritative_meta,
                 idempotency_key=idempotency_key,
                 status=AgentRun.STATUS_QUEUED,
                 queued_at=now,
@@ -521,14 +521,7 @@ class AgentService:
         try:
             with transaction.atomic():
                 run = (
-                    AgentRun.objects.select_for_update()
-                    .select_related(
-                        "room",
-                        "requested_by",
-                        "source_message",
-                        "source_message__channel",
-                        "result_message",
-                    )
+                    AgentRun.objects.select_for_update(of=("self",))
                     .filter(run_id=run_id)
                     .first()
                 )
@@ -651,11 +644,7 @@ class AgentService:
         self, run_id: str, result: AgentOrchestrationResult
     ) -> None:
         with transaction.atomic():
-            run = (
-                AgentRun.objects.select_for_update()
-                .select_related("room")
-                .get(run_id=run_id)
-            )
+            run = AgentRun.objects.select_for_update(of=("self",)).get(run_id=run_id)
             if run.status not in {
                 AgentRun.STATUS_RUNNING,
                 AgentRun.STATUS_CANCELLED,
@@ -800,9 +789,6 @@ class AgentService:
         if cap_reached:
             tool_schemas = []
 
-        if not skills:
-            _note_handoff(HandoffReason.NO_TOOLS_ENABLED, "no tools enabled")
-
         # Allow lookup by skill name and any tool alias attached by the schema builder.
         skill_lookup = {skill.name: skill for skill in skills}
         for skill in skills:
@@ -830,6 +816,9 @@ class AgentService:
                 HandoffReason.TOOL_EXCEPTION,
                 detail=f"{exc.__class__.__name__}: {exc}",
             )
+
+        if not skills:
+            _note_handoff(HandoffReason.NO_TOOLS_ENABLED, "no tools enabled")
 
 
         tool_hops = 0
@@ -1203,7 +1192,14 @@ class AgentService:
                         if not fallback_attempted and skills and tools_enabled:
                             candidate = self._fallback_candidate(skills, message_text, ctx)
                             if candidate and tool_hops < tool_hop_cap:
-                                executed = self._execute_fallback(candidate, message_text, ctx, messages)
+                                executed = self._execute_fallback(
+                                    candidate,
+                                    message_text,
+                                    ctx,
+                                    messages,
+                                    on_before_execute=_remember_tool_attempt,
+                                    on_exception=_note_tool_exception,
+                                )
                                 if executed:
                                     tools_used.append(candidate.name)
                                     tool_hops += 1
@@ -1867,6 +1863,9 @@ class AgentService:
         text: str,
         ctx: ConversationCtx,
         messages: list[dict[str, Any]],
+        *,
+        on_before_execute: Callable[[ToolCall, Skill | None], None] | None = None,
+        on_exception: Callable[[ToolCall, Skill | None, Exception], None] | None = None,
     ) -> bool:
         args = infer_args_from_text(skill, text)
         if not args and text:
@@ -1878,8 +1877,8 @@ class AgentService:
                 ctx,
                 messages,
                 limit=1,
-                on_before_execute=_remember_tool_attempt,
-                on_exception=_note_tool_exception,
+                on_before_execute=on_before_execute,
+                on_exception=on_exception,
             )
             return bool(executed)
         except Exception:  # pragma: no cover - defensive
@@ -2008,8 +2007,7 @@ class AgentService:
 
         with transaction.atomic():
             locked_run = (
-                AgentRun.objects.select_for_update()
-                .select_related("room", "source_message", "source_message__channel")
+                AgentRun.objects.select_for_update(of=("self",))
                 .get(pk=agent_run.pk)
             )
             if locked_run.result_message_id is not None:

--- a/backend/stream_server_django/chat_addons/agent/tasks.py
+++ b/backend/stream_server_django/chat_addons/agent/tasks.py
@@ -1,14 +1,12 @@
+"""Queue-compatible entry point for persisted agent work orders."""
+
 from __future__ import annotations
 
-import logging
-import os
-from typing import Any
+from functools import wraps
 
 try:  # pragma: no cover - Celery optional
     from celery import shared_task
 except ImportError:  # pragma: no cover - fallback when Celery is absent
-    from functools import wraps
-
     def shared_task(*decorator_args, **decorator_kwargs):
         def decorator(func):
             @wraps(func)
@@ -29,94 +27,12 @@ except ImportError:  # pragma: no cover - fallback when Celery is absent
             return decorator(decorator_args[0])
         return decorator
 
-from django.conf import settings
-from django.db import transaction
 
-from stream_server_django.chat.broadcast import _broadcast_to_cid
-from stream_server_django.chat.models import Channel, Message, Room
-from stream_server_django.chat.serializers import MessageSerializer
-from stream_server_django.chat.utils import canonical_cid
-
-from ..common_audit.models import MessageProvenance
 from .services.agent_service import get_agent_service
-from .utils import agent_user_id_for_room
-
-logger = logging.getLogger(__name__)
-
-
-def _agent_user_id(room_uuid: str) -> str:
-    prefix = (
-        getattr(settings, "CHAT_AGENT_USER_ID", None)
-        or os.environ.get("AGENT_USER_ID")
-    )
-    if prefix:
-        return f"{prefix}-{room_uuid}"
-    return agent_user_id_for_room(room_uuid)
-
-
-def _room_uuid(cid: str) -> str:
-    return cid.split(":", 1)[1] if ":" in cid else cid
-
-
-def _persist_message(
-    *, cid: str, text: str, custom_data: dict[str, Any] | None = None
-) -> Message:
-    payload: dict[str, Any] = {"text": text}
-    if custom_data is not None:
-        payload["custom_data"] = custom_data
-
-    serializer = MessageSerializer(data=payload)
-    serializer.is_valid(raise_exception=True)
-
-    room_uuid = _room_uuid(cid)
-    agent_user = _agent_user_id(room_uuid)
-
-    with transaction.atomic():
-        channel, _ = Channel.objects.select_for_update().get_or_create(
-            uuid=room_uuid,
-            defaults={"client": "stream"},
-        )
-        room, _ = Room.objects.select_for_update().get_or_create(
-            uuid=room_uuid,
-            defaults={"client": "stream"},
-        )
-        serializer.save(channel=channel, sent_by=agent_user)
-        room.messages.add(serializer.instance)
-
-    payload = MessageSerializer(serializer.instance).data
-    payload["user_id"] = agent_user
-    payload["user"] = {"id": agent_user, "name": "Assistant"}
-    _broadcast_to_cid(cid, {"type": "message.new", "message": payload})
-    return serializer.instance
 
 
 @shared_task
-def run_agent_invocation(
-    run_id: str,
-    cid: str,
-    prompt: str,
-    meta: dict[str, Any] | None = None,
-) -> None:
-    """Generate an agent reply and persist it as a chat message."""
+def run_agent_invocation(run_id: str) -> bool:
+    """Execute one persisted run; broker arguments carry no room authority."""
 
-    canonical = canonical_cid(cid)
-    service = get_agent_service()
-
-    try:
-        reply = service.generate(cid=canonical, prompt=prompt, meta=meta or {})
-    except Exception:  # pragma: no cover - defensive logging
-        logger.exception("Agent service failed for run %s", run_id)
-        return
-
-    if reply is None or not getattr(reply, "text", None):
-        logger.info("Agent service returned no content for run %s", run_id)
-        return
-
-    try:
-        message = _persist_message(cid=canonical, text=str(reply.text))
-        MessageProvenance.objects.get_or_create(
-            message=message,
-            defaults={"source": MessageProvenance.Source.AGENT},
-        )
-    except Exception:  # pragma: no cover - defensive logging
-        logger.exception("Unable to persist agent message for run %s", run_id)
+    return get_agent_service().execute_agent_run(run_id)

--- a/backend/stream_server_django/chat_addons/agent/tests/test_agent_authorization.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_agent_authorization.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from jatte.tests.jwt_factory import make_test_token
@@ -55,7 +56,10 @@ class AgentAuthorizationTests(APITestCase):
     @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_member_can_invoke_own_room_but_outsider_cannot(self, service_factory):
         service = Mock()
-        service.enqueue_generate.return_value = "job-pr5"
+        service.queue_authorized_run.return_value = (
+            SimpleNamespace(run_id="job-pr5"),
+            True,
+        )
         service_factory.return_value = service
         url = reverse("agent-invoke", kwargs={"cid": self.room.cid})
         payload = {
@@ -67,13 +71,13 @@ class AgentAuthorizationTests(APITestCase):
             url, payload, format="json", **self.auth(self.outsider)
         )
         self.assertEqual(denied.status_code, 403)
-        service.enqueue_generate.assert_not_called()
+        service.queue_authorized_run.assert_not_called()
 
         allowed = self.client.post(
             url, payload, format="json", **self.auth(self.member)
         )
         self.assertEqual(allowed.status_code, 202, allowed.data)
-        service.enqueue_generate.assert_called_once()
+        service.queue_authorized_run.assert_called_once()
 
     def test_agent_controls_require_room_agent_or_staff(self):
         enable_url = reverse("enable-agent", kwargs={"cid": self.room.cid})

--- a/backend/stream_server_django/chat_addons/agent/tests/test_background_run_postgresql.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_background_run_postgresql.py
@@ -1,0 +1,107 @@
+from decimal import Decimal
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import TransactionTestCase, override_settings
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from jatte.tests.jwt_factory import make_test_token
+from stream_server_django.chat.models import Channel, Message, Room
+from stream_server_django.chat_addons.agent.models import AgentRoomPolicy, AgentRun
+from stream_server_django.chat_addons.agent.services.agent_service import (
+    AgentOrchestrationResult,
+    AgentService,
+)
+
+
+User = get_user_model()
+
+
+@override_settings(ROOT_URLCONF="jatte.urls")
+class PostgreSQLRunLifecycleTests(TransactionTestCase):
+    """Exercise corrected nullable-relation locks on PostgreSQL."""
+
+    def setUp(self):
+        if connection.vendor != "postgresql":
+            self.skipTest("PostgreSQL locking regression")
+        self.member = User.objects.create_user(
+            username="postgres-run-member", supabase_uid="postgres-run-member"
+        )
+        self.agent = User.objects.create_user(
+            username="postgres-run-agent", supabase_uid="postgres-run-agent"
+        )
+        self.room = Room.objects.create(
+            uuid="postgres-run-room", client=self.member.username, agent=self.agent
+        )
+        self.channel = Channel.objects.create(
+            uuid=self.room.uuid, client=self.room.client
+        )
+        AgentRoomPolicy.objects.create(cid=self.room.cid, agent_enabled=True)
+        self.service = AgentService(llm_client=mock.Mock())
+
+    def make_run(self, *, suffix, status):
+        source = Message.objects.create(
+            channel=self.channel, body=suffix, sent_by=self.member.username
+        )
+        self.room.messages.add(source)
+        run = AgentRun.objects.create(
+            run_id=f"20000000-0000-4000-8000-{int(suffix):012d}",
+            cid=self.room.cid,
+            user_id=str(self.member.pk),
+            room=self.room,
+            requested_by=self.member,
+            source_message=source,
+            input_text=source.body,
+            request_meta={},
+            idempotency_key=f"postgres-lifecycle-{suffix}",
+            status=status,
+            queued_at=timezone.now(),
+            started_at=timezone.now() if status == AgentRun.STATUS_RUNNING else None,
+        )
+        self.room.agent_busy = True
+        self.room.active_agent_run_id = run.run_id
+        self.room.save(update_fields=["agent_busy", "active_agent_run_id"])
+        return run
+
+    def test_claim_placeholder_completion_and_cancellation(self):
+        first = self.make_run(suffix="1", status=AgentRun.STATUS_QUEUED)
+
+        def complete(**kwargs):
+            run = kwargs["authoritative_run"]
+            placeholder = self.service._persist_run_placeholder(run)
+            return AgentOrchestrationResult(
+                request_id=run.run_id,
+                text="complete",
+                status=AgentRun.STATUS_OK,
+                tools_used=[],
+                latency_ms=1,
+                tokens_in=0,
+                tokens_out=0,
+                cost_usd=Decimal("0"),
+                reason="ok",
+                handoff_triggered=False,
+                message=placeholder,
+            )
+
+        with mock.patch.object(self.service, "_orchestrate", side_effect=complete):
+            self.assertTrue(self.service.execute_agent_run(first.run_id))
+        first.refresh_from_db()
+        self.assertEqual(first.status, AgentRun.STATUS_OK)
+        self.assertIsNotNone(first.result_message_id)
+
+        second = self.make_run(suffix="2", status=AgentRun.STATUS_RUNNING)
+        self.service._persist_run_placeholder(second)
+        response = APIClient().post(
+            f"/api/rooms/{self.room.cid}/agent/cancel/",
+            {},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {make_test_token(self.agent.supabase_uid)}",
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        second.refresh_from_db()
+        self.room.refresh_from_db()
+        self.assertEqual(second.status, AgentRun.STATUS_CANCELLED)
+        self.assertFalse(self.room.agent_busy)
+        self.assertIsNone(self.room.active_agent_run_id)

--- a/backend/stream_server_django/chat_addons/agent/tests/test_background_run_trust.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_background_run_trust.py
@@ -6,6 +6,7 @@ import threading
 from unittest import mock
 
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -240,8 +241,14 @@ class BackgroundRunTrustTests(TestCase):
             AgentRun.STATUS_CAPPED,
         )
         with mock.patch.object(self.service, "_orchestrate") as orchestrate:
-            for status in terminal:
-                run = self.make_run(status=status)
+            for index, status in enumerate(terminal):
+                source = Message.objects.create(
+                    channel=self.channel,
+                    body=f"terminal-{index}",
+                    sent_by=self.member.username,
+                )
+                self.room.messages.add(source)
+                run = self.make_run(status=status, source_message=source)
                 self.assertFalse(self.service.execute_agent_run(run.run_id))
         orchestrate.assert_not_called()
 
@@ -399,6 +406,84 @@ class BackgroundRunTrustTests(TestCase):
             first.idempotency_key,
             f"agent:{self.room.pk}:message:{self.message.pk}",
         )
+
+    def test_client_id_then_fallback_retry_uses_same_work_order(self):
+        with mock.patch.object(self.service, "enqueue_generate"):
+            first, created = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={"source": "http"},
+                client_generated_id="client-pr12-1",
+            )
+            first.status = AgentRun.STATUS_OK
+            first.finished_at = timezone.now()
+            first.save(update_fields=["status", "finished_at", "updated_at"])
+            self.room.agent_busy = False
+            self.room.active_agent_run_id = None
+            self.room.save(update_fields=["agent_busy", "active_agent_run_id"])
+            retry, retry_created = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={"source": "http"},
+            )
+
+        self.assertTrue(created)
+        self.assertFalse(retry_created)
+        self.assertEqual(retry.pk, first.pk)
+        self.assertEqual(AgentRun.objects.count(), 1)
+        self.assertEqual(
+            first.idempotency_key,
+            f"agent:{self.room.pk}:message:{self.message.pk}",
+        )
+        self.assertEqual(first.request_meta["client_generated_id"], "client-pr12-1")
+
+    def test_fallback_then_client_id_retry_uses_same_work_order(self):
+        with mock.patch.object(self.service, "enqueue_generate"):
+            first, _ = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={},
+            )
+            first.status = AgentRun.STATUS_OK
+            first.finished_at = timezone.now()
+            first.save(update_fields=["status", "finished_at", "updated_at"])
+            self.room.agent_busy = False
+            self.room.active_agent_run_id = None
+            self.room.save(update_fields=["agent_busy", "active_agent_run_id"])
+            retry, retry_created = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={},
+                client_generated_id="client-pr12-1",
+            )
+
+        self.assertFalse(retry_created)
+        self.assertEqual(retry.pk, first.pk)
+        self.assertEqual(AgentRun.objects.count(), 1)
+
+    def test_authoritative_room_source_pair_is_database_unique(self):
+        self.make_run(status=AgentRun.STATUS_OK)
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            AgentRun.objects.create(
+                run_id="00000000-0000-4000-8000-999999999999",
+                cid=self.room.cid,
+                user_id=str(self.member.pk),
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={},
+                idempotency_key="alternate-identity",
+                status=AgentRun.STATUS_OK,
+            )
 
     def test_distinct_message_can_run_after_prior_terminal_run(self):
         first = self.make_run()

--- a/backend/stream_server_django/chat_addons/agent/tests/test_background_run_trust.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_background_run_trust.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+import threading
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, TransactionTestCase, override_settings
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from jatte.tests.jwt_factory import make_test_token
+from stream_server_django.chat.models import Channel, Message, Room
+from stream_server_django.chat_addons.admin_console.services.gating import (
+    _schedule_agent_if_enabled,
+)
+from stream_server_django.chat_addons.agent.models import (
+    AgentRoomPolicy,
+    AgentRun,
+    RoomAgentFlag,
+)
+from stream_server_django.chat_addons.agent.services.agent_service import (
+    AgentOrchestrationResult,
+    AgentRoomBusyError,
+    AgentService,
+    mark_agent_state,
+)
+from stream_server_django.chat_addons.agent.tasks import run_agent_invocation
+
+
+User = get_user_model()
+
+
+@override_settings(ROOT_URLCONF="jatte.urls")
+class BackgroundRunTrustTests(TestCase):
+    def setUp(self) -> None:
+        self.member = User.objects.create_user(
+            username="pr12-member", supabase_uid="pr12-member"
+        )
+        self.outsider = User.objects.create_user(
+            username="pr12-outsider", supabase_uid="pr12-outsider"
+        )
+        self.agent = User.objects.create_user(
+            username="pr12-agent", supabase_uid="pr12-agent"
+        )
+        self.room = Room.objects.create(
+            uuid="pr12-room",
+            client=self.member.username,
+            agent=self.agent,
+        )
+        self.channel = Channel.objects.create(
+            uuid=self.room.uuid, client=self.room.client
+        )
+        self.message = Message.objects.create(
+            channel=self.channel,
+            body="Please help",
+            sent_by=self.member.username,
+            custom_data={"client_generated_id": "client-pr12-1"},
+        )
+        self.room.messages.add(self.message)
+        RoomAgentFlag.objects.create(room=self.room, agent_enabled=True)
+        AgentRoomPolicy.objects.create(
+            cid=self.room.cid,
+            agent_enabled=True,
+            enabled_skills=[],
+        )
+        self.service = AgentService(llm_client=mock.Mock())
+        self.client = APIClient()
+
+    def auth(self, user=None) -> dict[str, str]:
+        actor = user or self.member
+        return {
+            "HTTP_AUTHORIZATION": f"Bearer {make_test_token(actor.supabase_uid)}"
+        }
+
+    def make_run(
+        self,
+        *,
+        status: str = AgentRun.STATUS_QUEUED,
+        source_message: Message | None = None,
+        room: Room | None = None,
+    ) -> AgentRun:
+        authoritative_room = room or self.room
+        source = source_message or self.message
+        run = AgentRun.objects.create(
+            run_id="00000000-0000-4000-8000-%012d" % (AgentRun.objects.count() + 1),
+            cid=authoritative_room.cid,
+            user_id=str(self.member.pk),
+            room=authoritative_room,
+            requested_by=self.member,
+            source_message=source,
+            input_text=source.body,
+            request_meta={"source": "test"},
+            idempotency_key=f"test:{authoritative_room.pk}:{source.pk}:{AgentRun.objects.count()}",
+            status=status,
+            queued_at=timezone.now(),
+            started_at=timezone.now() if status == AgentRun.STATUS_RUNNING else None,
+        )
+        if status in {AgentRun.STATUS_QUEUED, AgentRun.STATUS_RUNNING}:
+            authoritative_room.agent_busy = True
+            authoritative_room.active_agent_run_id = run.run_id
+            authoritative_room.save(
+                update_fields=["agent_busy", "active_agent_run_id"]
+            )
+        return run
+
+    def successful_orchestration(self, calls: dict[str, int]):
+        def execute(**kwargs):
+            calls["llm"] += 1
+            calls["tool"] += 1
+            run = kwargs["authoritative_run"]
+            message = self.service._persist_run_placeholder(run)
+            message.body = "done"
+            message.save(update_fields=["body", "updated_at"])
+            return AgentOrchestrationResult(
+                request_id=run.run_id,
+                text="done",
+                status=AgentRun.STATUS_OK,
+                tools_used=["representative_tool"],
+                latency_ms=5,
+                tokens_in=3,
+                tokens_out=2,
+                cost_usd=Decimal("0.000001"),
+                reason="ok",
+                handoff_triggered=False,
+                message=message,
+            )
+
+        return execute
+
+    def test_forged_run_id_has_zero_side_effects(self):
+        before = (
+            Room.objects.count(),
+            Channel.objects.count(),
+            Message.objects.count(),
+            AgentRun.objects.count(),
+        )
+        with mock.patch.object(self.service, "_orchestrate") as orchestrate:
+            self.assertFalse(self.service.execute_agent_run("missing-run"))
+        self.assertEqual(
+            before,
+            (
+                Room.objects.count(),
+                Channel.objects.count(),
+                Message.objects.count(),
+                AgentRun.objects.count(),
+            ),
+        )
+        orchestrate.assert_not_called()
+
+    @mock.patch(
+        "stream_server_django.chat_addons.agent.tasks.get_agent_service"
+    )
+    def test_legacy_task_accepts_only_run_id(self, service_factory):
+        service_factory.return_value.execute_agent_run.return_value = False
+        self.assertFalse(run_agent_invocation("opaque-run"))
+        service_factory.return_value.execute_agent_run.assert_called_once_with(
+            "opaque-run"
+        )
+        with self.assertRaises(TypeError):
+            run_agent_invocation("opaque-run", "messaging:forged", "prompt")
+
+    @mock.patch(
+        "stream_server_django.chat_addons.agent.services.agent_service.get_agent_service"
+    )
+    def test_admin_intake_schedules_the_same_persisted_work_order(
+        self, service_factory
+    ):
+        service = service_factory.return_value
+        _schedule_agent_if_enabled(message=self.message, actor=self.agent)
+        service.queue_authorized_run.assert_called_once_with(
+            room=self.room,
+            requested_by=self.agent,
+            source_message=self.message,
+            input_text=self.message.body,
+            request_meta={"source": "intake_approval"},
+        )
+
+    def test_source_message_substitution_fails_closed(self):
+        room_b = Room.objects.create(uuid="pr12-room-b", client="other")
+        channel_b = Channel.objects.create(uuid=room_b.uuid, client="other")
+        message_b = Message.objects.create(
+            channel=channel_b, body="foreign", sent_by="other"
+        )
+        room_b.messages.add(message_b)
+        run = self.make_run(source_message=message_b)
+
+        with mock.patch.object(self.service, "_orchestrate") as orchestrate:
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+
+        run.refresh_from_db()
+        self.room.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_ERROR)
+        self.assertFalse(self.room.agent_busy)
+        self.assertIsNone(self.room.active_agent_run_id)
+        orchestrate.assert_not_called()
+
+    def test_disabled_after_queue_fails_without_background_message(self):
+        run = self.make_run()
+        AgentRoomPolicy.objects.filter(cid=self.room.cid).update(agent_enabled=False)
+        with mock.patch.object(self.service, "_orchestrate") as orchestrate:
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+        run.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_ERROR)
+        self.assertIsNone(run.result_message_id)
+        self.assertEqual(Message.objects.count(), 1)
+        orchestrate.assert_not_called()
+
+    def test_sequential_duplicate_delivery_runs_llm_and_tool_once(self):
+        run = self.make_run()
+        calls = {"llm": 0, "tool": 0}
+        with mock.patch.object(
+            self.service,
+            "_orchestrate",
+            side_effect=self.successful_orchestration(calls),
+        ):
+            self.assertTrue(self.service.execute_agent_run(run.run_id))
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+
+        run.refresh_from_db()
+        self.room.refresh_from_db()
+        self.assertEqual(calls, {"llm": 1, "tool": 1})
+        self.assertEqual(run.status, AgentRun.STATUS_OK)
+        self.assertEqual(run.attempt_count, 1)
+        self.assertEqual(run.cost_usd, Decimal("0.000001"))
+        self.assertIsNotNone(run.result_message_id)
+        self.assertEqual(
+            Message.objects.filter(result_agent_run=run).count(), 1
+        )
+        self.assertFalse(self.room.agent_busy)
+        self.assertIsNone(self.room.active_agent_run_id)
+
+    def test_terminal_and_cancelled_redelivery_are_noops(self):
+        terminal = (
+            AgentRun.STATUS_OK,
+            AgentRun.STATUS_ERROR,
+            AgentRun.STATUS_CANCELLED,
+            AgentRun.STATUS_HANDOFF,
+            AgentRun.STATUS_CAPPED,
+        )
+        with mock.patch.object(self.service, "_orchestrate") as orchestrate:
+            for status in terminal:
+                run = self.make_run(status=status)
+                self.assertFalse(self.service.execute_agent_run(run.run_id))
+        orchestrate.assert_not_called()
+
+    def test_stale_running_redelivery_marks_error_without_replay(self):
+        run = self.make_run(status=AgentRun.STATUS_RUNNING)
+        AgentRun.objects.filter(pk=run.pk).update(
+            started_at=timezone.now() - timedelta(hours=1)
+        )
+        with self.settings(AGENT_STALE_RUN_SECONDS=60), mock.patch.object(
+            self.service, "_orchestrate"
+        ) as orchestrate:
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+        run.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_ERROR)
+        orchestrate.assert_not_called()
+
+    def test_worker_exception_is_terminal_and_clears_room(self):
+        run = self.make_run()
+        with mock.patch.object(
+            self.service, "_orchestrate", side_effect=RuntimeError("boom")
+        ) as orchestrate:
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+        run.refresh_from_db()
+        self.room.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_ERROR)
+        self.assertEqual(orchestrate.call_count, 1)
+        self.assertFalse(self.room.agent_busy)
+        self.assertIsNone(self.room.active_agent_run_id)
+
+    def test_final_message_state_does_not_clear_room_before_run_terminal(self):
+        run = self.make_run(status=AgentRun.STATUS_RUNNING)
+        placeholder = self.service._persist_run_placeholder(run)
+        mark_agent_state(
+            room=self.room,
+            ai_state="AI_STATE_IDLE",
+            ai_message=placeholder,
+            agent_run=run,
+            preserve_active_run=True,
+        )
+        self.room.refresh_from_db()
+        run.refresh_from_db()
+        self.assertTrue(self.room.agent_busy)
+        self.assertEqual(str(self.room.active_agent_run_id), run.run_id)
+        self.assertEqual(run.status, AgentRun.STATUS_RUNNING)
+
+    def test_queue_is_idempotent_and_room_busy_is_atomic(self):
+        with mock.patch.object(self.service, "enqueue_generate") as schedule:
+            with self.captureOnCommitCallbacks(execute=True):
+                first, created = self.service.queue_authorized_run(
+                    room=self.room,
+                    requested_by=self.member,
+                    source_message=self.message,
+                    input_text=self.message.body,
+                    request_meta={"source": "http"},
+                    client_generated_id="same-client-id",
+                )
+            second, duplicate_created = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={"source": "http"},
+                client_generated_id="same-client-id",
+            )
+        self.assertTrue(created)
+        self.assertFalse(duplicate_created)
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(AgentRun.objects.count(), 1)
+        schedule.assert_called_once_with(first.run_id)
+
+        other = Message.objects.create(
+            channel=self.channel, body="different", sent_by=self.member.username
+        )
+        self.room.messages.add(other)
+        with self.assertRaises(AgentRoomBusyError):
+            self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=other,
+                input_text=other.body,
+                request_meta={},
+            )
+
+    def test_scheduler_failure_marks_run_error_and_clears_busy_state(self):
+        with mock.patch.object(
+            self.service, "enqueue_generate", side_effect=RuntimeError("scheduler")
+        ):
+            with self.assertRaises(RuntimeError), self.captureOnCommitCallbacks(
+                execute=True
+            ):
+                self.service.queue_authorized_run(
+                    room=self.room,
+                    requested_by=self.member,
+                    source_message=self.message,
+                    input_text=self.message.body,
+                    request_meta={},
+                )
+        run = AgentRun.objects.get()
+        run.refresh_from_db()
+        self.room.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_ERROR)
+        self.assertFalse(self.room.agent_busy)
+        self.assertIsNone(self.room.active_agent_run_id)
+
+    @mock.patch(
+        "stream_server_django.chat_addons.agent.views.get_agent_service"
+    )
+    def test_duplicate_http_request_returns_same_durable_job(self, service_factory):
+        service_factory.return_value = self.service
+        url = f"/api/chat/agent/{self.room.cid}/invoke/"
+        payload = {
+            "room_uuid": self.room.uuid,
+            "last_human_message_id": self.message.pk,
+            "client_generated_id": "http-retry",
+            "trace_id": "trace-pr12",
+        }
+        with mock.patch.object(self.service, "enqueue_generate") as schedule:
+            with self.captureOnCommitCallbacks(execute=True):
+                first = self.client.post(
+                    url, payload, format="json", **self.auth()
+                )
+            second = self.client.post(url, payload, format="json", **self.auth())
+
+        self.assertEqual(first.status_code, 202, first.data)
+        self.assertEqual(second.status_code, 202, second.data)
+        self.assertEqual(first.data["job_id"], second.data["job_id"])
+        self.assertEqual(AgentRun.objects.count(), 1)
+        schedule.assert_called_once()
+        run = AgentRun.objects.get()
+        self.assertEqual(run.room, self.room)
+        self.assertEqual(run.requested_by, self.member)
+        self.assertEqual(run.source_message, self.message)
+        self.assertEqual(run.input_text, self.message.body)
+
+    def test_fallback_idempotency_uses_authorized_room_and_message(self):
+        with mock.patch.object(self.service, "enqueue_generate"):
+            first, _ = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={},
+            )
+            second, created = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=self.message,
+                input_text=self.message.body,
+                request_meta={},
+            )
+        self.assertFalse(created)
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(
+            first.idempotency_key,
+            f"agent:{self.room.pk}:message:{self.message.pk}",
+        )
+
+    def test_distinct_message_can_run_after_prior_terminal_run(self):
+        first = self.make_run()
+        calls = {"llm": 0, "tool": 0}
+        with mock.patch.object(
+            self.service,
+            "_orchestrate",
+            side_effect=self.successful_orchestration(calls),
+        ):
+            self.assertTrue(self.service.execute_agent_run(first.run_id))
+
+        second_message = Message.objects.create(
+            channel=self.channel,
+            body="A distinct request",
+            sent_by=self.member.username,
+        )
+        self.room.messages.add(second_message)
+        with mock.patch.object(self.service, "enqueue_generate"):
+            second, created = self.service.queue_authorized_run(
+                room=self.room,
+                requested_by=self.member,
+                source_message=second_message,
+                input_text=second_message.body,
+                request_meta={},
+            )
+        self.assertTrue(created)
+        self.assertNotEqual(first.run_id, second.run_id)
+
+    def test_unauthorized_missing_and_disabled_http_requests_have_no_side_effects(self):
+        url = f"/api/chat/agent/{self.room.cid}/invoke/"
+        payload = {
+            "room_uuid": self.room.uuid,
+            "last_human_message_id": self.message.pk,
+        }
+        denied = self.client.post(
+            url, payload, format="json", **self.auth(self.outsider)
+        )
+        missing = self.client.post(
+            "/api/chat/agent/messaging:does-not-exist/invoke/",
+            {**payload, "room_uuid": "does-not-exist"},
+            format="json",
+            **self.auth(),
+        )
+        RoomAgentFlag.objects.filter(room=self.room).update(agent_enabled=False)
+        disabled = self.client.post(url, payload, format="json", **self.auth())
+        self.assertEqual(denied.status_code, 403)
+        self.assertEqual(missing.status_code, 404)
+        self.assertEqual(disabled.status_code, 400)
+        self.assertEqual(AgentRun.objects.count(), 0)
+        self.assertFalse(Room.objects.filter(uuid="does-not-exist").exists())
+
+    def test_queued_cancellation_prevents_execution(self):
+        run = self.make_run()
+        response = self.client.post(
+            f"/api/rooms/{self.room.cid}/agent/cancel/",
+            {},
+            format="json",
+            **self.auth(self.agent),
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        with mock.patch.object(self.service, "_orchestrate") as orchestrate:
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+        run.refresh_from_db()
+        self.room.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_CANCELLED)
+        self.assertFalse(self.room.agent_busy)
+        self.assertIsNone(self.room.active_agent_run_id)
+        self.assertIsNone(run.result_message_id)
+        orchestrate.assert_not_called()
+
+    def test_running_cancellation_marks_placeholder_and_prevents_redelivery(self):
+        run = self.make_run(status=AgentRun.STATUS_RUNNING)
+        placeholder = self.service._persist_run_placeholder(run)
+        response = self.client.post(
+            f"/api/rooms/{self.room.cid}/agent/cancel/",
+            {},
+            format="json",
+            **self.auth(self.agent),
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        run.refresh_from_db()
+        placeholder.refresh_from_db()
+        self.assertEqual(run.status, AgentRun.STATUS_CANCELLED)
+        self.assertEqual(placeholder.custom_data["ai_state"], "AI_STATE_ERROR")
+        self.assertEqual(placeholder.custom_data["error_reason"], "cancelled")
+        with mock.patch.object(self.service, "_orchestrate") as orchestrate:
+            self.assertFalse(self.service.execute_agent_run(run.run_id))
+        orchestrate.assert_not_called()
+
+
+class ConcurrentRunClaimTests(TransactionTestCase):
+    reset_sequences = True
+
+    def test_concurrent_duplicate_claim_executes_once(self):
+        user = User.objects.create_user(username="claim-user", supabase_uid="claim-user")
+        room = Room.objects.create(uuid="claim-room", client=user.username)
+        channel = Channel.objects.create(uuid=room.uuid, client=room.client)
+        message = Message.objects.create(channel=channel, body="hello", sent_by=user.username)
+        room.messages.add(message)
+        AgentRoomPolicy.objects.create(cid=room.cid, agent_enabled=True)
+        run = AgentRun.objects.create(
+            run_id="10000000-0000-4000-8000-000000000001",
+            cid=room.cid,
+            user_id=str(user.pk),
+            room=room,
+            requested_by=user,
+            source_message=message,
+            input_text=message.body,
+            request_meta={},
+            idempotency_key="concurrent-claim",
+            status=AgentRun.STATUS_QUEUED,
+            queued_at=timezone.now(),
+        )
+        room.agent_busy = True
+        room.active_agent_run_id = run.run_id
+        room.save(update_fields=["agent_busy", "active_agent_run_id"])
+
+        service = AgentService(llm_client=mock.Mock())
+        entered = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def orchestration(**kwargs):
+            calls.append(kwargs["authoritative_run"].run_id)
+            entered.set()
+            release.wait(timeout=5)
+            return AgentOrchestrationResult(
+                request_id=run.run_id,
+                text="done",
+                status=AgentRun.STATUS_OK,
+                tools_used=[],
+                latency_ms=1,
+                tokens_in=1,
+                tokens_out=1,
+                cost_usd=Decimal("0"),
+                reason="ok",
+                handoff_triggered=False,
+                message=None,
+            )
+
+        results = []
+        with mock.patch.object(service, "_orchestrate", side_effect=orchestration):
+            first = threading.Thread(
+                target=lambda: results.append(service.execute_agent_run(run.run_id))
+            )
+            first.start()
+            self.assertTrue(entered.wait(timeout=5))
+            second = threading.Thread(
+                target=lambda: results.append(service.execute_agent_run(run.run_id))
+            )
+            second.start()
+            second.join(timeout=5)
+            release.set()
+            first.join(timeout=5)
+
+        self.assertEqual(calls, [run.run_id])
+        self.assertEqual(sorted(results), [False, True])

--- a/backend/stream_server_django/chat_addons/agent/tests/test_stream_agent_contract.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_stream_agent_contract.py
@@ -1,5 +1,6 @@
 """Frontend-facing agent response contract tests."""
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from jatte.tests.jwt_factory import make_test_token
@@ -66,7 +67,10 @@ class StreamAgentContractTests(APITestCase):
     @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_frontend_invoke_returns_stable_queued_shape(self, service_factory):
         service = Mock()
-        service.enqueue_generate.return_value = "job-contract-1"
+        service.queue_authorized_run.return_value = (
+            SimpleNamespace(run_id="job-contract-1"),
+            True,
+        )
         service_factory.return_value = service
         response = self.client.post(
             f"/api/chat/agent/{self.room.cid}/invoke/",
@@ -88,7 +92,7 @@ class StreamAgentContractTests(APITestCase):
                 "trace_id": "trace-contract-1",
             },
         )
-        service.enqueue_generate.assert_called_once()
+        service.queue_authorized_run.assert_called_once()
 
     @patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_disabled_agent_error_shape_stays_stable(self, service_factory):

--- a/backend/stream_server_django/chat_addons/agent/tests/test_views.py
+++ b/backend/stream_server_django/chat_addons/agent/tests/test_views.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from unittest import mock
+from types import SimpleNamespace
 
 from decimal import Decimal
 
-import jwt
-from django.conf import settings
+from jatte.tests.jwt_factory import make_test_token
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -37,10 +37,8 @@ class AgentViewsTests(APITestCase):
             self.operator.save(update_fields=["is_staff"])
 
     def make_token(self) -> str:
-        return jwt.encode(
-            {"sub": self.operator.supabase_uid, "email": self.operator.email},
-            settings.SUPABASE_JWT_SECRET,
-            algorithm="HS256",
+        return make_test_token(
+            self.operator.supabase_uid, email=self.operator.email
         )
 
     def auth_headers(self) -> dict[str, str]:
@@ -80,7 +78,7 @@ class AgentViewsTests(APITestCase):
         flag.refresh_from_db()
         self.assertFalse(flag.agent_enabled)
 
-    @mock.patch("stream_server_django.chat_addons.agent.tasks._broadcast_to_cid")
+    @mock.patch("stream_server_django.chat_addons.agent.services.agent_service._broadcast_to_cid")
     def test_echo_invoke_creates_message(
         self, mock_broadcast: mock.MagicMock
     ) -> None:
@@ -114,6 +112,7 @@ class AgentViewsTests(APITestCase):
         RoomAgentFlag.objects.create(room=room, agent_enabled=True)
 
         user_message = Message.objects.create(channel=channel, body="Hello", sent_by="u-1")
+        room.messages.add(user_message)
 
         url = reverse("agent-rag")
         response = self.client.post(
@@ -149,9 +148,13 @@ class AgentViewsTests(APITestCase):
         user_message = Message.objects.create(
             channel=channel, body="Hello", sent_by="user-1"
         )
+        room.messages.add(user_message)
 
         service = mock.Mock()
-        service.enqueue_generate.return_value = "job-123"
+        service.queue_authorized_run.return_value = (
+            SimpleNamespace(run_id="job-123"),
+            True,
+        )
         mock_get_service.return_value = service
 
         response = self.client.post(
@@ -171,13 +174,13 @@ class AgentViewsTests(APITestCase):
         self.assertEqual(payload["job_id"], "job-123")
         self.assertEqual(payload["trace_id"], "trace-1")
 
-        service.enqueue_generate.assert_called_once()
-        _, kwargs = service.enqueue_generate.call_args
-        self.assertEqual(kwargs["cid"], f"messaging:{room.uuid}")
-        self.assertEqual(kwargs["user_id"], str(self.operator.id))
-        self.assertEqual(kwargs["text"], user_message.body)
-        self.assertEqual(kwargs["request_id"], "trace-1")
-        self.assertEqual(kwargs["meta"].get("job_request_id"), "trace-1")
+        service.queue_authorized_run.assert_called_once()
+        _, kwargs = service.queue_authorized_run.call_args
+        self.assertEqual(kwargs["room"], room)
+        self.assertEqual(kwargs["requested_by"], self.operator)
+        self.assertEqual(kwargs["source_message"], user_message)
+        self.assertEqual(kwargs["input_text"], user_message.body)
+        self.assertEqual(kwargs["request_meta"].get("request_id"), "trace-1")
 
     @mock.patch("stream_server_django.chat_addons.agent.views.get_agent_service")
     def test_llm_invoke_returns_500_when_enqueue_fails(
@@ -190,9 +193,10 @@ class AgentViewsTests(APITestCase):
         user_message = Message.objects.create(
             channel=channel, body="Hello", sent_by="user-1"
         )
+        room.messages.add(user_message)
 
         service = mock.Mock()
-        service.enqueue_generate.side_effect = RuntimeError("enqueue failed")
+        service.queue_authorized_run.side_effect = RuntimeError("enqueue failed")
         mock_get_service.return_value = service
 
         response = self.client.post(

--- a/backend/stream_server_django/chat_addons/agent/views.py
+++ b/backend/stream_server_django/chat_addons/agent/views.py
@@ -419,8 +419,7 @@ class AgentCancelView(APIView):
         active_run_id = str(resolved_room.active_agent_run_id)
         with transaction.atomic():
             run = (
-                AgentRun.objects.select_for_update()
-                .select_related("result_message")
+                AgentRun.objects.select_for_update(of=("self",))
                 .filter(
                     run_id=active_run_id,
                     room=resolved_room,

--- a/backend/stream_server_django/chat_addons/agent/views.py
+++ b/backend/stream_server_django/chat_addons/agent/views.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
-import time
 from typing import Any, Sequence
 
 from django.db import transaction
 from django.db.models import Q
+from django.http import Http404
+from django.utils import timezone
 from rest_framework import serializers, status
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import APIException, PermissionDenied
@@ -49,8 +50,11 @@ from .serializers import (
     RoomSkillPolicySerializer,
 )
 from ..common_audit.models import MessageProvenance
-from .tasks import _persist_message
-from .services.agent_service import get_agent_service, mark_agent_state
+from .services.agent_service import (
+    AgentRoomBusyError,
+    get_agent_service,
+    mark_agent_state,
+)
 from .services.memory import MemoryService
 from .utils import agent_enabled_for_room, agent_user_id_for_room
 
@@ -211,7 +215,9 @@ class AgentInvokeView(APIView):
             echo_text = fallback_serializer.validated_data["prompt"]
         else:
             raise serializers.ValidationError(serializer.errors or {})
-        agent_message = _persist_message(cid=canonical, text=f"Echo: {echo_text}")
+        agent_message = get_agent_service()._persist_message(
+            cid=canonical, text=f"Echo: {echo_text}"
+        )
 
         logger.info(
             "AgentInvokeView created agent message id=%s cid=%s text=%r",
@@ -252,9 +258,8 @@ class AgentLLMInvokeView(APIView):
     """
     Invoke the room's agent using the AgentService orchestration pipeline.
 
-    This is similar to AgentInvokeView, but instead of echoing the last
-    human message, it calls AgentService.generate(), which goes through
-    the LLM client (and eventually RAG, tools, memory, etc).
+    This is similar to AgentInvokeView, but persists an authorized AgentRun
+    work order for the last human message before scheduling the LLM pipeline.
 
     AgentInvokeView remains as a simple echo endpoint for smoke tests.
     """
@@ -282,7 +287,7 @@ class AgentLLMInvokeView(APIView):
             return response
 
         try:
-            identity = get_chat_identity(request)
+            get_chat_identity(request)
 
             # Normalize CID + room and mark that this room has ever used an agent
             canonical, room = _resolve_room_for_member(request, cid)
@@ -313,7 +318,7 @@ class AgentLLMInvokeView(APIView):
 
             # Look up the last human message we are supposed to respond to
             message_id = serializer.validated_data["last_human_message_id"]
-            message = Message.objects.filter(
+            message = room.messages.filter(
                 channel__uuid=room.uuid, id=message_id
             ).first()
             if not message:
@@ -331,14 +336,6 @@ class AgentLLMInvokeView(APIView):
                     Response(
                     {"detail": "Agent replies cannot be chained."},
                     status=status.HTTP_400_BAD_REQUEST,
-                    )
-                )
-
-            if room.agent_busy:
-                return _log_http_end(
-                    Response(
-                        {"detail": "Agent is already processing a request."},
-                        status=status.HTTP_409_CONFLICT,
                     )
                 )
 
@@ -361,16 +358,26 @@ class AgentLLMInvokeView(APIView):
             }
 
             service = get_agent_service()
-            meta["job_request_id"] = trace_id
             meta = {k: v for k, v in meta.items() if v is not None}
-
-            job_id = service.enqueue_generate(
-                cid=canonical,
-                user_id=str(identity.id) if identity.id is not None else None,
-                text=message.body or "",
-                meta=meta,
-                request_id=trace_id,
-            )
+            try:
+                agent_run, _created = service.queue_authorized_run(
+                    room=room,
+                    requested_by=request.user,
+                    source_message=message,
+                    input_text=message.body or "",
+                    request_meta=meta,
+                    client_generated_id=serializer.validated_data.get(
+                        "client_generated_id"
+                    ),
+                )
+            except AgentRoomBusyError:
+                return _log_http_end(
+                    Response(
+                        {"detail": "Agent is already processing a request."},
+                        status=status.HTTP_409_CONFLICT,
+                    )
+                )
+            job_id = agent_run.run_id
 
             payload = {
                 "status": "queued",
@@ -381,7 +388,7 @@ class AgentLLMInvokeView(APIView):
             response = Response(payload, status=status.HTTP_202_ACCEPTED)
             return _log_http_end(response, job_id=job_id)
 
-        except APIException:
+        except (APIException, Http404):
             raise
         except Exception:
             # This is the safety net we were missing: log the full stack trace.
@@ -405,38 +412,48 @@ class AgentCancelView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request: Request, cid: str) -> Response:
-        canonical, room = _resolve_room_for_control(request, cid)
+        canonical, resolved_room = _resolve_room_for_control(request, cid)
 
-        if not room.agent_busy:
+        if not resolved_room.agent_busy or not resolved_room.active_agent_run_id:
             return Response(status=status.HTTP_204_NO_CONTENT)
-
-        run: AgentRun | None = None
-        if room.active_agent_run_id:
-            run = AgentRun.objects.filter(
-                run_id=str(room.active_agent_run_id), cid=canonical
-            ).first()
-
-        if run is None:
+        active_run_id = str(resolved_room.active_agent_run_id)
+        with transaction.atomic():
             run = (
-                AgentRun.objects.filter(
-                    cid=canonical, status=AgentRun.STATUS_RUNNING
+                AgentRun.objects.select_for_update()
+                .select_related("result_message")
+                .filter(
+                    run_id=active_run_id,
+                    room=resolved_room,
+                    cid=canonical,
                 )
-                .order_by("-created_at", "-id")
                 .first()
             )
-
-        ai_message = (
-            Message.objects.filter(
-                channel__uuid=room.uuid,
-                custom_data__ai_generated=True,
-                custom_data__ai_state__in=[
-                    "AI_STATE_THINKING",
-                    "AI_STATE_GENERATING",
-                ],
-            )
-            .order_by("-created_at", "-id")
-            .first()
-        )
+            room = Room.objects.select_for_update().get(pk=resolved_room.pk)
+            if (
+                not room.agent_busy
+                or str(room.active_agent_run_id) != active_run_id
+            ):
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            if run is None:
+                room.agent_busy = False
+                room.active_agent_run_id = None
+                room.save(update_fields=["agent_busy", "active_agent_run_id"])
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            if run.status in {
+                AgentRun.STATUS_OK,
+                AgentRun.STATUS_CAPPED,
+                AgentRun.STATUS_HANDOFF,
+                AgentRun.STATUS_ERROR,
+                AgentRun.STATUS_CANCELLED,
+            }:
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            run.status = AgentRun.STATUS_CANCELLED
+            run.finished_at = timezone.now()
+            run.save(update_fields=["status", "finished_at", "updated_at"])
+            room.agent_busy = False
+            room.active_agent_run_id = None
+            room.save(update_fields=["agent_busy", "active_agent_run_id"])
+            ai_message = run.result_message
 
         mark_agent_state(
             room=room,

--- a/backend/stream_server_django/chat_addons/common_audit/tests/test_audit_features.py
+++ b/backend/stream_server_django/chat_addons/common_audit/tests/test_audit_features.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+# This legacy standalone pytest module bootstraps Django before app imports.
+# ruff: noqa: E402,F841
+
 import json
 import os
 import sys
 import uuid
 from pathlib import Path
 from typing import Iterator, TYPE_CHECKING
+from unittest.mock import patch
 
 BACKEND_DIR = Path(__file__).resolve().parents[3]
 if str(BACKEND_DIR) not in sys.path:
@@ -29,7 +33,7 @@ from django.contrib.auth import get_user_model
 from stream_server_django.chat.models import Channel, Message, Room
 from stream_server_django.chat_addons.admin_console.models import MessageIntake
 from stream_server_django.chat_addons.agent.tasks import run_agent_invocation
-from stream_server_django.chat_addons.common_audit.models import AuditTrail, MessageProvenance
+from stream_server_django.chat_addons.common_audit.models import AuditTrail
 from stream_server_django.chat_addons.common_audit.throttling import reset_rate_limit_cache
 User = get_user_model()
 
@@ -76,16 +80,15 @@ def auth_headers(operator_token: str) -> dict[str, str]:
     return {"HTTP_AUTHORIZATION": f"Bearer {operator_token}"}
 
 
-def test_agent_message_provenance_recorded() -> None:
-    cid = "messaging:room-prov"
-    prompt = "Hello agent"
+def test_agent_task_delegates_only_persisted_run_id() -> None:
+    with patch(
+        "stream_server_django.chat_addons.agent.tasks.get_agent_service"
+    ) as service_factory:
+        service = service_factory.return_value
+        service.execute_agent_run.return_value = True
 
-    run_agent_invocation("run-123", cid, prompt, meta={"foo": "bar"})
-
-    message = Message.objects.filter(channel__uuid="room-prov").order_by("-id").first()
-    assert message is not None
-    provenance = MessageProvenance.objects.get(message=message)
-    assert provenance.source == MessageProvenance.Source.AGENT
+        assert run_agent_invocation("run-123") is True
+        service.execute_agent_run.assert_called_once_with("run-123")
 
 
 @override_settings(ADDON_RATE_LIMITS={"claim": "1/min"})

--- a/backend/stream_server_django/chat_addons/migrations/0004_agentrun_work_order.py
+++ b/backend/stream_server_django/chat_addons/migrations/0004_agentrun_work_order.py
@@ -1,0 +1,109 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0001_initial"),
+        ("chat_addons", "0003_merge"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentrun",
+            name="attempt_count",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="finished_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="idempotency_key",
+            field=models.CharField(blank=True, max_length=512, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="input_text",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="queued_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="request_meta",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="requested_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="requested_agent_runs",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="result_message",
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="result_agent_run",
+                to="chat.message",
+            ),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="room",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="agent_runs",
+                to="chat.room",
+            ),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="source_message",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="source_agent_runs",
+                to="chat.message",
+            ),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="started_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name="agentrun",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("queued", "Queued"),
+                    ("running", "Running"),
+                    ("ok", "Ok"),
+                    ("capped", "Capped"),
+                    ("handoff", "Handoff"),
+                    ("error", "Error"),
+                    ("cancelled", "Cancelled"),
+                ],
+                max_length=16,
+            ),
+        ),
+    ]

--- a/backend/stream_server_django/chat_addons/migrations/0004_agentrun_work_order.py
+++ b/backend/stream_server_django/chat_addons/migrations/0004_agentrun_work_order.py
@@ -106,4 +106,12 @@ class Migration(migrations.Migration):
                 max_length=16,
             ),
         ),
+        migrations.AddConstraint(
+            model_name="agentrun",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(room__isnull=False, source_message__isnull=False),
+                fields=("room", "source_message"),
+                name="unique_authoritative_agent_run_source",
+            ),
+        ),
     ]


### PR DESCRIPTION
## Summary

- Persist authorized AgentRun work orders before scheduling and pass only opaque run_id values to background executors.
- Use persisted Room, requester, source Message, input snapshot, metadata, and a unique result Message; background execution never creates Room or Channel topology.
- Make duplicate, terminal, cancelled, running, stale, and forged deliveries safe no-ops or fail-closed terminal outcomes.

## Corrective hardening

- Lock only the AgentRun row on PostgreSQL; nullable relationships are loaded separately rather than joined into SELECT FOR UPDATE.
- Make (room, source_message) the canonical work-order identity, enforced by a conditional database uniqueness constraint.
- Retain a validated client_generated_id only as request metadata, so retries with or without it resolve to the same run.
- Remove the file-wide Ruff F821 waiver, order the no-skills handoff helper before use, and explicitly pass fallback-tool callbacks.

## Migration

chat_addons.0004_agentrun_work_order adds nullable authoritative relationships and lifecycle fields, queued status, and the conditional authoritative room/source-message uniqueness constraint. Historical audit rows remain unbound unless authoritative relationships exist.

## Verification

- Focused PR12 trust/idempotency tests: 22 passed on SQLite.
- Dedicated PostgreSQL lifecycle regression: 1 passed.
- Active agent/view/authorization/Stream selection: 40 passed.
- No-enabled-skills regression: 1 passed.
- Established RAG/streaming/tool/sanitizer selection: 15 passed.
- Prior PR1-PR11 implementation battery: 125 passed.
- Corrective prior-security selection: 105 passed; one known legacy notification test uses a pre-PR10 minimal JWT fixture and fails current authority validation.
- Django check, migration drift, fresh migrations, compilation, Ruff without F821 suppression, and diff checks: passed.

## Known unrelated conditions

- Repository-wide migration drift remains the pre-existing agent.0005_alter_documentchunk_id.
- Broad legacy discovery still contains stale import paths and minimal JWT fixtures outside the maintained security battery.