### PR TITLE
REALTIME-01C-C — Adopt shared realtime lifecycle in standalone Jatte

### DIFF
--- a/.github/workflows/realtime-convergence.yml
+++ b/.github/workflows/realtime-convergence.yml
@@ -25,8 +25,6 @@ jobs:
           fetch-depth: 2
           submodules: recursive
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.2
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/realtime-convergence.yml
+++ b/.github/workflows/realtime-convergence.yml
@@ -1,0 +1,48 @@
+name: Realtime convergence
+
+on:
+  pull_request:
+    paths:
+      - .gitmodules
+      - libs/iliad-realtime
+      - frontend/package.json
+      - pnpm-lock.yaml
+      - frontend/src/lib/stream-adapter/**
+      - frontend/src/lib/authTokenStore.ts
+      - frontend/src/config/endpoints.ts
+      - scripts/check-realtime-authority.mjs
+      - .github/workflows/realtime-convergence.yml
+
+permissions:
+  contents: read
+
+jobs:
+  convergence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          submodules: recursive
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Verify shared and consumer authorities
+        run: |
+          pnpm --dir libs/iliad-realtime check
+          node scripts/check-realtime-authority.mjs
+          node scripts/check-stream-fork-authority.mjs
+      - name: Focused Jatte realtime tests
+        run: >-
+          pnpm --filter @jatte-headless/chat-kit exec vitest run
+          src/config/__tests__/endpoints.test.ts
+          src/lib/stream-adapter/__tests__/jatteRealtime.test.ts
+          src/lib/stream-adapter/__tests__/channelRealtimeEvents.test.ts
+          src/lib/stream-adapter/__tests__/disconnectRealtime.test.ts
+          __tests__/adapter/tokenManager.test.ts
+      - run: git diff --check HEAD^

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libs/stream-chat-shim"]
 	path = libs/stream-chat-shim
 	url = https://github.com/ili-ad/iliad-stream-chat-react.git
+[submodule "libs/iliad-realtime"]
+	path = libs/iliad-realtime
+	url = https://github.com/ili-ad/iliad-realtime.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,11 +118,11 @@ writes or updates a markdown file in `audit/` rather than guess-editing code.
 
 - For chat/agent UI work, prefer:
   1. New components / overrides in `frontend/`.
-  2. Only if necessary, small, reusable adaptations in `stream-chat-shim`.
+  2. Only if necessary, small, reusable adaptations in `libs/chat-shim`.
 
-Generic Stream-derived UI changes begin in
-`ili-ad/iliad-stream-chat-react`; Jatte advances only an exact reviewed
-submodule commit. Jatte-specific adapter and application behavior stays here.
+Generic Stream-derived changes are made in `ili-ad/iliad-stream-chat-react`;
+Jatte advances the reviewed submodule pin. Jatte-specific adapter and
+application behavior stays here.
 
 
 ---

--- a/docs/stream-realtime-authority.md
+++ b/docs/stream-realtime-authority.md
@@ -1,0 +1,45 @@
+# Stream UI and realtime authority
+
+Jatte has two independent public upstream relationships:
+
+- Stream-derived UI: `libs/stream-chat-shim` → `ili-ad/iliad-stream-chat-react`.
+- Generic connection lifecycle: `libs/iliad-realtime` → `@iliad/realtime`.
+
+The Stream-compatible host seam remains `frontend/src/lib/stream-adapter/**`.
+Jatte owns authentication and credential refresh, room/CID identity, WebSocket
+endpoint and token transport, the `channel.watch` handshake, strict read-only
+REST resynchronization, and event-to-Stream-compatible state mapping.
+`@iliad/realtime` owns bounded reconnect/backoff, refresh and resync ordering,
+socket generations, stale-callback rejection, diagnostics, and teardown.
+
+GetStream upgrades happen in `ili-ad/iliad-stream-chat-react`; generic realtime
+upgrades happen in `ili-ad/iliad-realtime`. Realtime changes do not belong in
+the Stream fork, and Stream UI upgrades do not belong in `@iliad/realtime`.
+
+## Migration inventory
+
+Before REALTIME-01C-C, `Channel.watch()` owned initial message/member REST
+hydration, imported the WebSocket base from the Stream-derived package,
+constructed the browser `WebSocket`, sent `channel.watch` from `onopen`, parsed
+JSON and applied domain events from `onmessage`, logged `onerror`/`onclose`, and
+had no reconnect implementation. Credentials came from `ChatClient.jwt`; the
+only approved refresh authority was—and remains—`ChatClient.refreshToken()`.
+
+After the migration, `Channel` still owns initial hydration and domain event
+application. The Jatte facade in `jatteRealtime.ts` owns endpoint construction,
+credential query transport and the watch handshake. The shared client owns all
+generic callbacks, reconnect, generation fencing and teardown.
+
+## Close policy
+
+| Code or event | Current server meaning | Refresh | Reconnect | Terminal evidence |
+| --- | --- | --- | --- | --- |
+| `1000` | Intentional/normal close | No | No | WebSocket standard and client shutdown |
+| `4401` | Missing or rejected JWT, including expiry | Yes | Bounded | `ChatConsumer.connect`; JWT/WS security tests |
+| `4408` | Socket frame rate limit exhausted | No | No | `test_ws_rate_limit.py` |
+| `1009` | Oversized frame | No | No | `ChatConsumer.receive`; resource-limit test |
+| `forbidden` error frame | Room authorization denied | No | No automatic reconnect | `ChatConsumer._send_forbidden`; WS security tests |
+| Other abnormal close | Transport/network failure | No | Bounded | Shared default recovery policy |
+
+Reconnect ordering is shared delay → approved refresh → strict authorized GET
+resync → replacement socket → one Jatte `channel.watch` frame → connected.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   eslint: { ignoreDuringBuilds: true },
+  transpilePackages: ['@iliad/realtime'],
 
   webpack(cfg) {
     cfg.resolve ??= {};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "ci": "turbo run build test --filter='...[HEAD^]'"
   },
   "dependencies": {
+    "@iliad/realtime": "workspace:*",
     "@supabase/supabase-js": "2.50.0",
     "mitt": "^3.0.1",
     "mml-react": "0.4.7",

--- a/frontend/src/config/__tests__/endpoints.test.ts
+++ b/frontend/src/config/__tests__/endpoints.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveWsBase } from '../endpoints';
+
+describe('resolveWsBase', () => {
+  it('uses and normalizes an explicit endpoint', () => {
+    expect(resolveWsBase(' wss://socket.example.test/// ', undefined)).toBe(
+      'wss://socket.example.test',
+    );
+  });
+
+  it('derives ws from an HTTP browser location', () => {
+    expect(resolveWsBase(' ', { protocol: 'http:', hostname: 'chat.test' } as Location))
+      .toBe('ws://chat.test:8000');
+  });
+
+  it('derives wss from an HTTPS browser location', () => {
+    expect(resolveWsBase(' ', { protocol: 'https:', hostname: 'chat.test' } as Location))
+      .toBe('wss://chat.test:8000');
+  });
+
+  it('uses the server development fallback', () => {
+    expect(resolveWsBase(' ', null)).toBe('ws://127.0.0.1:8000');
+  });
+});

--- a/frontend/src/config/endpoints.ts
+++ b/frontend/src/config/endpoints.ts
@@ -1,18 +1,28 @@
 const ENV_API = process.env.NEXT_PUBLIC_API_URL;
-const ENV_WS = process.env.NEXT_PUBLIC_WS_URL;
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
 
-function defaultWsBase(): string {
-  if (typeof window === "undefined") {
-    return "ws://127.0.0.1:8000";
-  }
+export function resolveWsBase(
+  envValue = process.env.NEXT_PUBLIC_WS_URL,
+  location: Pick<Location, "protocol" | "hostname"> | null | undefined =
+    typeof window === "undefined" ? undefined : window.location,
+): string {
+  const explicit = envValue?.trim();
+  if (explicit) return trimTrailingSlash(explicit);
 
-  const proto = window.location.protocol === "https:" ? "wss" : "ws";
-  const host = window.location.hostname || "127.0.0.1";
+  if (location == null) return "ws://127.0.0.1:8000";
+
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  const hostname = location.hostname || "127.0.0.1";
+  const host = hostname.includes(":") && !hostname.startsWith("[")
+    ? `[${hostname}]`
+    : hostname;
   return `${proto}://${host}:8000`;
 }
 
 export const API_BASE: string = (ENV_API && ENV_API.trim()) || "";
-export const WS_BASE: string = (ENV_WS && ENV_WS.trim()) || defaultWsBase();
+export const WS_BASE: string = resolveWsBase();
 
 export function resolveApiUrl(path: string): string {
   const normalized = path.startsWith("/") ? path : `/${path}`;

--- a/frontend/src/lib/stream-adapter/Channel.ts
+++ b/frontend/src/lib/stream-adapter/Channel.ts
@@ -7,7 +7,15 @@ import { apiFetch } from '../api';
 import { AuthError } from '../errors';
 import { getAccessToken } from '../authTokenStore';
 import { buildAttachmentManager } from './composer/attachments';
-import { WS_BASE } from '@iliad/stream-chat-shim';
+import { createRealtimeClient, type RealtimeClient, type RealtimeDiagnostic } from '@iliad/realtime';
+import {
+    createJatteRealtimeSocket,
+    createJatteCredentialProvider,
+    decodeRealtimeEvent,
+    shouldReconnectJatte,
+    shouldRefreshJatteCredential,
+    type JatteRealtimeEvent,
+} from './jatteRealtime';
 import {
     clearAgentTypingTimer,
     normalizeMessagesWithDisplayName,
@@ -43,7 +51,7 @@ export class Channel {
 
     private roomUuid!: string;
 
-    private socket?: WebSocket;
+    private realtimeClient?: RealtimeClient<JatteRealtimeEvent>;
     private emitter = mitt<ChatEvents>();
     /** Track optimistic messages so we can reconcile server echoes */
     private pendingMessages = new Map<string, true>();
@@ -972,349 +980,199 @@ export class Channel {
     /** Fetch initial state without opening a websocket */
     async query() {
         try {
-            const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
-                headers: { Authorization: `Bearer ${this.client['jwt']}` },
-            });
-
-            if (res.ok) {
-                const payload: any = await res.json().catch(() => ({}));
-                const rawList: Message[] = Array.isArray(payload)
-                    ? payload
-                    : (payload?.messages ?? payload?.results ?? []);
-
-                const nextCursor = Array.isArray(payload) ? null : (payload?.next ?? null);
-
-                // Ensure chronological order (oldest → newest)
-                const first = [...rawList].sort((a: any, b: any) => {
-                    const ta = new Date(a?.created_at ?? 0).getTime();
-                    const tb = new Date(b?.created_at ?? 0).getTime();
-                    return ta - tb;
-                });
-
-                const me = this.client.user?.id;
-
-                const patch: any = {
-                    messages: first,
-                    latestMessages: first,
-                    messagePagination: {
-                        ...this._state.messagePagination,
-                        hasPrev: Boolean(nextCursor),
-                        hasNext: false,
-                    },
-                };
-
-                if (me) {
-                    const last = first.length ? first[first.length - 1] : undefined;
-                    patch.read = {
-                        ...this._state.read,
-                        [me]: {
-                            last_read: new Date(),
-                            last_read_message_id: last?.id,
-                            unread_messages: 0,
-                        },
-                    };
-                }
-
-                this.bump(patch);
-            }
-
-            const memRes = await apiFetch(`${API.ROOMS}${this.uuid}/members/`, {
-                headers: { Authorization: `Bearer ${this.client['jwt']}` },
-            });
-
-            if (memRes.ok) {
-                const payload: any = await memRes.json().catch(() => ({}));
-                const list: any[] = Array.isArray(payload)
-                    ? payload
-                    : (payload?.members ?? payload?.results ?? []);
-
-                const map: Record<string, { user: { id: string } }> = {};
-                for (const m of list) {
-                    const id =
-                        (m as any).id ??
-                        (m as any).user_id ??
-                        (m as any).user?.id;
-
-                    if (id) map[String(id)] = { user: { id: String(id) } };
-                }
-
-                this.bump({ members: map });
-            }
+            await this.hydrateAuthoritativeState({ strict: false, updateRead: true });
         } catch (err) {
             if (process.env.NODE_ENV !== 'production') {
-                // eslint-disable-next-line no-console
                 console.warn('[Channel.query] failed to hydrate history', err);
             }
         }
-
         this.initialized = true;
     }
 
+    private async hydrateAuthoritativeState(options: {
+        strict: boolean;
+        updateRead: boolean;
+    }): Promise<void> {
+        const headers = { Authorization: `Bearer ${this.client.userToken ?? ''}` };
+        const [messagesResult, membersResult] = await Promise.allSettled([
+            apiFetch(`${API.ROOMS}${this.uuid}/messages/`, { headers }),
+            apiFetch(`${API.ROOMS}${this.uuid}/members/`, { headers }),
+        ]);
+        if (options.strict && (messagesResult.status === 'rejected' || membersResult.status === 'rejected')) {
+            throw new Error('authoritative channel resync failed');
+        }
+        const messagesResponse = messagesResult.status === 'fulfilled' ? messagesResult.value : undefined;
+        const membersResponse = membersResult.status === 'fulfilled' ? membersResult.value : undefined;
 
-    async watch() {
-        if (this.socket) return;
-        this.client.activeChannels[this.cid] = this;
+        if (options.strict && (!messagesResponse?.ok || !membersResponse?.ok)) {
+            throw new Error('authoritative channel resync failed');
+        }
 
-        /* initial history + read row */
-        try {
-            const res = await apiFetch(`${API.ROOMS}${this.uuid}/messages/`, {
-                headers: { Authorization: `Bearer ${this.client['jwt']}` },
-            });
+        let messagesPayload: any;
+        let membersPayload: any;
+        if (messagesResponse?.ok) {
+            try {
+                messagesPayload = await messagesResponse.json();
+            } catch {
+                if (options.strict) throw new Error('authoritative channel resync returned malformed JSON');
+            }
+        }
+        if (membersResponse?.ok) {
+            try {
+                membersPayload = await membersResponse.json();
+            } catch {
+                if (options.strict) throw new Error('authoritative channel resync returned malformed JSON');
+            }
+        }
 
-            if (res.ok) {
-                const payload: any = await res.json().catch(() => ({}));
-                const rawList: Message[] = Array.isArray(payload)
-                    ? payload
-                    : (payload?.messages ?? payload?.results ?? []);
+        const rawMessages = Array.isArray(messagesPayload)
+            ? messagesPayload
+            : messagesPayload?.messages ?? messagesPayload?.results;
+        const rawMembers = Array.isArray(membersPayload)
+            ? membersPayload
+            : membersPayload?.members ?? membersPayload?.results;
 
-                const nextCursor = Array.isArray(payload) ? null : (payload?.next ?? null);
+        if (options.strict && (!Array.isArray(rawMessages) || !Array.isArray(rawMembers))) {
+            if (options.strict) throw new Error('authoritative channel resync returned invalid state');
+        }
 
-                // Ensure chronological order (oldest → newest)
-                const first = [...rawList].sort((a: any, b: any) => {
-                    const ta = new Date(a?.created_at ?? 0).getTime();
-                    const tb = new Date(b?.created_at ?? 0).getTime();
-                    return ta - tb;
-                });
-
-                const me = this.client.user?.id;
-                const last = first.length ? first[first.length - 1] : undefined;
-
-                const patch: any = {
-                    messages: first,
-                    latestMessages: first, // keep mirror
-                    messagePagination: {
-                        ...this._state.messagePagination,
-                        hasPrev: Boolean(nextCursor),
-                        hasNext: false,
+        const patch: any = {};
+        if (Array.isArray(rawMessages)) {
+            const messages = [...rawMessages].sort((a: any, b: any) =>
+                new Date(a?.created_at ?? 0).getTime() - new Date(b?.created_at ?? 0).getTime(),
+            ) as Message[];
+            const nextCursor = Array.isArray(messagesPayload) ? null : messagesPayload?.next ?? null;
+            patch.messages = messages;
+            patch.latestMessages = messages;
+            patch.messagePagination = {
+                ...this._state.messagePagination,
+                hasPrev: Boolean(nextCursor),
+                hasNext: false,
+            };
+            const me = this.client.user?.id;
+            if (options.updateRead && me) {
+                patch.read = {
+                    ...this._state.read,
+                    [me]: {
+                        last_read: new Date(),
+                        last_read_message_id: messages.at(-1)?.id,
+                        unread_messages: 0,
                     },
                 };
-
-                // Only set read state if we know who "me" is; do not bail out of watch().
-                if (me) {
-                    patch.read = {
-                        ...this._state.read,
-                        [me]: {
-                            last_read: new Date(),
-                            last_read_message_id: last?.id,
-                            unread_messages: 0,
-                        },
-                    };
-                }
-
-                this.bump(patch);
-            }
-
-            const memRes = await apiFetch(`${API.ROOMS}${this.uuid}/members/`, {
-                headers: { Authorization: `Bearer ${this.client['jwt']}` },
-            });
-
-            if (memRes.ok) {
-                const payload: any = await memRes.json().catch(() => ({}));
-                const list: any[] = Array.isArray(payload)
-                    ? payload
-                    : (payload?.members ?? payload?.results ?? []);
-
-                const map: Record<string, { user: { id: string } }> = {};
-                for (const m of list) {
-                    const id =
-                        (m as any).id ??
-                        (m as any).user_id ??
-                        (m as any).user?.id;
-
-                    if (id) map[String(id)] = { user: { id: String(id) } };
-                }
-
-                this.bump({ members: map });
-            }
-        } catch (err) {
-            if (process.env.NODE_ENV !== 'production') {
-                // eslint-disable-next-line no-console
-                console.warn('[Channel.watch] failed to hydrate history', err);
             }
         }
-
-
-        this.initialized = true;
-
-        /* web-socket for live updates */
-        // const wsRoot = process.env.NEXT_PUBLIC_WS_URL;
-        // if (!wsRoot) {
-        //     throw new Error('NEXT_PUBLIC_WS_URL is not set');
-        // }
-        // this.socket = new WebSocket(
-        //     `${wsRoot}/ws/${this.cid}/?token=${this.client['jwt']}`,
-        // );
-
-        const wsUrl = `${WS_BASE}/ws/${this.cid}/?token=${encodeURIComponent(
-            this.client['jwt'] ?? '',
-        )}`;
-
-        if (process.env.NODE_ENV !== 'production') {
-            // eslint-disable-next-line no-console
-            console.log('[agent/ws] opening socket', {
-                cid: this.cid,
-                uuid: this.uuid,
-                endpoint: `${WS_BASE}/ws/${this.cid}/`,
-            });
-        }
-
-        this.socket = new WebSocket(wsUrl);
-
-        this.socket.onopen = () => {
-        const frame = {
-            type: 'channel.watch',
-            cid: this.cid,
-            // you can add extra metadata here if the consumer ever needs it
-            // data: { user_id: this.client.user?.id },
-        };
-
-        if (process.env.NODE_ENV !== 'production') {
-            // eslint-disable-next-line no-console
-            console.log('[agent/ws] open', {
-            cid: this.cid,
-            uuid: this.uuid,
-            });
-            // eslint-disable-next-line no-console
-            console.log('[agent/ws] sending watch', frame);
-        }
-
-        try {
-            this.socket?.send(JSON.stringify(frame));
-        } catch (err) {
-            // eslint-disable-next-line no-console
-            console.error('[agent/ws] failed to send watch', err);
-        }
-        };
-
-
-        this.socket.onerror = (event) => {
-            if (process.env.NODE_ENV !== 'production') {
-                const isErrorEvent = typeof ErrorEvent !== 'undefined' && event instanceof ErrorEvent;
-                if (isErrorEvent) {
-                    // eslint-disable-next-line no-console
-                    console.error('[agent/ws] error', {
-                        cid: this.cid,
-                        uuid: this.uuid,
-                        message: event.message,
-                    });
+        if (Array.isArray(rawMembers)) {
+            const members: Record<string, { user: { id: string } }> = {};
+            for (const member of rawMembers) {
+                const id = member?.id ?? member?.user_id ?? member?.user?.id;
+                if (id !== undefined && id !== null) {
+                    members[String(id)] = { user: { id: String(id) } };
                 }
             }
-        };
-
-        this.socket.onclose = (event) => {
-            if (process.env.NODE_ENV !== 'production') {
-                // eslint-disable-next-line no-console
-                console.log('[agent/ws] close', {
-                    cid: this.cid,
-                    uuid: this.uuid,
-                    code: event.code,
-                    reason: event.reason,
-                    wasClean: event.wasClean,
-                });
-            }
-        };
-
-        this.socket.onmessage = (ev) => {
-            try {
-                const p = JSON.parse(ev.data);
-
-                if (process.env.NODE_ENV !== 'production') {
-                    // eslint-disable-next-line no-console
-                    console.log('[agent/ws] raw event', p);
-                }
-
-                const { type } = p as { type?: string };
-
-                switch (type) {
-                    case 'message':
-                    case 'message.new':
-                    case 'message.updated': {
-                        const msg = (p.message ?? p.data ?? (p as any).message ?? p.data?.message) as Message & {
-                            client_generated_id?: string;
-                        };
-
-                        if (!msg) {
-                            if (process.env.NODE_ENV !== 'production') {
-                                // eslint-disable-next-line no-console
-                                console.warn('[agent/ws] message event without payload', p);
-                            }
-                            break;
-                        }
-
-                        if (process.env.NODE_ENV !== 'production') {
-                            // eslint-disable-next-line no-console
-                            console.log('[agent/ws] message event', {
-                                cid: this.cid,
-                                uuid: this.uuid,
-                                id: msg.id,
-                                user_id: (msg as any).user_id,
-                                client_generated_id: (msg as any).client_generated_id,
-                                ai_generated: (msg as any).ai_generated,
-                            });
-                        }
-
-                        this.integrateIncomingMessage(
-                            { ...msg, status: (msg as any).status ?? 'received' },
-                            (msg as any).client_generated_id,
-                        );
-                        this.emitter.emit(EVENTS.MESSAGE_NEW, { type: EVENTS.MESSAGE_NEW, message: msg });
-                        break;
-                    }
-
-                    case 'typing.start':
-                    case 'typing.stop': {
-                        if (process.env.NODE_ENV !== 'production') {
-                            // eslint-disable-next-line no-console
-                            console.log('[agent/ws] typing event', {
-                                cid: this.cid,
-                                uuid: this.uuid,
-                                type,
-                                user_id: (p as any).user_id,
-                            });
-                        }
-
-                        this.applyTypingEvent({ type: type as any, user_id: (p as any).user_id } as any);
-                        this.emitter.emit(type as any, { type, cid: this.cid, user_id: (p as any).user_id } as any);
-                        this.client.emit(type as any, { type, cid: this.cid, user_id: (p as any).user_id } as any);
-                        break;
-                    }
-
-                    case 'ai_indicator.update': {
-                        const aiState = this.client.normalizeAIState((p as any).ai_state);
-                        this.client.setAIState(aiState, this.cid);
-                        break;
-                    }
-
-                    case 'ai_indicator.clear': {
-                        this.client.clearAIState(this.cid);
-                        break;
-                    }
-
-                    // Backend emits read events as type: "message.read" with
-                    // { cid, user: { id, channel_last_read_at, channel_unread_count, ... } }.
-                    case 'message.read': {
-                        this.handleMessageReadEvent(p as any);
-                        break;
-                    }
-
-                    default: {
-                        if (process.env.NODE_ENV !== 'production') {
-                            // eslint-disable-next-line no-console
-                            console.log('[agent/ws] unhandled event type', {
-                                cid: this.cid,
-                                uuid: this.uuid,
-                                event: p,
-                            });
-                        }
-                    }
-                }
-            } catch (err) {
-                // eslint-disable-next-line no-console
-                console.error('[agent/ws] bad payload', ev.data, err);
-            }
-        };
+            patch.members = members;
+        }
+        if (Object.keys(patch).length > 0) this.bump(patch);
     }
 
+    async resyncAuthoritativeState(): Promise<void> {
+        await this.hydrateAuthoritativeState({ strict: true, updateRead: false });
+    }
+
+    async watch() {
+        if (this.realtimeClient) return;
+        this.client.activeChannels[this.cid] = this;
+        await this.query();
+
+        const realtime = createRealtimeClient<JatteRealtimeEvent>({
+            credentialProvider: createJatteCredentialProvider(this.client),
+            createSocket: ({ credential }) => createJatteRealtimeSocket({
+                credential,
+                cid: this.cid,
+            }),
+            decodeEvent: decodeRealtimeEvent,
+            resync: () => this.resyncAuthoritativeState(),
+            shouldReconnect: shouldReconnectJatte,
+            shouldRefreshCredential: shouldRefreshJatteCredential,
+            reconnect: {
+                maxAttempts: 5,
+                initialDelayMs: 400,
+                maximumDelayMs: 8000,
+                multiplier: 2,
+                jitterRatio: 0,
+            },
+        });
+        this.realtimeClient = realtime;
+        realtime.subscribe(event => this.applyRealtimeEvent(event));
+        realtime.subscribeDiagnostics(diagnostic => this.handleRealtimeDiagnostic(diagnostic));
+        await realtime.start();
+    }
+
+    stopRealtime() {
+        this.realtimeClient?.stop();
+        this.realtimeClient = undefined;
+    }
+
+    realtimeState() {
+        return this.realtimeClient?.state() ?? 'disconnected';
+    }
+
+    private handleRealtimeDiagnostic(diagnostic: RealtimeDiagnostic) {
+        if (process.env.NODE_ENV === 'production') return;
+        if (diagnostic.type === 'socket_error' || diagnostic.type === 'resync_failed') {
+            console.warn('[agent/ws] lifecycle diagnostic', {
+                cid: this.cid,
+                type: diagnostic.type,
+                ...('generation' in diagnostic ? { generation: diagnostic.generation } : {}),
+                ...('attempt' in diagnostic ? { attempt: diagnostic.attempt } : {}),
+            });
+        }
+    }
+
+    private applyRealtimeEvent(event: JatteRealtimeEvent) {
+        const p = event as any;
+        const type = p.type;
+        switch (type) {
+            case 'message':
+            case 'message.new':
+            case 'message.updated': {
+                const msg = (p.message ?? p.data?.message ?? p.data) as Message & {
+                    client_generated_id?: string;
+                };
+                if (!msg || typeof msg !== 'object') return;
+                this.integrateIncomingMessage(
+                    { ...msg, status: (msg as any).status ?? 'received' },
+                    msg.client_generated_id,
+                );
+                this.emitter.emit(EVENTS.MESSAGE_NEW, { type: EVENTS.MESSAGE_NEW, message: msg });
+                return;
+            }
+            case 'typing.start':
+            case 'typing.stop': {
+                this.applyTypingEvent({ type, user_id: p.user_id } as any);
+                const payload = { type, cid: this.cid, user_id: p.user_id } as any;
+                this.emitter.emit(type as any, payload);
+                this.client.emit(type as any, payload);
+                return;
+            }
+            case 'ai_indicator.update':
+                this.client.setAIState(this.client.normalizeAIState(p.ai_state), this.cid);
+                return;
+            case 'ai_indicator.clear':
+                this.client.clearAIState(this.cid);
+                return;
+            case 'message.read':
+                this.handleMessageReadEvent(p);
+                return;
+            default:
+                if (process.env.NODE_ENV !== 'production') {
+                    console.log('[agent/ws] unhandled event type', {
+                        cid: this.cid,
+                        uuid: this.uuid,
+                        type,
+                    });
+                }
+        }
+    }
     private handleMessageReadEvent(event: {
         cid?: string;
         user?: {

--- a/frontend/src/lib/stream-adapter/ChatClient.ts
+++ b/frontend/src/lib/stream-adapter/ChatClient.ts
@@ -403,6 +403,9 @@ export class ChatClient {
 
     /** Tear-down helper mirroring Stream’s client.disconnectUser */
     disconnectUser() {
+        for (const channel of Object.values(this.activeChannels)) {
+            channel?.stopRealtime?.();
+        }
         const token = this.jwt;
         if (token) {
             apiFetch(API.SESSION, {

--- a/frontend/src/lib/stream-adapter/__tests__/channelRealtimeEvents.test.ts
+++ b/frontend/src/lib/stream-adapter/__tests__/channelRealtimeEvents.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatClient } from '../ChatClient';
+
+describe('Channel realtime event application', () => {
+  it('preserves message, typing, read, and AI event semantics exactly once', () => {
+    const client = new ChatClient('u1', 'jwt');
+    const channel = client.channel('messaging', 'room-1');
+    client.activeChannels[channel.cid] = channel;
+    const emitted: string[] = [];
+    channel.on('message.new' as any, () => emitted.push('message.new'));
+    channel.on('typing.start' as any, () => emitted.push('typing.start'));
+
+    const apply = (event: Record<string, unknown>) =>
+      (channel as any).applyRealtimeEvent(event);
+    apply({
+      type: 'message.new',
+      message: { id: 'm1', text: 'hello', user_id: 'u2', created_at: '2025-01-01T00:00:00Z' },
+    });
+    apply({ type: 'typing.start', user_id: 'u2' });
+    apply({
+      type: 'message.read',
+      cid: channel.cid,
+      user: { id: 'u2', channel_last_read_at: '2025-01-02T00:00:00Z', channel_unread_count: 1 },
+    });
+    apply({ type: 'ai_indicator.update', ai_state: 'AI_STATE_THINKING' });
+
+    expect(channel.state.messages.map(message => message.id)).toEqual(['m1']);
+    expect(emitted).toEqual(['message.new', 'typing.start']);
+    expect(channel.state.typing.u2?.user.id).toBe('u2');
+    expect(channel.state.read.u2?.unread_messages).toBe(1);
+    expect(client.getAIState(channel.cid)).toBe('AI_STATE_THINKING');
+
+    apply({ type: 'typing.stop', user_id: 'u2' });
+    apply({ type: 'ai_indicator.clear' });
+    expect(channel.state.typing.u2).toBeUndefined();
+    expect(client.getAIState(channel.cid)).toBe('AI_STATE_IDLE');
+  });
+
+  it('strict reconnect resync is read-only and rejects required failures', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ messages: [] }) })
+      .mockResolvedValueOnce({ ok: false, json: async () => ({}) });
+    global.fetch = fetchMock as any;
+    const client = new ChatClient('u1', 'jwt');
+    const channel = client.channel('messaging', 'room-1');
+    await expect(channel.resyncAuthoritativeState()).rejects.toThrow(
+      'authoritative channel resync failed',
+    );
+    expect(fetchMock.mock.calls.every(([, init]) => !init?.method || init.method === 'GET')).toBe(true);
+    global.fetch = originalFetch;
+  });
+});

--- a/frontend/src/lib/stream-adapter/__tests__/disconnectRealtime.test.ts
+++ b/frontend/src/lib/stream-adapter/__tests__/disconnectRealtime.test.ts
@@ -1,0 +1,17 @@
+import { expect, it, vi } from 'vitest';
+
+import { ChatClient } from '../ChatClient';
+
+it('stops every active channel before clearing the collection', () => {
+  const client = new ChatClient('u1', null);
+  const observations: number[] = [];
+  client.activeChannels = {
+    first: { stopRealtime: vi.fn(() => observations.push(Object.keys(client.activeChannels).length)) },
+    second: { stopRealtime: vi.fn(() => observations.push(Object.keys(client.activeChannels).length)) },
+  };
+
+  client.disconnectUser();
+
+  expect(observations).toEqual([2, 2]);
+  expect(client.activeChannels).toEqual({});
+});

--- a/frontend/src/lib/stream-adapter/__tests__/jatteRealtime.test.ts
+++ b/frontend/src/lib/stream-adapter/__tests__/jatteRealtime.test.ts
@@ -1,0 +1,203 @@
+import { createRealtimeClient, type RealtimeDiagnostic } from '@iliad/realtime';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createJatteCredentialProvider,
+  createJatteRealtimeSocket,
+  decodeRealtimeEvent,
+  shouldReconnectJatte,
+  shouldRefreshJatteCredential,
+  type JatteRealtimeEvent,
+  type RawWebSocketLike,
+} from '../jatteRealtime';
+
+class FakeRawSocket implements RawWebSocketLike {
+  static instances: FakeRawSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((event: { code: number; wasClean?: boolean }) => void) | null = null;
+  sent: string[] = [];
+  closed: Array<[number | undefined, string | undefined]> = [];
+
+  constructor(readonly url: string) { FakeRawSocket.instances.push(this); }
+  send(data: string) { this.sent.push(data); }
+  close(code?: number, reason?: string) { this.closed.push([code, reason]); }
+  open() { this.onopen?.(); }
+  message(data: unknown) { this.onmessage?.({ data }); }
+  closeFromServer(code: number, wasClean = false) { this.onclose?.({ code, wasClean }); }
+}
+
+class FailingWatchSocket extends FakeRawSocket {
+  send() { throw new Error('watch failed'); }
+}
+
+function harness(overrides: {
+  credential?: string | null;
+  refresh?: () => Promise<string>;
+  resync?: () => Promise<void>;
+} = {}) {
+  let credential = overrides.credential === undefined ? 'jwt-one' : overrides.credential;
+  const order: string[] = [];
+  const events: JatteRealtimeEvent[] = [];
+  const diagnostics: RealtimeDiagnostic[] = [];
+  const refresh = vi.fn(overrides.refresh ?? (async () => {
+    credential = 'jwt-two';
+    order.push('refresh');
+    return credential;
+  }));
+  const provider = createJatteCredentialProvider({
+    get userToken() { return credential; },
+    refreshToken: refresh,
+  });
+  const client = createRealtimeClient<JatteRealtimeEvent>({
+    credentialProvider: provider,
+    createSocket: ({ credential: token }) => {
+      order.push(`socket:${token}`);
+      return createJatteRealtimeSocket({
+        credential: token,
+        cid: 'messaging:room-1',
+        WebSocketCtor: FakeRawSocket,
+      });
+    },
+    decodeEvent: decodeRealtimeEvent,
+    resync: async () => {
+      order.push('resync:start');
+      await (overrides.resync?.() ?? Promise.resolve());
+      order.push('resync:end');
+    },
+    shouldReconnect: shouldReconnectJatte,
+    shouldRefreshCredential: shouldRefreshJatteCredential,
+    reconnect: { maxAttempts: 2, initialDelayMs: 10, maximumDelayMs: 20, multiplier: 2, jitterRatio: 0 },
+  });
+  client.subscribe(event => events.push(event));
+  client.subscribeDiagnostics(event => diagnostics.push(event));
+  return { client, diagnostics, events, order, refresh };
+}
+
+afterEach(() => {
+  FakeRawSocket.instances = [];
+  vi.useRealTimers();
+});
+
+describe('Jatte realtime lifecycle adapter', () => {
+  it('acquires one credential and sends one watch before connected', async () => {
+    const { client } = harness();
+    await client.start();
+    const socket = FakeRawSocket.instances[0];
+    expect(client.state()).toBe('connecting');
+    socket.open();
+    expect(socket.sent).toEqual([JSON.stringify({ type: 'channel.watch', cid: 'messaging:room-1' })]);
+    expect(client.state()).toBe('connected');
+    await client.start();
+    expect(FakeRawSocket.instances).toHaveLength(1);
+  });
+
+  it('does not report connected when the watch handshake cannot be sent', () => {
+    const socket = createJatteRealtimeSocket({
+      credential: 'jwt-one',
+      cid: 'messaging:room-1',
+      WebSocketCtor: FailingWatchSocket,
+    });
+    const opened = vi.fn();
+    socket.onopen = opened;
+    FakeRawSocket.instances[0].open();
+    expect(opened).not.toHaveBeenCalled();
+    expect(FakeRawSocket.instances[0].closed).toEqual([[1011, 'watch_handshake_failed']]);
+  });
+
+  it('fails closed when no credential is available', async () => {
+    const { client } = harness({ credential: null });
+    await client.start();
+    expect(client.state()).toBe('degraded');
+    expect(FakeRawSocket.instances).toHaveLength(0);
+  });
+
+  it('resyncs before constructing a replacement and fences stale messages', async () => {
+    vi.useFakeTimers();
+    const { client, events, order } = harness();
+    await client.start();
+    const oldSocket = FakeRawSocket.instances[0];
+    oldSocket.open();
+    oldSocket.closeFromServer(1006);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(order).toEqual(['socket:jwt-one', 'resync:start', 'resync:end', 'socket:jwt-one']);
+    const replacement = FakeRawSocket.instances[1];
+    replacement.open();
+    expect(replacement.sent).toHaveLength(1);
+    oldSocket.message(JSON.stringify({ type: 'message.new', message: { id: 'stale' } }));
+    replacement.message(JSON.stringify({ type: 'message.new', message: { id: 'fresh' } }));
+    expect(events).toHaveLength(1);
+  });
+
+  it('refreshes once for 4401 before resync and replacement', async () => {
+    vi.useFakeTimers();
+    const { client, order, refresh } = harness();
+    await client.start();
+    FakeRawSocket.instances[0].open();
+    FakeRawSocket.instances[0].closeFromServer(4401);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['socket:jwt-one', 'refresh', 'resync:start', 'resync:end', 'socket:jwt-two']);
+  });
+
+  it.each([1000, 1009, 4408])('does not reconnect terminal close %s', async code => {
+    vi.useFakeTimers();
+    const { client } = harness();
+    await client.start();
+    FakeRawSocket.instances[0].open();
+    FakeRawSocket.instances[0].closeFromServer(code);
+    await vi.runAllTimersAsync();
+    expect(FakeRawSocket.instances).toHaveLength(1);
+    expect(client.state()).toBe('disconnected');
+  });
+
+  it('degrades without replacement when refresh fails', async () => {
+    vi.useFakeTimers();
+    const { client } = harness({ refresh: async () => { throw new Error('refresh failed'); } });
+    await client.start();
+    FakeRawSocket.instances[0].open();
+    FakeRawSocket.instances[0].closeFromServer(4401);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(client.state()).toBe('degraded');
+    expect(FakeRawSocket.instances).toHaveLength(1);
+  });
+
+  it('degrades without replacement when strict resync fails', async () => {
+    vi.useFakeTimers();
+    const { client } = harness({ resync: async () => { throw new Error('resync failed'); } });
+    await client.start();
+    FakeRawSocket.instances[0].open();
+    FakeRawSocket.instances[0].closeFromServer(1006);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(client.state()).toBe('degraded');
+    expect(FakeRawSocket.instances).toHaveLength(1);
+  });
+
+  it('rejects malformed events and isolates handler failures without leaking credentials', async () => {
+    const { client, diagnostics } = harness();
+    client.subscribe(() => { throw new Error('consumer'); });
+    await client.start();
+    const socket = FakeRawSocket.instances[0];
+    socket.open();
+    socket.message('not-json');
+    socket.message(JSON.stringify({ type: 'message.new' }));
+    expect(diagnostics.map(item => item.type)).toContain('event_rejected');
+    expect(diagnostics.map(item => item.type)).toContain('event_handler_failed');
+    expect(JSON.stringify(diagnostics)).not.toContain('jwt-one');
+  });
+
+  it('cancels backoff and rejects post-stop callbacks', async () => {
+    vi.useFakeTimers();
+    const { client, events } = harness();
+    await client.start();
+    const socket = FakeRawSocket.instances[0];
+    socket.open();
+    socket.closeFromServer(1006);
+    client.stop();
+    socket.message(JSON.stringify({ type: 'message.new' }));
+    await vi.runAllTimersAsync();
+    expect(FakeRawSocket.instances).toHaveLength(1);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/stream-adapter/jatteRealtime.ts
+++ b/frontend/src/lib/stream-adapter/jatteRealtime.ts
@@ -1,0 +1,91 @@
+import type {
+  RealtimeCredentialProvider,
+  RealtimeSocket,
+  RealtimeSocketCloseEvent,
+  RealtimeSocketMessageEvent,
+} from '@iliad/realtime';
+
+import { resolveWsBase } from '../../config/endpoints';
+
+export type JatteRealtimeEvent = Record<string, unknown> & { type: string };
+
+export interface RawWebSocketLike {
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: (() => void) | null;
+  onclose: ((event: { code: number; wasClean?: boolean }) => void) | null;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type RawWebSocketConstructor = new (url: string) => RawWebSocketLike;
+
+export function createJatteCredentialProvider(client: {
+  readonly userToken: string | null;
+  refreshToken(): Promise<string>;
+}): RealtimeCredentialProvider {
+  return {
+    async getCredential() {
+      const credential = client.userToken;
+      if (!credential) throw new Error('Jatte realtime credential unavailable');
+      return credential;
+    },
+    refreshCredential: () => client.refreshToken(),
+  };
+}
+
+export function buildJatteSocketUrl(credential: string, cid: string): string {
+  return `${resolveWsBase()}/ws/${cid}/?token=${encodeURIComponent(credential)}`;
+}
+
+export function createJatteRealtimeSocket(options: {
+  credential: string;
+  cid: string;
+  WebSocketCtor?: RawWebSocketConstructor;
+}): RealtimeSocket {
+  const WebSocketCtor = options.WebSocketCtor ?? (WebSocket as unknown as RawWebSocketConstructor);
+  const raw = new WebSocketCtor(buildJatteSocketUrl(options.credential, options.cid));
+  const facade: RealtimeSocket = {
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    close: (code, reason) => raw.close(code, reason),
+  };
+
+  raw.onopen = () => {
+    try {
+      raw.send(JSON.stringify({ type: 'channel.watch', cid: options.cid }));
+    } catch {
+      raw.close(1011, 'watch_handshake_failed');
+      return;
+    }
+    facade.onopen?.();
+  };
+  raw.onmessage = event => facade.onmessage?.({ data: event.data } as RealtimeSocketMessageEvent);
+  raw.onerror = () => facade.onerror?.();
+  raw.onclose = event => facade.onclose?.({ code: event.code, wasClean: event.wasClean });
+  return facade;
+}
+
+export function decodeRealtimeEvent(raw: unknown): JatteRealtimeEvent | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const type = (parsed as { type?: unknown }).type;
+    return typeof type === 'string' && type.length > 0
+      ? parsed as JatteRealtimeEvent
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function shouldReconnectJatte(event: RealtimeSocketCloseEvent): boolean {
+  return ![1000, 1009, 4408].includes(event.code);
+}
+
+export function shouldRefreshJatteCredential(event: RealtimeSocketCloseEvent): boolean {
+  return event.code === 4401;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
 
   frontend:
     dependencies:
+      '@iliad/realtime':
+        specifier: workspace:*
+        version: link:../libs/iliad-realtime
       '@supabase/supabase-js':
         specifier: 2.50.0
         version: 2.50.0
@@ -191,6 +194,21 @@ importers:
       '@iliad/stream-chat-shim':
         specifier: workspace:*
         version: link:../stream-chat-shim
+
+  libs/iliad-realtime:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.1
+      prettier:
+        specifier: 3.6.2
+        version: 3.6.2
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@20.19.1)(jsdom@24.1.3)(terser@5.43.1)
 
   libs/stream-chat-shim:
     dependencies:
@@ -1690,17 +1708,46 @@ packages:
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/runner@1.6.1':
     resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/snapshot@1.6.1':
     resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/spy@1.6.1':
     resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -1876,6 +1923,10 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -2026,6 +2077,10 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2057,6 +2112,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2200,6 +2259,10 @@ packages:
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-equal@2.2.3:
@@ -2548,6 +2611,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -3429,6 +3496,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3881,6 +3951,10 @@ packages:
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3965,6 +4039,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -4497,6 +4576,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
@@ -4505,8 +4587,20 @@ packages:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
@@ -4788,6 +4882,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4828,6 +4927,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 1.6.1
       '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -6358,10 +6482,34 @@ snapshots:
       '@vitest/utils': 1.6.1
       chai: 4.5.0
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@20.19.1)(terser@5.43.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.19.1)(terser@5.43.1)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/runner@1.6.1':
     dependencies:
       '@vitest/utils': 1.6.1
       p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
       pathe: 1.1.2
 
   '@vitest/snapshot@1.6.1':
@@ -6370,9 +6518,19 @@ snapshots:
       pathe: 1.1.2
       pretty-format: 29.7.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.17
+      pathe: 1.1.2
+
   '@vitest/spy@1.6.1':
     dependencies:
       tinyspy: 2.2.1
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -6380,6 +6538,12 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -6609,6 +6773,8 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -6785,6 +6951,14 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6809,6 +6983,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -6945,6 +7121,8 @@ snapshots:
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-equal@2.2.3:
     dependencies:
@@ -7512,6 +7690,8 @@ snapshots:
       strip-final-newline: 3.0.0
 
   exit@0.1.2: {}
+
+  expect-type@1.4.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -8630,6 +8810,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -9334,6 +9516,8 @@ snapshots:
 
   pathval@1.1.1: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -9402,6 +9586,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.6.2: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -10160,6 +10346,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.2)
@@ -10167,7 +10355,13 @@ snapshots:
 
   tinypool@0.8.4: {}
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
   tinyspy@2.2.1: {}
+
+  tinyspy@3.0.2: {}
 
   tmpl@1.0.5: {}
 
@@ -10512,6 +10706,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@20.19.1)(terser@5.43.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.19(@types/node@20.19.1)(terser@5.43.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.19(@types/node@20.19.1)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
@@ -10550,6 +10762,42 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@20.19.1)(jsdom@24.1.3)(terser@5.43.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.19.1)(terser@5.43.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.4.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.19(@types/node@20.19.1)(terser@5.43.1)
+      vite-node: 2.1.9(@types/node@20.19.1)(terser@5.43.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.1
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus

--- a/scripts/check-realtime-authority.mjs
+++ b/scripts/check-realtime-authority.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const PIN = '1aa5e3301a34fb3a56dd4103f600c415b4998656';
+const URL = 'https://github.com/ili-ad/iliad-realtime.git';
+
+function run(command, args, cwd = process.cwd(), allowFailure = false) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  if (!allowFailure && result.status !== 0) throw new Error(result.stderr.trim());
+  return { status: result.status, output: result.stdout.trim() };
+}
+function assert(condition, message) { if (!condition) throw new Error(message); }
+
+assert(
+  run('git', ['ls-files', '--stage', 'libs/iliad-realtime']).output ===
+    `160000 ${PIN} 0\tlibs/iliad-realtime`,
+  'unexpected iliad-realtime gitlink',
+);
+const modules = readFileSync('.gitmodules', 'utf8');
+assert(modules.includes('[submodule "libs/iliad-realtime"]'), 'realtime submodule missing');
+assert(modules.includes(`url = ${URL}`), 'realtime submodule URL mismatch');
+assert(run('git', ['rev-parse', 'HEAD'], 'libs/iliad-realtime').output === PIN, 'realtime checkout mismatch');
+const packageJson = JSON.parse(readFileSync('libs/iliad-realtime/package.json', 'utf8'));
+assert(packageJson.name === '@iliad/realtime', 'realtime package identity mismatch');
+assert(!existsSync('packages/realtime') && !existsSync('frontend/src/realtime'), 'copied realtime authority found');
+const channelSource = readFileSync('frontend/src/lib/stream-adapter/Channel.ts', 'utf8');
+const adapterSource = readFileSync('frontend/src/lib/stream-adapter/jatteRealtime.ts', 'utf8');
+assert(channelSource.includes('createRealtimeClient'), 'Channel does not delegate to @iliad/realtime');
+assert(!channelSource.includes('new WebSocket('), 'Channel still owns raw WebSocket lifecycle');
+assert(!/setTimeout|reconnectAttempts?|socketGeneration|generationCounter/.test(adapterSource),
+  'Jatte adapter contains duplicate generic lifecycle machinery');
+const streamImport = run(
+  'git',
+  ['grep', '-n', '-F', '@iliad/realtime', '--', 'src', 'package.json'],
+  'libs/stream-chat-shim',
+  true,
+);
+assert(streamImport.status === 1 && streamImport.output === '', 'Stream fork depends on @iliad/realtime');
+console.log('Realtime authority: PASS');


### PR DESCRIPTION
## Summary

- pin public `ili-ad/iliad-realtime` v0.1.0 at `1aa5e3301a34fb3a56dd4103f600c415b4998656`
- delegate generic connection, reconnect, generation fencing, resync sequencing, diagnostics, and teardown to `@iliad/realtime`
- retain Jatte-owned credential authority, endpoint/token transport, `channel.watch`, event mapping, close policy, and strict read-only REST resync
- stop active channel lifecycle clients before `ChatClient.disconnectUser()` clears channel state
- add authority guards, deterministic lifecycle tests, CI, and architecture documentation

## Authority and compatibility

- Jatte start: `a04ac3c8d7a3eefe6b19e748fc94b0e23dc308f4`
- Stream fork gitlink unchanged: `62aa736965da360e2b2cb070e58a976e5d944d7a`
- Stream source tree unchanged: `f13cbdd600e4e18bb63ea8aaeb735cdbbc0892d3`
- shared realtime gitlink: `1aa5e3301a34fb3a56dd4103f600c415b4998656`
- NTO shared pin: `1aa5e3301a34fb3a56dd4103f600c415b4998656`
- cross-repository realtime SHA invariant: **YES**
- Stream-derived source changed: **NO**

`Channel` no longer owns a raw browser WebSocket lifecycle. The Jatte adapter owns the raw socket facade and sends exactly one `channel.watch` frame before forwarding open to the shared client. Reconnect order is bounded delay, approved credential refresh when applicable, strict authorized GET resync, replacement socket, watch handshake, then connected.

## Validation

- focused realtime/credential/endpoint tests: 22 passed
- optimistic and agent adapter regressions: 5 passed
- shared runtime standalone checks: format, typecheck, 13 tests, boundary check, build passed
- Stream-fork authority guard: passed
- realtime authority guard: passed
- frozen workspace install: passed
- selected Jatte hardening regression: 175 passed, 37 subtests passed, 2 skipped; one legacy `test_ws_watch` JWT expectation failed identically at the starting SHA
- frontend production build: compilation passed, then reproduced the accepted starting-baseline `Message.custom_data` type-validation defect

No shared-runtime amendment was required. This PR is intentionally left draft for review and does not resume any unrelated Stream UI work.
